### PR TITLE
ci/infra/libvirt: fixed the libvirt setup

### DIFF
--- a/ci/infra/libvirt/README.md
+++ b/ci/infra/libvirt/README.md
@@ -45,7 +45,7 @@ All the nodes can ping each other and can resolve their FQDN.
 Download the image referenced inside of the checkout of this repository:
 
 ```
-$ wget `grep http cluster.tf | awk {'print $3'} | sed -e 's/"//g'`
+$ wget `grep qcow2 variables.tf | awk {'print $3'} | sed -e 's/"//g'`
 ```
 
 Then `cp terraform.tfvars.example terraform.tfvars` and edit it to reference

--- a/ci/infra/libvirt/cloud-init/lb.cfg.tpl
+++ b/ci/infra/libvirt/cloud-init/lb.cfg.tpl
@@ -81,6 +81,9 @@ write_files:
       ${backends}
 
 runcmd:
-  - [ systemctl, enable, haproxy ]
+  # Since we are currently inside of the cloud-init systemd unit, trying to
+  # start another service by either `enable --now` or `start` will create a
+  # deadlock. Instead, we have to use the `--no-block-` flag.
+  - [ systemctl, enable, --now, --no-block, haproxy ]
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -24,3 +24,9 @@ img_source_url = "openSUSE-Leap-15.0-OpenStack.x86_64-0.0.4-Buildlp150.12.113.qc
 
 # define the base url of the repository to use
 # repo_baseurl = "https://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode/openSUSE_Leap_15.0"
+
+# Add your key here as you would do for the `~/.ssh/authorized_keys` file. They
+# will be added into this same file for each node.
+#authorized_keys = [
+#  ""
+#]


### PR DESCRIPTION
This is based on the work by Dario in #38.

First of all, I've fixed the documentation on how to fetch the image, since the
command was plain wrong. Moreover, I've also added documentation on how to
manage SSH keys, since it wasn't too clear to newcomers.

I've added the `authorized_keys` terraform variable where it was required. Plus,
I've added `depends_on` terraform instructions into the master and the worker
nodes to avoid concurrency problems: they will now wait for the LB first to
finish (we did the same in kubic-project/automation). Finally, I've changed the
names for the master/worker nodes so they don't contain underscores (which is
troublesome down the line).

Last but not least, I've also changed the cloud-init file for the load-balancer
so it starts haproxy always (before it was just enabled but it never started).

As a final note, with these changes everything seems to work except for Helm,
which is unable to forward some ports (I've seen that this is related to some
global DNS records which are expected by the provider). This is an issue to be
solved in the future.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>
Suggested-by: Dario Maiocchi <dmaiocchi@suse.de>