### PR TITLE
Do not forcefully set `node-ip` in the kubelet args.

### DIFF
--- a/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
+++ b/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
 	"path"
 	"strings"
@@ -92,9 +91,6 @@ func downloadSecrets(target *deployments.Target) error {
 func addTargetInformationToInitConfiguration(target *deployments.Target, initConfiguration *kubeadmapi.InitConfiguration) {
 	if initConfiguration.NodeRegistration.KubeletExtraArgs == nil {
 		initConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
-	}
-	if ip := net.ParseIP(target.Target); ip != nil {
-		initConfiguration.NodeRegistration.KubeletExtraArgs["node-ip"] = target.Target
 	}
 	initConfiguration.NodeRegistration.Name = target.Nodename
 	initConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename

--- a/pkg/caaspctl/actions/node/join/join.go
+++ b/pkg/caaspctl/actions/node/join/join.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
 	"strings"
 	"time"
@@ -100,9 +99,6 @@ func addFreshTokenToJoinConfiguration(target string, joinConfiguration *kubeadma
 func addTargetInformationToJoinConfiguration(target *deployments.Target, role deployments.Role, joinConfiguration *kubeadmapi.JoinConfiguration) {
 	if joinConfiguration.NodeRegistration.KubeletExtraArgs == nil {
 		joinConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
-	}
-	if ip := net.ParseIP(target.Target); ip != nil {
-		joinConfiguration.NodeRegistration.KubeletExtraArgs["node-ip"] = target.Target
 	}
 	joinConfiguration.NodeRegistration.Name = target.Nodename
 	joinConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename


### PR DESCRIPTION
Do not try to be smart here because we don't know if the targeted IP is
a floating IP and the kubelet won't be able to see the same address we
use for bootstrap/join. Let the kubelet discover this IP address, and in
case of cloud providers we will have the ExternalIP populated with CPI.

Fixes: https://github.com/SUSE/avant-garde/issues/86