### PR TITLE
Don't overwrite existing configuration directory

### DIFF
--- a/pkg/caaspctl/actions/cluster/init/init.go
+++ b/pkg/caaspctl/actions/cluster/init/init.go
@@ -38,22 +38,25 @@ type InitConfiguration struct {
 //        using the PWD
 // FIXME: error handling with `github.com/pkg/errors`; return errors
 func Init(initConfiguration InitConfiguration) {
+	if _, err := os.Stat(initConfiguration.ClusterName); err == nil {
+		log.Fatalf("Error: cluster configuration directory %q already exists\n", initConfiguration.ClusterName)
+	}
 	if err := os.MkdirAll(initConfiguration.ClusterName, 0700); err != nil {
-		log.Fatalf("could not create directory %s\n", initConfiguration.ClusterName)
+		log.Fatalf("Error: could not create cluster directory %q: %v\n", initConfiguration.ClusterName, err)
 	}
 	if err := os.Chdir(initConfiguration.ClusterName); err != nil {
-		log.Fatalf("could not change to directory %s\n", initConfiguration.ClusterName)
+		log.Fatalf("Error: could not change to cluster directory %q: %v\n", initConfiguration.ClusterName, err)
 	}
 	for _, file := range scaffoldFiles {
 		filePath, _ := filepath.Split(file.Location)
 		if filePath != "" {
 			if err := os.MkdirAll(filePath, 0700); err != nil {
-				log.Fatalf("could not create directory %s\n", filePath)
+				log.Fatalf("Error: could not create directory %q: %v\n", filePath, err)
 			}
 		}
 		f, err := os.Create(file.Location)
 		if err != nil {
-			log.Fatalf("could not create file %s\n", file.Location)
+			log.Fatalf("Error: could not create file %q: %v\n", file.Location, err)
 		}
 		f.WriteString(renderTemplate(file.Content, initConfiguration))
 		f.Close()


### PR DESCRIPTION
Overriding existing cluster config files does not report error during init. It fails afterwards when running bootstrap.

Terraform generates new machines:
```
ip_ext_load_balancer = 10.86.1.180
ip_internal_load_balancer = 172.28.0.10
ip_masters = [
    10.86.2.147
]
ip_workers = [
    10.86.2.159,
    10.86.1.88
]
```

Bootstrap output:
```
→ caaspctl cluster init --control-plane 10.86.1.180 cluster
→ caaspctl node bootstrap --user opensuse --sudo --target 10.86.2.147 master-0                [eed8ab3]
2019/03/27 09:38:12 downloading remote file "/etc/os-release" contents
2019/03/27 09:38:15 === applying state kubernetes.bootstrap.upload-secrets ===
2019/03/27 09:38:15 uploading local file "pki/ca.crt" to remote file "/etc/kubernetes/pki/ca.crt"
2019/03/27 09:38:15 uploading local file "/etc/kubernetes/pki/ca.crt" with contents
2019/03/27 09:38:15 uploading local file "pki/ca.key" to remote file "/etc/kubernetes/pki/ca.key"
2019/03/27 09:38:15 uploading local file "/etc/kubernetes/pki/ca.key" with contents
2019/03/27 09:38:16 uploading local file "pki/sa.key" to remote file "/etc/kubernetes/pki/sa.key"
2019/03/27 09:38:16 uploading local file "/etc/kubernetes/pki/sa.key" with contents
2019/03/27 09:38:17 uploading local file "pki/sa.pub" to remote file "/etc/kubernetes/pki/sa.pub"
2019/03/27 09:38:17 uploading local file "/etc/kubernetes/pki/sa.pub" with contents
2019/03/27 09:38:18 uploading local file "pki/front-proxy-ca.crt" to remote file "/etc/kubernetes/pki/front-proxy-ca.crt"
2019/03/27 09:38:18 uploading local file "/etc/kubernetes/pki/front-proxy-ca.crt" with contents
2019/03/27 09:38:19 uploading local file "pki/front-proxy-ca.key" to remote file "/etc/kubernetes/pki/front-proxy-ca.key"
2019/03/27 09:38:19 uploading local file "/etc/kubernetes/pki/front-proxy-ca.key" with contents
2019/03/27 09:38:20 uploading local file "pki/etcd/ca.crt" to remote file "/etc/kubernetes/pki/etcd/ca.crt"
2019/03/27 09:38:20 uploading local file "/etc/kubernetes/pki/etcd/ca.crt" with contents
2019/03/27 09:38:21 uploading local file "pki/etcd/ca.key" to remote file "/etc/kubernetes/pki/etcd/ca.key"
2019/03/27 09:38:21 uploading local file "/etc/kubernetes/pki/etcd/ca.key" with contents
2019/03/27 09:38:22 uploading local file "admin.conf" to remote file "/etc/kubernetes/admin.conf"
2019/03/27 09:38:22 uploading local file "/etc/kubernetes/admin.conf" with contents
2019/03/27 09:38:23 === state kubernetes.bootstrap.upload-secrets applied successfully ===
2019/03/27 09:38:23 === applying state kubelet.configure ===
2019/03/27 09:38:23 uploading local file "/usr/lib/systemd/system/kubelet.service" with contents
2019/03/27 09:38:24 uploading local file "/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf" with contents
2019/03/27 09:38:24 uploading local file "/etc/sysconfig/kubelet" with contents
2019/03/27 09:38:26 running command: "sudo sh -c 'systemctl daemon-reload'"
2019/03/27 09:38:26 === state kubelet.configure applied successfully ===
2019/03/27 09:38:26 === applying state kubelet.enable ===
2019/03/27 09:38:26 running command: "sudo sh -c 'systemctl enable kubelet'"
2019/03/27 09:38:26 stderr | Created symlink /etc/systemd/system/multi-user.target.wants/kubelet.service → /usr/lib/systemd/system/kubelet.service.
2019/03/27 09:38:27 === state kubelet.enable applied successfully ===
2019/03/27 09:38:27 === applying state kubeadm.init ===
2019/03/27 09:38:27 uploading local file "kubeadm-init.conf" to remote file "/tmp/kubeadm.conf"
2019/03/27 09:38:27 uploading local file "/tmp/kubeadm.conf" with contents
2019/03/27 09:38:28 running command: "sudo sh -c 'systemctl enable --now docker'"
2019/03/27 09:38:28 stderr | Created symlink /etc/systemd/system/multi-user.target.wants/docker.service → /usr/lib/systemd/system/docker.service.
2019/03/27 09:38:29 running command: "sudo sh -c 'systemctl stop kubelet'"
2019/03/27 09:38:30 running command: "sudo sh -c 'kubeadm init --config /tmp/kubeadm.conf --skip-token-print '"
2019/03/27 09:38:30 stdout | [init] Using Kubernetes version: v1.13.3
2019/03/27 09:38:30 stdout | [preflight] Running pre-flight checks
2019/03/27 09:38:30 stderr | 	[WARNING Hostname]: hostname "master-0" could not be reached
2019/03/27 09:38:30 stderr | 	[WARNING Hostname]: hostname "master-0": lookup master-0 on 172.28.0.2:53: no such host
2019/03/27 09:38:30 stdout | [preflight] Pulling images required for setting up a Kubernetes cluster
2019/03/27 09:38:30 stdout | [preflight] This might take a minute or two, depending on the speed of your internet connection
2019/03/27 09:38:30 stdout | [preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
2019/03/27 09:38:56 stdout | [kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
2019/03/27 09:38:56 stdout | [kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
2019/03/27 09:38:56 stdout | [kubelet-start] Activating the kubelet service
2019/03/27 09:38:57 stdout | [certs] Using certificateDir folder "/etc/kubernetes/pki"
2019/03/27 09:38:57 stdout | [certs] Using existing ca certificate authority
2019/03/27 09:38:57 stdout | [certs] Generating "apiserver-kubelet-client" certificate and key
2019/03/27 09:38:58 stdout | [certs] Generating "apiserver" certificate and key
2019/03/27 09:38:58 stdout | [certs] apiserver serving cert is signed for DNS names [master-0 kubernetes kubernetes.default kubernetes.default.svc kubernetes.default.svc.cluster.local] and IPs [10.96.0.1 172.28.0.7 10.86.1.180 10.86.1.180]
2019/03/27 09:38:58 stdout | [certs] Using existing front-proxy-ca certificate authority
2019/03/27 09:38:58 stdout | [certs] Generating "front-proxy-client" certificate and key
2019/03/27 09:38:58 stdout | [certs] Using existing etcd/ca certificate authority
2019/03/27 09:38:59 stdout | [certs] Generating "apiserver-etcd-client" certificate and key
2019/03/27 09:38:59 stdout | [certs] Generating "etcd/server" certificate and key
2019/03/27 09:38:59 stdout | [certs] etcd/server serving cert is signed for DNS names [master-0 localhost] and IPs [172.28.0.7 127.0.0.1 ::1]
2019/03/27 09:38:59 stdout | [certs] Generating "etcd/peer" certificate and key
2019/03/27 09:38:59 stdout | [certs] etcd/peer serving cert is signed for DNS names [master-0 localhost] and IPs [172.28.0.7 127.0.0.1 ::1]
2019/03/27 09:39:00 stdout | [certs] Generating "etcd/healthcheck-client" certificate and key
2019/03/27 09:39:00 stdout | [certs] Using the existing "sa" key
2019/03/27 09:39:00 stdout | [kubeconfig] Using kubeconfig folder "/etc/kubernetes"
2019/03/27 09:39:01 stderr | error execution phase kubeconfig/admin: a kubeconfig file "/etc/kubernetes/admin.conf" exists already but has got the wrong API Server URL
2019/03/27 09:39:01 running command: "sudo sh -c 'rm /tmp/kubeadm.conf'"
2019/03/27 09:39:01 === failed to apply state kubeadm.init: Process exited with status 1 ===
2019/03/27 09:39:01 === applying state cni.deploy ===
2019/03/27 09:39:01 uploading local file "addons/cni/flannel.yaml" to remote file "/tmp/cni.d/flannel.yaml"
2019/03/27 09:39:01 uploading local file "/tmp/cni.d/flannel.yaml" with contents
2019/03/27 09:39:02 running command: "sudo sh -c 'kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/cni.d'"
2019/03/27 09:39:21 stderr | unable to recognize "/tmp/cni.d/flannel.yaml": Get https://10.86.3.172:6443/api?timeout=32s: dial tcp 10.86.3.172:6443: connect: no route to host
2019/03/27 09:39:21 stderr | unable to recognize "/tmp/cni.d/flannel.yaml": Get https://10.86.3.172:6443/api?timeout=32s: dial tcp 10.86.3.172:6443: connect: no route to host
2019/03/27 09:39:21 stderr | unable to recognize "/tmp/cni.d/flannel.yaml": Get https://10.86.3.172:6443/api?timeout=32s: dial tcp 10.86.3.172:6443: connect: no route to host
2019/03/27 09:39:21 stderr | unable to recognize "/tmp/cni.d/flannel.yaml": Get https://10.86.3.172:6443/api?timeout=32s: dial tcp 10.86.3.172:6443: connect: no route to host
2019/03/27 09:39:21 stderr | unable to recognize "/tmp/cni.d/flannel.yaml": Get https://10.86.3.172:6443/api?timeout=32s: dial tcp 10.86.3.172:6443: connect: no route to host
2019/03/27 09:39:21 running command: "sudo sh -c 'rm -rf /tmp/cni.d'"
2019/03/27 09:39:21 === failed to apply state cni.deploy: Process exited with status 1 ===
2019/03/27 09:39:21 downloading remote file "/etc/kubernetes/pki/ca.crt" contents
2019/03/27 09:39:22 downloading remote file "/etc/kubernetes/pki/ca.key" contents
2019/03/27 09:39:22 downloading remote file "/etc/kubernetes/pki/sa.key" contents
2019/03/27 09:39:22 downloading remote file "/etc/kubernetes/pki/sa.pub" contents
2019/03/27 09:39:23 downloading remote file "/etc/kubernetes/pki/front-proxy-ca.crt" contents
2019/03/27 09:39:23 downloading remote file "/etc/kubernetes/pki/front-proxy-ca.key" contents
2019/03/27 09:39:24 downloading remote file "/etc/kubernetes/pki/etcd/ca.crt" contents
2019/03/27 09:39:24 downloading remote file "/etc/kubernetes/pki/etcd/ca.key" contents
2019/03/27 09:39:25 downloading remote file "/etc/kubernetes/admin.conf" contents
```