### PR TITLE
add preflight ignore flags in bootstrap and join command

### DIFF
--- a/internal/app/caaspctl/node/bootstrap.go
+++ b/internal/app/caaspctl/node/bootstrap.go
@@ -26,10 +26,11 @@ import (
 )
 
 type bootstrapOptions struct {
-	target string
-	user   string
-	sudo   bool
-	port   int
+	target                string
+	user                  string
+	sudo                  bool
+	port                  int
+	ignorePreflightErrors string
 }
 
 func NewBootstrapCmd() *cobra.Command {
@@ -46,6 +47,7 @@ func NewBootstrapCmd() *cobra.Command {
 					bootstrapOptions.user,
 					bootstrapOptions.sudo,
 					bootstrapOptions.port,
+					map[string]interface{}{"ignore-preflight-errors": bootstrapOptions.ignorePreflightErrors},
 				),
 			)
 			if err != nil {
@@ -59,6 +61,7 @@ func NewBootstrapCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&bootstrapOptions.user, "user", "u", "root", "User identity used to connect to target")
 	cmd.Flags().IntVarP(&bootstrapOptions.port, "port", "p", 22, "Port to connect to using SSH")
 	cmd.Flags().BoolVarP(&bootstrapOptions.sudo, "sudo", "s", false, "Run remote command via sudo")
+	cmd.Flags().StringVarP(&bootstrapOptions.ignorePreflightErrors, "ignore-preflight-errors", "", "", "Comma separated list of preflight errors to ignore")
 
 	cmd.MarkFlagRequired("target")
 

--- a/internal/app/caaspctl/node/join.go
+++ b/internal/app/caaspctl/node/join.go
@@ -28,11 +28,12 @@ import (
 )
 
 type joinOptions struct {
-	target string
-	user   string
-	sudo   bool
-	port   int
-	role   string
+	target                string
+	user                  string
+	sudo                  bool
+	port                  int
+	role                  string
+	ignorePreflightErrors string
 }
 
 func NewJoinCmd() *cobra.Command {
@@ -60,6 +61,7 @@ func NewJoinCmd() *cobra.Command {
 					joinOptions.user,
 					joinOptions.sudo,
 					joinOptions.port,
+					map[string]interface{}{"ignore-preflight-errors": joinOptions.ignorePreflightErrors},
 				),
 			)
 		},
@@ -71,6 +73,7 @@ func NewJoinCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&joinOptions.sudo, "sudo", "s", false, "Run remote command via sudo")
 	cmd.Flags().IntVarP(&joinOptions.port, "port", "p", 22, "Port to connect to using SSH")
 	cmd.Flags().StringVarP(&joinOptions.role, "role", "r", "", "Role that this node will have in the cluster (master|worker)")
+	cmd.Flags().StringVarP(&joinOptions.ignorePreflightErrors, "ignore-preflight-errors", "", "", "Comma separated list of preflight errors to ignore")
 
 	cmd.MarkFlagRequired("target")
 	cmd.MarkFlagRequired("role")

--- a/internal/pkg/caaspctl/deployments/deployments.go
+++ b/internal/pkg/caaspctl/deployments/deployments.go
@@ -35,10 +35,11 @@ type TargetCache struct {
 }
 
 type Target struct {
-	Target     string
-	Nodename   string
-	Actionable Actionable
-	Cache      TargetCache
+	Target      string
+	Nodename    string
+	Actionable  Actionable
+	Cache       TargetCache
+	KubeadmArgs map[string]interface{}
 }
 
 func (t *Target) Apply(data interface{}, states ...string) error {

--- a/internal/pkg/caaspctl/deployments/ssh/kubeadm.go
+++ b/internal/pkg/caaspctl/deployments/ssh/kubeadm.go
@@ -43,7 +43,13 @@ func kubeadmInit() Runner {
 		if _, _, err := t.ssh("systemctl", "stop", "kubelet"); err != nil {
 			return err
 		}
-		_, _, err := t.ssh("kubeadm", "init", "--config", "/tmp/kubeadm.conf", "--skip-token-print")
+
+		ignorePreflightErrors := ""
+		ignorePreflightErrorsVal := t.target.KubeadmArgs["ignore-preflight-errors"].(string)
+		if len(ignorePreflightErrorsVal) > 0 {
+			ignorePreflightErrors = "--ignore-preflight-errors=" + ignorePreflightErrorsVal
+		}
+		_, _, err := t.ssh("kubeadm", "init", "--config", "/tmp/kubeadm.conf", "--skip-token-print", ignorePreflightErrors)
 		return err
 	}
 }
@@ -66,7 +72,12 @@ func kubeadmJoin() Runner {
 		if _, _, err := t.ssh("systemctl", "stop", "kubelet"); err != nil {
 			return err
 		}
-		_, _, err := t.ssh("kubeadm", "join", "--config", "/tmp/kubeadm.conf")
+		ignorePreflightErrors := ""
+		ignorePreflightErrorsVal := t.target.KubeadmArgs["ignore-preflight-errors"].(string)
+		if len(ignorePreflightErrorsVal) > 0 {
+			ignorePreflightErrors = "--ignore-preflight-errors=" + ignorePreflightErrorsVal
+		}
+		_, _, err := t.ssh("kubeadm", "join", "--config", "/tmp/kubeadm.conf", ignorePreflightErrors)
 		return err
 	}
 }

--- a/internal/pkg/caaspctl/deployments/ssh/ssh.go
+++ b/internal/pkg/caaspctl/deployments/ssh/ssh.go
@@ -43,10 +43,11 @@ type Target struct {
 	client *ssh.Client
 }
 
-func NewTarget(nodename, target, user string, sudo bool, port int) *deployments.Target {
+func NewTarget(nodename, target, user string, sudo bool, port int, kubeadmArgs map[string]interface{}) *deployments.Target {
 	res := deployments.Target{
-		Target:   target,
-		Nodename: nodename,
+		Target:      target,
+		Nodename:    nodename,
+		KubeadmArgs: kubeadmArgs,
 	}
 	res.Actionable = &Target{
 		target: &res,


### PR DESCRIPTION
## What does this PR?
add new flags for ignore-preflight-errors to pass on to kubeadm
```
caaspctl node bootstrap -h
Bootstraps the first master node of the cluster

Usage:
  caaspctl node bootstrap <node-name> [flags]

Flags:
  -h, --help                             help for bootstrap
      --ignore-preflight-errors string   Comma separated list of preflight errors to ignore
  -p, --port int                         Port to connect to using SSH (default 22)
  -s, --sudo                             Run remote command via sudo
  -t, --target string                    IP or FQDN of the node to connect to using SSH
  -u, --user string                      User identity used to connect to target (default "root")

```
## Why
bootstrap on SLES or leap fails if root filesystem is btrfs. This PR allows to pass kubeadm's ignore-preflight-errors

Signed-off-by: Nirmoy Das <ndas@suse.de>