### PR TITLE
Added dependencies for VMs in order to avoid deployement errors

### DIFF
--- a/ci/infra/libvirt/cluster.tf
+++ b/ci/infra/libvirt/cluster.tf
@@ -252,6 +252,7 @@ resource "libvirt_domain" "master" {
     password = "linux"
   }
 
+  depends_on = ["libvirt_domain.lb"]
 }
 
 output "masters" {
@@ -322,6 +323,8 @@ resource "libvirt_domain" "worker" {
     user     = "root"
     password = "linux"
   }
+
+  depends_on = ["libvirt_domain.master"]
 }
 
 output "workers" {


### PR DESCRIPTION
Without dependencies, several different errors occur each time while creating VMs in libvirt.
1. timeout for all VMs
2. ag-master shutoff 
3. ag-worker was not created 