### PR TITLE
Fix flannel configuration on 1.14

### DIFF
--- a/pkg/caaspctl/actions/cluster/init/manifests.go
+++ b/pkg/caaspctl/actions/cluster/init/manifests.go
@@ -60,7 +60,7 @@ discovery:
 
 	flannelManifest = `---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -85,7 +85,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:


### PR DESCRIPTION
Some objects used by flannel have been promoted to stable with 1.14. We have to change their definition otherwise the network won't applied.

CC @danielorf, @ereslibre and @jordimassaguerpla 