### PR TITLE
Add post stage to pipeline to clean up on failure

### DIFF
--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -933,7 +933,12 @@ pipeline {
             sh "git clone https://${GITHUB_TOKEN}@github.com/SUSE/caaspctl"
         } }
         %s
-   }
+    }
+    post {
+        unsuccessful {
+            sh "caaspctl/ci/infra/testrunner/testrunner stage=final_cleanup ${PARAMS}"
+        }
+    }
 }
     """
     stage_tpl = """


### PR DESCRIPTION
Testrunner generates a Jenkins pipeline including a
post -> unsuccessful step to do a cleanup. Useful to tear
down OpenStack clusters.