### PR TITLE
Fix message typo when uploading files with contents

### DIFF
--- a/internal/pkg/caaspctl/deployments/ssh/files.go
+++ b/internal/pkg/caaspctl/deployments/ssh/files.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (t *Target) UploadFileContents(targetPath, contents string) error {
-	log.Printf("uploading local file %q with contents", targetPath)
+	log.Printf("uploading to remote file %q with contents", targetPath)
 	dir, _ := path.Split(targetPath)
 	encodedContents := base64.StdEncoding.EncodeToString([]byte(contents))
 	if _, _, err := t.silentSsh("mkdir", "-p", dir); err != nil {


### PR DESCRIPTION
Fix message typo that led to think that we were uploading a local file to the remote, when we are in reality pushing some contents to a remote location.