### PR TITLE
choose a smaller but still fitting flavor in openstack

### DIFF
--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -970,8 +970,8 @@ packages = [
 masters = 3
 workers = 2
 
-master_size = "m1.large"
-worker_size = "m1.large"
+master_size = "caasp.medium"
+worker_size = "caasp.medium"
 
 authorized_keys = [
   "{authorized_keys}"


### PR DESCRIPTION
m1.large has 80GB of disk and 40GB is enough

Signed-off-by: Maximilian Meister <mmeister@suse.de>

Follow up of https://github.com/SUSE/caaspctl/pull/57