### PR TITLE
Change libvirt pool-name to default and fix leap15 url

### DIFF
--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -16,9 +16,10 @@ variable "pool" {
 # Cluster variables #
 #####################
 
+## fixme: see issue https://github.com/SUSE/avant-garde/issues/91
 variable "img_source_url" {
   type        = "string"
-  default     = "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/openSUSE-Leap-15.0-OpenStack.x86_64-0.0.4-Buildlp150.12.127.qcow2"
+  default     = "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.0/images/openSUSE-Leap-15.0-OpenStack.x86_64-0.0.4-Buildlp150.12.136.qcow2"
 }
 
 variable "repo_baseurl" {


### PR DESCRIPTION
- add default pool name instead of custom one 
- add new build and reference the issue on leap15