### PR TITLE
Configure different image repository sources depending on the build settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,11 @@ docs/man/%.1: docs/man/%.1.md
 
 .PHONY: docs
 docs: $(MANPAGES)
+
+.PHONY: staging
+staging:
+	$(GO) install $(CAASPCTL_LDFLAGS) -tags staging suse.com/caaspctl/cmd/...
+
+.PHONY: release
+release:
+	$(GO) install $(CAASPCTL_LDFLAGS) -tags release suse.com/caaspctl/cmd/...

--- a/README.md
+++ b/README.md
@@ -38,7 +38,42 @@ mkdir -p $GOPATH/src/suse.com
 cd $GOPATH/src/suse.com
 git clone https://github.com/SUSE/caaspctl.git
 cd caaspctl
+```
+
+### Development
+
+A development build will:
+
+* Pull container images from `registry.suse.de/devel/caasp/4.0/containers/caasp/v4`
+
+To build it, run:
+
+```sh
 make
+```
+
+### Staging
+
+A staging build will:
+
+* Pull container images from `registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4`
+
+To build it, run:
+
+```sh
+make staging
+```
+
+### Release
+
+A release build will:
+
+* Pull container images from `registry.suse.com/caasp/v4`
+
+To build it, run:
+
+```sh
+make release
 ```
 
 ## Creating a cluster

--- a/internal/pkg/caaspctl/kubernetes/versions.go
+++ b/internal/pkg/caaspctl/kubernetes/versions.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019 SUSE LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package kubernetes
+
+import (
+	"log"
+)
+
+type Component string
+
+const (
+	Etcd    Component = "etcd"
+	CoreDNS Component = "coredns"
+	Pause   Component = "pause"
+)
+
+type ControlPlaneComponentsVersion struct {
+	EtcdVersion    string
+	CoreDNSVersion string
+	PauseVersion   string
+}
+
+type ComponentsVersion struct {
+	KubeletVersion string
+}
+
+type KubernetesVersion struct {
+	ControlPlaneComponentsVersion ControlPlaneComponentsVersion
+	ComponentsVersion             ComponentsVersion
+}
+
+const (
+	CurrentVersion = "v1.13.4"
+)
+
+var (
+	Versions = map[string]KubernetesVersion{
+		"v1.13.4": KubernetesVersion{
+			ControlPlaneComponentsVersion: ControlPlaneComponentsVersion{
+				EtcdVersion:    "3.3.1",
+				CoreDNSVersion: "1.2.6",
+				PauseVersion:   "3.1",
+			},
+			ComponentsVersion: ComponentsVersion{
+				KubeletVersion: "1.13.4",
+			},
+		},
+	}
+)
+
+func CurrentComponentVersion(component Component) string {
+	currentKubernetesVersion := Versions[CurrentVersion]
+	switch component {
+	case Etcd:
+		return currentKubernetesVersion.ControlPlaneComponentsVersion.EtcdVersion
+	case CoreDNS:
+		return currentKubernetesVersion.ControlPlaneComponentsVersion.CoreDNSVersion
+	case Pause:
+		return currentKubernetesVersion.ControlPlaneComponentsVersion.PauseVersion
+	}
+	log.Fatalf("unknown component %q", component)
+	panic("unreachable")
+}

--- a/pkg/caaspctl/actions/cluster/init/manifests.go
+++ b/pkg/caaspctl/actions/cluster/init/manifests.go
@@ -26,7 +26,7 @@ localAPIEndpoint:
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: v1.13.3
+kubernetesVersion: _DO_NOT_CHANGE_WILL_BE_REPLACED_ON_BOOTSTRAP_
 apiServer:
   certSANs:
     - {{.ControlPlane}}
@@ -135,7 +135,7 @@ data:
     {
       "Network": "10.244.0.0/16",
       "Backend": {
-        "Type": "vxlan"
+        "Type": "udp"
       }
     }
 ---
@@ -163,7 +163,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.11.0-amd64
+        image: registry.suse.de/devel/casp/head/containers/sle-12-sp3/container/caasp/v4/flannel:0.9.1
         command:
         - cp
         args:
@@ -177,9 +177,9 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.11.0-amd64
+        image: registry.suse.de/devel/casp/head/containers/sle-12-sp3/container/caasp/v4/flannel:0.9.1
         command:
-        - /opt/bin/flanneld
+        - /usr/sbin/flanneld
         args:
         - --ip-masq
         - --kube-subnet-mgr

--- a/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
+++ b/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
@@ -27,9 +27,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"suse.com/caaspctl/internal/pkg/caaspctl/deployments"
+	"suse.com/caaspctl/internal/pkg/caaspctl/kubernetes"
 	"suse.com/caaspctl/pkg/caaspctl"
 )
 
@@ -45,6 +47,7 @@ func Bootstrap(target *deployments.Target) error {
 	}
 	addTargetInformationToInitConfiguration(target, initConfiguration)
 	setHyperkubeImageToInitConfiguration(initConfiguration)
+	setContainerImages(initConfiguration)
 	finalInitConfigurationContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(initConfiguration, schema.GroupVersion{
 		Group:   "kubeadm.k8s.io",
 		Version: "v1beta1",
@@ -94,6 +97,7 @@ func addTargetInformationToInitConfiguration(target *deployments.Target, initCon
 	}
 	initConfiguration.NodeRegistration.Name = target.Nodename
 	initConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename
+	initConfiguration.NodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = images.GetGenericImage(caaspctl.ImageRepository, "pause", kubernetes.CurrentComponentVersion(kubernetes.Pause))
 	osRelease, err := target.OSRelease()
 	if err != nil {
 		log.Fatalf("could not retrieve OS release information: %v", err)
@@ -105,6 +109,21 @@ func addTargetInformationToInitConfiguration(target *deployments.Target, initCon
 
 func setHyperkubeImageToInitConfiguration(initConfiguration *kubeadmapi.InitConfiguration) {
 	initConfiguration.UseHyperKubeImage = true
+}
+
+func setContainerImages(initConfiguration *kubeadmapi.InitConfiguration) {
+	initConfiguration.ImageRepository = caaspctl.ImageRepository
+	initConfiguration.KubernetesVersion = kubernetes.CurrentVersion
+	initConfiguration.Etcd.Local = &kubeadmapi.LocalEtcd{
+		ImageMeta: kubeadmapi.ImageMeta{
+			ImageRepository: caaspctl.ImageRepository,
+			ImageTag:        kubernetes.CurrentComponentVersion(kubernetes.Etcd),
+		},
+	}
+	initConfiguration.DNS.ImageMeta = kubeadmapi.ImageMeta{
+		ImageRepository: caaspctl.ImageRepository,
+		ImageTag:        kubernetes.CurrentComponentVersion(kubernetes.CoreDNS),
+	}
 }
 
 func configFileAndDefaultsToInternalConfig(cfgPath string) (*kubeadmapi.InitConfiguration, error) {

--- a/pkg/caaspctl/actions/node/join/join.go
+++ b/pkg/caaspctl/actions/node/join/join.go
@@ -32,6 +32,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmtokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
@@ -102,6 +103,7 @@ func addTargetInformationToJoinConfiguration(target *deployments.Target, role de
 	}
 	joinConfiguration.NodeRegistration.Name = target.Nodename
 	joinConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename
+	joinConfiguration.NodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = images.GetGenericImage(caaspctl.ImageRepository, "pause", kubernetes.CurrentComponentVersion(kubernetes.Pause))
 	osRelease, err := target.OSRelease()
 	if err != nil {
 		log.Fatalf("could not retrieve OS release information: %v", err)

--- a/pkg/caaspctl/development_constants.go
+++ b/pkg/caaspctl/development_constants.go
@@ -1,0 +1,24 @@
+// +build !staging,!release
+
+/*
+ * Copyright (c) 2019 SUSE LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package caaspctl
+
+const (
+	ImageRepository = "registry.suse.de/devel/caasp/4.0/containers/caasp/v4"
+)

--- a/pkg/caaspctl/release_constants.go
+++ b/pkg/caaspctl/release_constants.go
@@ -1,0 +1,24 @@
+// +build release
+
+/*
+ * Copyright (c) 2019 SUSE LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package caaspctl
+
+const (
+	ImageRepository = "registry.suse.com/caasp/v4"
+)

--- a/pkg/caaspctl/staging_constants.go
+++ b/pkg/caaspctl/staging_constants.go
@@ -1,0 +1,24 @@
+// +build staging
+
+/*
+ * Copyright (c) 2019 SUSE LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package caaspctl
+
+const (
+	ImageRepository = "registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4"
+)


### PR DESCRIPTION
**Do not merge, specified image repositories haven't got the expected images yet**

It is possible to build caaspctl in development, staging or release mode.

Depending on what tag was passed on build time, the caaspctl artifact will
refer to a specific image repository.

This is done at build time since the development and staging builds are
only for our internal consumption (development and QA).

The builds customers will receive will always be release.

Fixes https://github.com/SUSE/avant-garde/issues/7

cc/ @jordimassaguerpla @kravciak @ellisab @thehejik 