### PR TITLE
Add sles username and use bigger flavor

### DIFF
--- a/ci/infra/openstack/terraform.tfvars.sles.example
+++ b/ci/infra/openstack/terraform.tfvars.sles.example
@@ -4,8 +4,15 @@ internal_net = "testing"
 # identifier to make all your resources unique and avoid clashes with other users of this terraform project
 stack_name = "testing"
 
+# instance user name
+username = "sles"
+
 # define which image to use
 image_name = "SLES15-SP1-JeOS-GM"
+
+# openstack flavor
+master_size = "caasp.medium"
+worker_size = "caasp.medium"
 
 # define the repositories to use
 repositories = [


### PR DESCRIPTION
Default user is opensuse which does not exist on SLE-15-JeOS.

There was error when using default flavor, not sure `caasp.medium` is right though.
```
* openstack_compute_instance_v2.master: 1 error(s) occurred:

* openstack_compute_instance_v2.master: Error creating OpenStack server: Bad request with: [POST https://engcloud.prv.suse.net:8774/v2.1/05394ae447d74bc0b3ed2cca262c9b7c/servers], error message: {"badRequest": {"message": "Flavor's memory is too small for requested image.", "code": 400}}
* openstack_compute_instance_v2.worker[0]: 1 error(s) occurred:
```