### PR TITLE
Make error output consistent by not having an Error prefix

### DIFF
--- a/internal/pkg/caaspctl/deployments/ssh/states.go
+++ b/internal/pkg/caaspctl/deployments/ssh/states.go
@@ -19,6 +19,8 @@ package ssh
 
 import (
 	"log"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -32,7 +34,7 @@ func (t *Target) Apply(data interface{}, states ...string) error {
 		log.Printf("=== applying state %s ===\n", stateName)
 		if state, stateExists := stateMap[stateName]; stateExists {
 			if err := state(t, data); err != nil {
-				log.Printf("=== failed to apply state %s: %v ===\n", stateName, err)
+				return errors.Errorf("failed to apply state %s: %v", stateName, err)
 			} else {
 				log.Printf("=== state %s applied successfully ===\n", stateName)
 			}

--- a/pkg/caaspctl/actions/cluster/init/init.go
+++ b/pkg/caaspctl/actions/cluster/init/init.go
@@ -39,24 +39,24 @@ type InitConfiguration struct {
 // FIXME: error handling with `github.com/pkg/errors`; return errors
 func Init(initConfiguration InitConfiguration) {
 	if _, err := os.Stat(initConfiguration.ClusterName); err == nil {
-		log.Fatalf("Error: cluster configuration directory %q already exists\n", initConfiguration.ClusterName)
+		log.Fatalf("cluster configuration directory %q already exists\n", initConfiguration.ClusterName)
 	}
 	if err := os.MkdirAll(initConfiguration.ClusterName, 0700); err != nil {
-		log.Fatalf("Error: could not create cluster directory %q: %v\n", initConfiguration.ClusterName, err)
+		log.Fatalf("could not create cluster directory %q: %v\n", initConfiguration.ClusterName, err)
 	}
 	if err := os.Chdir(initConfiguration.ClusterName); err != nil {
-		log.Fatalf("Error: could not change to cluster directory %q: %v\n", initConfiguration.ClusterName, err)
+		log.Fatalf("could not change to cluster directory %q: %v\n", initConfiguration.ClusterName, err)
 	}
 	for _, file := range scaffoldFiles {
 		filePath, _ := filepath.Split(file.Location)
 		if filePath != "" {
 			if err := os.MkdirAll(filePath, 0700); err != nil {
-				log.Fatalf("Error: could not create directory %q: %v\n", filePath, err)
+				log.Fatalf("could not create directory %q: %v\n", filePath, err)
 			}
 		}
 		f, err := os.Create(file.Location)
 		if err != nil {
-			log.Fatalf("Error: could not create file %q: %v\n", file.Location, err)
+			log.Fatalf("could not create file %q: %v\n", file.Location, err)
 		}
 		f.WriteString(renderTemplate(file.Content, initConfiguration))
 		f.Close()


### PR DESCRIPTION
When a sequential operation fails do not continue with further
operations.