### PR TITLE
update logging to use KLog

### DIFF
--- a/cmd/caaspctl/caaspctl.go
+++ b/cmd/caaspctl/caaspctl.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/klog"
+
 	"github.com/spf13/cobra"
 
 	"suse.com/caaspctl/internal/app/caaspctl"
@@ -42,6 +44,7 @@ func newRootCmd(args []string) *cobra.Command {
 
 func main() {
 	fmt.Println("** This is a BETA release and NOT intended for production usage. **")
+	klog.InitFlags(nil)
 	cmd := newRootCmd(os.Args[1:])
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)

--- a/internal/app/caaspctl/node/bootstrap.go
+++ b/internal/app/caaspctl/node/bootstrap.go
@@ -18,7 +18,7 @@
 package node
 
 import (
-	"log"
+	"k8s.io/klog"
 
 	"github.com/spf13/cobra"
 	"suse.com/caaspctl/internal/pkg/caaspctl/deployments/ssh"
@@ -51,7 +51,7 @@ func NewBootstrapCmd() *cobra.Command {
 				),
 			)
 			if err != nil {
-				log.Fatal(err)
+				klog.Fatal(err)
 			}
 		},
 		Args: cobra.ExactArgs(1),

--- a/internal/app/caaspctl/node/join.go
+++ b/internal/app/caaspctl/node/join.go
@@ -18,7 +18,7 @@
 package node
 
 import (
-	"log"
+	"k8s.io/klog"
 
 	"github.com/spf13/cobra"
 
@@ -51,7 +51,7 @@ func NewJoinCmd() *cobra.Command {
 			case "worker":
 				joinConfiguration.Role = deployments.WorkerRole
 			default:
-				log.Fatalf("invalid role provided: %q, 'master' or 'worker' are the only accepted roles", joinOptions.role)
+				klog.Fatalf("invalid role provided: %q, 'master' or 'worker' are the only accepted roles", joinOptions.role)
 			}
 
 			node.Join(joinConfiguration,

--- a/internal/pkg/caaspctl/deployments/deployments.go
+++ b/internal/pkg/caaspctl/deployments/deployments.go
@@ -21,7 +21,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+
+	"k8s.io/klog"
 )
 
 type Actionable interface {
@@ -47,7 +48,7 @@ func (t *Target) Apply(data interface{}, states ...string) error {
 }
 
 func (t *Target) UploadFile(sourcePath, targetPath string) error {
-	log.Printf("uploading local file %q to remote file %q", sourcePath, targetPath)
+	klog.Infof("uploading local file %q to remote file %q", sourcePath, targetPath)
 	if contents, err := ioutil.ReadFile(sourcePath); err == nil {
 		return t.UploadFileContents(targetPath, string(contents))
 	}

--- a/internal/pkg/caaspctl/deployments/ssh/files.go
+++ b/internal/pkg/caaspctl/deployments/ssh/files.go
@@ -20,12 +20,13 @@ package ssh
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
 	"path"
+
+	"k8s.io/klog"
 )
 
 func (t *Target) UploadFileContents(targetPath, contents string) error {
-	log.Printf("uploading to remote file %q with contents", targetPath)
+	klog.Infof("uploading to remote file %q with contents", targetPath)
 	dir, _ := path.Split(targetPath)
 	encodedContents := base64.StdEncoding.EncodeToString([]byte(contents))
 	if _, _, err := t.silentSsh("mkdir", "-p", dir); err != nil {
@@ -36,7 +37,7 @@ func (t *Target) UploadFileContents(targetPath, contents string) error {
 }
 
 func (t *Target) DownloadFileContents(sourcePath string) (string, error) {
-	log.Printf("downloading remote file %q contents", sourcePath)
+	klog.Infof("downloading remote file %q contents", sourcePath)
 	if stdout, _, err := t.silentSsh("base64", "-w0", sourcePath); err == nil {
 		decodedStdout, err := base64.StdEncoding.DecodeString(stdout)
 		if err != nil {

--- a/internal/pkg/caaspctl/deployments/ssh/ssh.go
+++ b/internal/pkg/caaspctl/deployments/ssh/ssh.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	"k8s.io/klog"
 	"net"
 	"os"
 	"strings"
@@ -59,8 +59,8 @@ func NewTarget(nodename, target, user string, sudo bool, port int, kubeadmArgs m
 }
 
 func (t *Target) silentSsh(command string, args ...string) (stdout string, stderr string, error error) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stderr)
+	klog.SetOutput(ioutil.Discard)
+	defer klog.SetOutput(os.Stderr)
 	return t.ssh(command, args...)
 }
 
@@ -69,8 +69,8 @@ func (t *Target) ssh(command string, args ...string) (stdout string, stderr stri
 }
 
 func (t *Target) silentSshWithStdin(stdin string, command string, args ...string) (stdout string, stderr string, error error) {
-	log.SetOutput(ioutil.Discard)
-	defer log.SetOutput(os.Stderr)
+	klog.SetOutput(ioutil.Discard)
+	defer klog.SetOutput(os.Stderr)
 	return t.sshWithStdin(stdin, command, args...)
 }
 
@@ -99,7 +99,7 @@ func (t *Target) sshWithStdin(stdin string, command string, args ...string) (std
 	if t.sudo {
 		finalCommand = fmt.Sprintf("sudo sh -c '%s'", finalCommand)
 	}
-	log.Printf("running command: %q", finalCommand)
+	klog.Infof("running command: %q", finalCommand)
 	if err := session.Start(finalCommand); err != nil {
 		return "", "", err
 	}
@@ -120,7 +120,7 @@ func readerStreamer(reader io.Reader, outputChan chan<- string, description stri
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		result.Write([]byte(scanner.Text()))
-		log.Printf("%s%s\n", description, scanner.Text())
+		klog.Infof("%s%s\n", description, scanner.Text())
 	}
 	outputChan <- result.String()
 }

--- a/internal/pkg/caaspctl/deployments/ssh/states.go
+++ b/internal/pkg/caaspctl/deployments/ssh/states.go
@@ -18,9 +18,8 @@
 package ssh
 
 import (
-	"log"
-
 	"github.com/pkg/errors"
+	"k8s.io/klog"
 )
 
 var (
@@ -31,15 +30,15 @@ type Runner func(t *Target, data interface{}) error
 
 func (t *Target) Apply(data interface{}, states ...string) error {
 	for _, stateName := range states {
-		log.Printf("=== applying state %s ===\n", stateName)
+		klog.Infof("=== applying state %s ===\n", stateName)
 		if state, stateExists := stateMap[stateName]; stateExists {
 			if err := state(t, data); err != nil {
 				return errors.Errorf("failed to apply state %s: %v", stateName, err)
 			} else {
-				log.Printf("=== state %s applied successfully ===\n", stateName)
+				klog.Infof("=== state %s applied successfully ===\n", stateName)
 			}
 		} else {
-			log.Fatalf("state does not exist: %s", stateName)
+			klog.Fatalf("state does not exist: %s", stateName)
 		}
 	}
 	return nil

--- a/internal/pkg/caaspctl/kubeadm/configmap.go
+++ b/internal/pkg/caaspctl/kubeadm/configmap.go
@@ -18,7 +18,7 @@
 package kubeadm
 
 import (
-	"log"
+	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,16 +34,16 @@ import (
 func RemoveAPIEndpointFromConfigMap(node *v1.Node) error {
 	kubeadmConfig, err := kubernetes.GetAdminClientSet().CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(kubeadmconstants.KubeadmConfigConfigMap, metav1.GetOptions{})
 	if err != nil {
-		log.Fatalf("could not retrieve the kubeadm-config configmap to change the apiEndpoints\n")
+		klog.Fatalf("could not retrieve the kubeadm-config configmap to change the apiEndpoints\n")
 	}
 	clusterStatus := &kubeadmapi.ClusterStatus{}
 	if err := runtime.DecodeInto(kubeadmscheme.Codecs.UniversalDecoder(), []byte(kubeadmConfig.Data[kubeadmconstants.ClusterStatusConfigMapKey]), clusterStatus); err != nil {
-		log.Fatalf("could not unmarshal cluster status from kubeadm-config configmap\n")
+		klog.Fatalf("could not unmarshal cluster status from kubeadm-config configmap\n")
 	}
 	delete(clusterStatus.APIEndpoints, node.ObjectMeta.Name)
 	clusterStatusYaml, err := configutil.MarshalKubeadmConfigObject(clusterStatus)
 	if err != nil {
-		log.Fatalf("could not marshal modified cluster status\n")
+		klog.Fatalf("could not marshal modified cluster status\n")
 	}
 	_, err = kubernetes.GetAdminClientSet().CoreV1().ConfigMaps(metav1.NamespaceSystem).Update(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -56,7 +56,7 @@ func RemoveAPIEndpointFromConfigMap(node *v1.Node) error {
 		},
 	})
 	if err != nil {
-		log.Fatalf("could not update kubeadm-config configmap\n")
+		klog.Fatalf("could not update kubeadm-config configmap\n")
 	}
 	return nil
 }

--- a/internal/pkg/caaspctl/kubernetes/clientset.go
+++ b/internal/pkg/caaspctl/kubernetes/clientset.go
@@ -18,7 +18,7 @@
 package kubernetes
 
 import (
-	"log"
+	"k8s.io/klog"
 
 	clientset "k8s.io/client-go/kubernetes"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
@@ -29,7 +29,7 @@ import (
 func GetAdminClientSet() *clientset.Clientset {
 	client, err := kubeconfigutil.ClientSetFromFile(caaspctl.KubeConfigAdminFile())
 	if err != nil {
-		log.Fatal("could not load admin kubeconfig file")
+		klog.Fatal("could not load admin kubeconfig file")
 	}
 	return client
 }

--- a/internal/pkg/caaspctl/kubernetes/jobs.go
+++ b/internal/pkg/caaspctl/kubernetes/jobs.go
@@ -20,7 +20,7 @@ package kubernetes
 import (
 	"errors"
 	"fmt"
-	"log"
+	"k8s.io/klog"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -50,13 +50,13 @@ func CreateAndWaitForJob(name string, spec batchv1.JobSpec) error {
 	for i := 0; i < 60; i++ {
 		job, err := GetAdminClientSet().BatchV1().Jobs(metav1.NamespaceSystem).Get(name, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("failed to get status for job %s, continuing...\n", name)
+			klog.Infof("failed to get status for job %s, continuing...\n", name)
 		} else {
 			if job.Status.Active > 0 {
-				log.Printf("job %s is active, waiting...\n", name)
+				klog.Infof("job %s is active, waiting...\n", name)
 			} else {
 				if job.Status.Succeeded > 0 {
-					log.Printf("job %s executed successfully\n", name)
+					klog.Infof("job %s executed successfully\n", name)
 					return nil
 				}
 			}

--- a/internal/pkg/caaspctl/kubernetes/nodes.go
+++ b/internal/pkg/caaspctl/kubernetes/nodes.go
@@ -19,7 +19,7 @@ package kubernetes
 
 import (
 	"fmt"
-	"log"
+	"k8s.io/klog"
 	"os/exec"
 
 	v1 "k8s.io/api/core/v1"
@@ -47,10 +47,10 @@ func DrainNode(node *v1.Node) error {
 		"drain", "--delete-local-data=true", "--force=true", "--ignore-daemonsets=true", node.ObjectMeta.Name)
 
 	if err := cmd.Run(); err != nil {
-		log.Printf("could not drain node %s, aborting (use --force if you want to ignore this error)\n", node.ObjectMeta.Name)
+		klog.Infof("could not drain node %s, aborting (use --force if you want to ignore this error)\n", node.ObjectMeta.Name)
 		return err
 	} else {
-		log.Printf("node %s correctly drained\n", node.ObjectMeta.Name)
+		klog.Infof("node %s correctly drained\n", node.ObjectMeta.Name)
 	}
 
 	return nil

--- a/pkg/caaspctl/actions/cluster/init/init.go
+++ b/pkg/caaspctl/actions/cluster/init/init.go
@@ -19,10 +19,11 @@ package cluster
 
 import (
 	"bytes"
-	"log"
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"k8s.io/klog"
 )
 
 type InitConfiguration struct {
@@ -39,24 +40,24 @@ type InitConfiguration struct {
 // FIXME: error handling with `github.com/pkg/errors`; return errors
 func Init(initConfiguration InitConfiguration) {
 	if _, err := os.Stat(initConfiguration.ClusterName); err == nil {
-		log.Fatalf("cluster configuration directory %q already exists\n", initConfiguration.ClusterName)
+		klog.Fatalf("cluster configuration directory %q already exists\n", initConfiguration.ClusterName)
 	}
 	if err := os.MkdirAll(initConfiguration.ClusterName, 0700); err != nil {
-		log.Fatalf("could not create cluster directory %q: %v\n", initConfiguration.ClusterName, err)
+		klog.Fatalf("could not create cluster directory %q: %v\n", initConfiguration.ClusterName, err)
 	}
 	if err := os.Chdir(initConfiguration.ClusterName); err != nil {
-		log.Fatalf("could not change to cluster directory %q: %v\n", initConfiguration.ClusterName, err)
+		klog.Fatalf("could not change to cluster directory %q: %v\n", initConfiguration.ClusterName, err)
 	}
 	for _, file := range scaffoldFiles {
 		filePath, _ := filepath.Split(file.Location)
 		if filePath != "" {
 			if err := os.MkdirAll(filePath, 0700); err != nil {
-				log.Fatalf("could not create directory %q: %v\n", filePath, err)
+				klog.Fatalf("could not create directory %q: %v\n", filePath, err)
 			}
 		}
 		f, err := os.Create(file.Location)
 		if err != nil {
-			log.Fatalf("could not create file %q: %v\n", file.Location, err)
+			klog.Fatalf("could not create file %q: %v\n", file.Location, err)
 		}
 		f.WriteString(renderTemplate(file.Content, initConfiguration))
 		f.Close()
@@ -66,11 +67,11 @@ func Init(initConfiguration InitConfiguration) {
 func renderTemplate(templateContents string, initConfiguration InitConfiguration) string {
 	template, err := template.New("").Parse(templateContents)
 	if err != nil {
-		log.Fatal("could not parse template")
+		klog.Fatal("could not parse template")
 	}
 	var rendered bytes.Buffer
 	if err := template.Execute(&rendered, initConfiguration); err != nil {
-		log.Fatal("could not render configuration")
+		klog.Fatal("could not render configuration")
 	}
 	return rendered.String()
 }

--- a/pkg/caaspctl/actions/cluster/status/status.go
+++ b/pkg/caaspctl/actions/cluster/status/status.go
@@ -18,7 +18,7 @@
 package cluster
 
 import (
-	"log"
+	"k8s.io/klog"
 	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +37,7 @@ func Status() {
 
 	nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
-		log.Fatal("could not retrieve node list")
+		klog.Fatal("could not retrieve node list")
 	}
 
 	outputFormat := "custom-columns=NAME:.metadata.name,OS-IMAGE:.status.nodeInfo.osImage,KERNEL-VERSION:.status.nodeInfo.kernelVersion,CONTAINER-RUNTIME:.status.nodeInfo.containerRuntimeVersion,HAS-UPDATES:.metadata.annotations.caasp\\.suse\\.com/has-updates,HAS-DISRUPTIVE-UPDATES:.metadata.annotations.caasp\\.suse\\.com/has-disruptive-updates"
@@ -47,7 +47,7 @@ func Status() {
 
 	printer, err := printFlags.ToPrinter()
 	if err != nil {
-		log.Fatal("could not create printer")
+		klog.Fatal("could not create printer")
 	}
 	printer.PrintObj(nodeList, os.Stdout)
 }

--- a/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
+++ b/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
@@ -20,10 +20,11 @@ package node
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"strings"
+
+	"k8s.io/klog"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -104,7 +105,7 @@ func addTargetInformationToInitConfiguration(target *deployments.Target, initCon
 	initConfiguration.NodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = images.GetGenericImage(caaspctl.ImageRepository, "pause", kubernetes.CurrentComponentVersion(kubernetes.Pause))
 	osRelease, err := target.OSRelease()
 	if err != nil {
-		log.Fatalf("could not retrieve OS release information: %v", err)
+		klog.Fatalf("could not retrieve OS release information: %v", err)
 	}
 	if strings.Contains(osRelease["ID_LIKE"], "suse") {
 		initConfiguration.NodeRegistration.KubeletExtraArgs["cni-bin-dir"] = "/usr/lib/cni"


### PR DESCRIPTION
Why do we need this:
Currently our logging does not follow upstream best practices. This PR updates all logging to use klog for all logging with as minimal changes to anything else as possible to support this.

Related: https://github.com/SUSE/avant-garde/issues/25