### PR TITLE
Fix README typo and update Gopkg.lock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -950,6 +950,7 @@
     "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm",
     "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme",
     "k8s.io/kubernetes/cmd/kubeadm/app/constants",
+    "k8s.io/kubernetes/cmd/kubeadm/app/images",
     "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node",
     "k8s.io/kubernetes/cmd/kubeadm/app/util",
     "k8s.io/kubernetes/cmd/kubeadm/app/util/config",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd caaspctl
 
 A development build will:
 
-* Pull container images from `registry.suse.de/devel/caasp/4.0/containers/caasp/v4`
+* Pull container images from `registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4`
 
 To build it, run:
 

--- a/internal/app/caaspctl/version.go
+++ b/internal/app/caaspctl/version.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019 SUSE LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package caaspctl
 
 import (


### PR DESCRIPTION
This does not affect the v0.1.0 release.

Add missing Gopkg.lock for the solver.

Fix README after we had the final image repository location for devel.