### PR TITLE
added feedback to cluster init

### DIFF
--- a/pkg/caaspctl/actions/cluster/init/init.go
+++ b/pkg/caaspctl/actions/cluster/init/init.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"text/template"
@@ -61,6 +62,12 @@ func Init(initConfiguration InitConfiguration) {
 		}
 		f.WriteString(renderTemplate(file.Content, initConfiguration))
 		f.Close()
+	}
+
+	if currentDir, err := os.Getwd(); err != nil {
+		klog.Fatalf("could not get current directory %s\n", err)
+	} else {
+		fmt.Printf("configuration files written to %s\n", currentDir)
 	}
 }
 


### PR DESCRIPTION
Why we need this:
No user feedback on successful init

What does this do:
provides user feedback on successful init

fixes: https://github.com/SUSE/avant-garde/issues/104