### PR TITLE
Terraform script for LXD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Binary folder
 /bin
+
+terraform.tfstate*
+.terraform

--- a/ci/infra/lxd/README.md
+++ b/ci/infra/lxd/README.md
@@ -1,0 +1,50 @@
+## Introduction
+
+Terraform cluster definition leveraging the libvirt provider.
+
+The whole infra is based on openSUSE Leap 15.0 built for public cloud usage.
+
+The image customization relies on cloud-init.
+
+## Pre-requisites
+
+* _LXD_
+
+  The easiest way to install LXD is with a Snap: https://snapcraft.io/lxd.
+  Just do a `snap install lxd`. Then you will have to add your username to
+  the `lxc` group (for accessing the LXD socket without being root).
+
+* _terraform/LXD_
+
+  You whill have to compile the LXD provider by yourself with a Golang compiler
+  (and your `GOPATH` properly set).
+  Do a `go get -v -u github.com/sl1pm4t/terraform-provider-lxd`.
+  Maybe you will have to add the provider to your `~/.terraformrc` if terraform does not find
+  the provider automatically. For example:
+  ```
+  providers {
+    lxd = "/users/me/go/src/github.com/sl1pm4t/terraform-provider-lxd/terraform-provider-lxd"
+  }
+  ```
+
+## Machine access
+
+By default all the machines will have the following users:
+
+* All the instances have a `root` user with `linux` password.
+* It is important to have your public ssh key within the `authorized_keys`,
+this is done by `cloud-init` through a terraform variable called `authorized_keys`.
+
+## Load balancer
+
+Terraform will create a static DHCP configuration to be used.
+
+## Topology
+
+The cluster will be made by these machines:
+
+  * A load balancer
+  * X master nodes: have `kubeadm`, `kubelet` and `kubectl` preinstalled
+  * Y worker nodes: have `kubeadm`, `kubelet` and `kubectl` preinstalled
+
+All node should be able to ping each other and resolve their FQDN.

--- a/ci/infra/lxd/cluster.tf
+++ b/ci/infra/lxd/cluster.tf
@@ -1,0 +1,130 @@
+#######################
+# Cluster declaration #
+#######################
+
+provider "lxd" {
+  generate_client_certificates = true
+  accept_remote_certificate    = true
+}
+
+locals {
+  authorized_keys_file = <<EOT
+${join("\n", formatlist("%s", var.authorized_keys))}
+${file("${path.module}/../id_shared.pub")}
+EOT
+}
+
+##############
+# Base image #
+##############
+
+resource "null_resource" "base_image" {
+  # make sure we have an opensuse-caasp image
+  # if that is not the case, build one with the help of distrobuilder
+  provisioner "local-exec" {
+    command = "./support/build-image.sh --img '${var.img}' --force '${var.force_img}'"
+  }
+}
+
+#####################
+### Cluster masters #
+#####################
+
+resource "lxd_container" "master" {
+  count      = "${var.master_count}"
+  name       = "${var.name_prefix}master-${count.index}"
+  image      = "${var.img}"
+  depends_on = ["null_resource.base_image"]
+
+  connection {
+    type     = "ssh"
+    user     = "${var.ssh_user}"
+    password = "${var.ssh_pass}"
+  }
+
+  provisioner "file" {
+    content     = "${local.authorized_keys_file}"
+    destination = "/root/.ssh/authorized_keys"
+  }
+}
+
+output "masters" {
+  value = ["${lxd_container.master.*.ip_address}"]
+}
+
+####################
+## Cluster workers #
+####################
+
+resource "lxd_container" "worker" {
+  count      = "${var.worker_count}"
+  name       = "${var.name_prefix}worker-${count.index}"
+  image      = "${var.img}"
+  depends_on = ["lxd_container.master"]
+
+  connection {
+    type     = "ssh"
+    user     = "${var.ssh_user}"
+    password = "${var.ssh_pass}"
+  }
+
+  provisioner "file" {
+    content     = "${local.authorized_keys_file}"
+    destination = "/root/.ssh/authorized_keys"
+  }
+}
+
+output "workers" {
+  value = ["${lxd_container.worker.*.ip_address}"]
+}
+
+######################
+# Load Balancer node #
+######################
+data "template_file" "haproxy_backends_master" {
+  count    = "${var.master_count}"
+  template = "${file("templates/haproxy-backends.tpl")}"
+
+  vars = {
+    fqdn = "${var.name_prefix}master-${count.index}.${var.name_prefix}${var.domain_name}"
+    ip   = "${element(lxd_container.master.*.ip_address, count.index)}"
+  }
+}
+
+data "template_file" "haproxy_cfg" {
+  template = "${file("templates/haproxy.cfg.tpl")}"
+
+  vars = {
+    backends = "${join("      ", data.template_file.haproxy_backends_master.*.rendered)}"
+  }
+}
+
+resource "lxd_container" "lb" {
+  name       = "${var.name_prefix}lb"
+  image      = "${var.img}"
+  depends_on = ["lxd_container.master"]
+
+  connection {
+    type     = "ssh"
+    user     = "${var.ssh_user}"
+    password = "${var.ssh_pass}"
+  }
+
+  provisioner "file" {
+    content     = "${local.authorized_keys_file}"
+    destination = "/root/.ssh/authorized_keys"
+  }
+
+  provisioner "file" {
+    content     = "${data.template_file.haproxy_cfg.rendered}"
+    destination = "/etc/haproxy/haproxy.cfg"
+  }
+
+  provisioner "remote-exec" {
+    inline = "systemctl enable --now haproxy"
+  }
+}
+
+output "ip_lb" {
+  value = "${lxd_container.lb.ip_address}"
+}

--- a/ci/infra/lxd/support/build-image.sh
+++ b/ci/infra/lxd/support/build-image.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+#
+# LXD image build
+#
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+FIRST_GOPATH=$(echo `echo ${GOPATH} | cut -f1 -d':'`)
+GOBIN=$([ -n "${GOBIN}" ] && echo ${GOBIN} || (echo $(GOPATH)/bin))
+
+DISTROBUILDER=
+DISTROBUILDER_YAML=$DIR/distrobuilder-opensuse.yaml
+
+IMAGE_ALIAS="opensuse-caasp"
+
+FORCE=
+
+read -r -d '' HELP <<- EOM
+Usage:
+
+  $0 [args]
+
+where [args] can be:
+
+  --img <IMAGE>          the name for the image to load in LXD
+                         (default: $IMAGE_ALIAS)
+  --yaml <YAML>          the YAML definition file
+                         (default: $DISTROBUILDER_YAML)
+  --distrobuilder <EXE>  the distrobuilder executable
+                         (will be downloaded if no provided/autodetected)
+  --force <BOOL>         force the image (re)creation
+
+EOM
+
+while [ $# -gt 0 ] ; do
+  case $1 in
+    --img|--alias)
+      IMAGE_ALIAS=$2
+      shift
+      ;;
+    --distrobuilder|--exe)
+      DISTROBUILDER=$2
+      shift
+      ;;
+    --yaml|--definition)
+      DISTROBUILDER_YAML=$2
+      shift
+      ;;
+    --force)
+      case $2 in
+        true|TRUE|yes|YES|1)
+          FORCE=1
+          ;;
+        false|FALSE|no|NO|0)
+          FORCE=
+          ;;
+      esac
+      shift
+      ;;
+    --help|-h)
+      echo "$HELP"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+#########################################################################
+
+check_distrobuilder() {
+    if [ -n "$DISTROBUILDER" ] ; then
+        echo ">>> (distrobuilder provided: $DISTROBUILDER)"
+        return
+    fi
+
+    if command distrobuilder &>/dev/null ; then
+        DISTROBUILDER="$(which distrobuilder)"
+        echo ">>> (distrobuilder found in the PATH)"
+        return
+    fi
+
+    if [ -x $GOBIN/distrobuilder ] ; then
+        echo ">>> (distrobuilder found at $GOBIN/distrobuilder)"
+        DISTROBUILDER=$GOBIN/distrobuilder
+        return
+    fi
+
+    echo ">>> downloading distrobuilde with 'go get'..."
+    go get -d github.com/lxc/distrobuilder
+    echo ">>> building distrobuilder..."
+    make -C $FIRST_GOPATH/src/github.com/lxc/distrobuilder
+    echo ">>> distrobuilder installed at $GOBIN/distrobuilder"
+    DISTROBUILDER=$GOBIN/distrobuilder
+}
+
+#########################################################################
+# LXD images
+
+image_exists() {
+    lxc image show $IMAGE_ALIAS &>/dev/null
+}
+
+image_delete() {
+    echo ">>> deleting any previous image $IMAGE_ALIAS..."
+    lxc image delete $IMAGE_ALIAS 2>/dev/null || /bin/true
+}
+
+image_artifacts_exist() {
+    [ -f lxd.tar.xz ] && [ -f rootfs.squashfs ]
+}
+
+image_build() {
+    echo ">>> building LXD image with $DISTROBUILDER..."
+    echo ">>> IMPORTANT: distrobuilder will be launched with SUDO !!!"
+    sudo $DISTROBUILDER --cleanup=false build-lxd $DISTROBUILDER_YAML
+}
+
+image_import() {
+    image_delete
+
+    echo ">>> importing LXD image..."
+    lxc image import lxd.tar.xz rootfs.squashfs --alias $IMAGE_ALIAS
+    echo ">>> removing leftovers"
+    rm -f lxd.tar.xz rootfs.squashfs
+    echo ">>> current list of LXD images:"
+    lxc image list
+}
+
+image_cleanup() {
+    echo ">>> cleaning up leftovers..."
+    # just in case...
+}
+
+[ -n "$FORCE" ] && image_delete
+echo ">>> checking if $IMAGE_ALIAS image exists..."
+if ! image_exists ; then
+    echo ">>> $IMAGE_ALIAS does not exist: building..."
+    check_distrobuilder
+    trap image_cleanup EXIT
+    image_artifacts_exist || image_build
+    image_artifacts_exist && image_import
+else
+    echo ">>> $IMAGE_ALIAS already present!"
+fi
+

--- a/ci/infra/lxd/support/distrobuilder-opensuse.yaml
+++ b/ci/infra/lxd/support/distrobuilder-opensuse.yaml
@@ -1,0 +1,147 @@
+#
+# openSUSE definition file for CaaSP
+#
+###################################################################################
+# NOTE: make sure you REMOVE the old image (with `lxc delete opensuse-caasp`)
+#       AFTER MODIFYING THIS FILE
+###################################################################################
+
+image:
+  distribution: openSUSE
+  release: 15.0
+  description: openSUSE Leap {{ image.release }} for CaaSP
+  expiry: 30d
+  architecture: x86_64
+
+source:
+  downloader: opensuse-http
+  url: https://download.opensuse.org
+  skip_verification: true
+
+targets:
+  lxc:
+    create-message: |
+      You just created an openSUSE Leap container (release={{ image.release }}, arch={{ image.architecture }})
+
+    config:
+      - type: all
+        before: 5
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/opensuse.common.conf
+
+      - type: user
+        before: 5
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/opensuse.userns.conf
+
+      - type: all
+        after: 4
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/common.conf
+
+      - type: user
+        after: 4
+        content: |-
+          lxc.include = LXC_TEMPLATE_CONFIG/userns.conf
+
+      - type: all
+        content: |-
+          lxc.arch = {{ image.architecture_kernel }}
+
+files:
+  - path: /etc/hostname
+    generator: hostname
+
+  - path: /etc/hosts
+    generator: hosts
+
+  - name: ifcfg-eth0.lxd
+    path: /etc/sysconfig/network/ifcfg-eth0
+    generator: template
+    content: |-
+      STARTMODE='auto'
+      BOOTPROTO='dhcp'
+      HOSTNAME={{ container.name }}
+      DHCP_HOSTNAME=`hostname`
+
+packages:
+  manager: zypper
+  update: false
+  refresh: true
+  cleanup: true
+  repositories:
+    - name: caasp
+      url: https://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode/openSUSE_Leap_15.0
+  sets:
+    - packages:
+        - systemd-sysvinit
+        - openssh
+        - sudo
+        - apparmor-abstractions
+        - elfutils
+        - file
+        - glib2-tools
+        - gzip
+        - hardlink
+        - hostname
+        - iputils
+        - net-tools
+        - openslp
+        - rsync
+        - shared-mime-info
+        - which
+        - vim
+        # CaaSP packages
+        - salt-ssh
+        - kubernetes-kubeadm
+        - kubernetes-kubelet
+        - kubectl
+        - cni-plugins
+        - haproxy
+        - cri-o
+      action: install
+
+actions:
+  - trigger: post-packages
+    action: |-
+      #!/bin/sh
+
+      # encryted "linux"
+      # obtained with `echo "linux" | openssl passwd -1 -stdin`
+      ROOT_PASSWORD='$1$62xujQ/G$IxTMM4LZimNXF3LFcBawC1'
+
+      echo ">>> setting a trivial password for root"
+      echo "root:$ROOT_PASSWORD" | /usr/sbin/chpasswd -e
+      echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+
+      mkdir -p /root/.ssh
+      chmod 700 /root/.ssh
+      touch /root/.ssh/authorized_keys
+      chmod 600 /root/.ssh/authorized_keys
+
+      # for using this image with the Vagrant-LXD  plugin, uncomment the following lines:
+      # encryted "vagrant"
+      # obtained with `echo "vagrant" | openssl passwd -1 -stdin`
+      # PASSWORD='$1$TEfkpqbs$cwgryzvqKnlWf5WgPBvKS0'
+      # echo ">>> creating vagrant user"
+      # groupadd -f vagrant
+      # useradd --create-home -p "$PASSWORD" -s /bin/bash vagrant
+      # echo ">>> adding vagrant to the 'sudo' group"
+      # groupadd -f sudo
+      # usermod -a -G sudo vagrant
+      # echo ">>> adding vagrant to the 'docker' group"
+      # usermod -a -G docker vagrant
+      # echo ">>> enabling passwordless sudo for users under the 'sudo' group"
+      # mkdir -p /etc/sudoers.d
+      # echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/sudo
+
+      echo ">>> enabling services"
+      systemctl enable sshd
+      systemctl enable crio
+      
+      exit 0
+
+environment:
+  variables:
+    - key: HOME
+      value: /root

--- a/ci/infra/lxd/templates/haproxy-backends.tpl
+++ b/ci/infra/lxd/templates/haproxy-backends.tpl
@@ -1,0 +1,1 @@
+server ${fqdn} ${ip}:6443 check check-ssl verify none

--- a/ci/infra/lxd/templates/haproxy.cfg.tpl
+++ b/ci/infra/lxd/templates/haproxy.cfg.tpl
@@ -1,0 +1,37 @@
+global
+  log /dev/log daemon
+  maxconn 32768
+  chroot /var/lib/haproxy
+  user haproxy
+  group haproxy
+  daemon
+  stats socket /var/lib/haproxy/stats user haproxy group haproxy mode 0640 level operator
+  tune.bufsize 32768
+  tune.ssl.default-dh-param 2048
+  ssl-default-bind-ciphers ALL:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK:!RC4:!ADH:!LOW@STRENGTH
+
+defaults
+  log     global
+  mode    tcp
+  option  log-health-checks
+  option  log-separate-errors
+  option  dontlog-normal
+  option  dontlognull
+  option  httplog
+  option  socket-stats
+  retries 3
+  option  redispatch
+  maxconn 10000
+  timeout connect     5s
+  timeout client     50s
+  timeout server    450s
+
+frontend apiserver
+  bind 0.0.0.0:6443
+  default_backend apiserver-backend
+
+backend apiserver-backend
+  option httpchk GET /healthz
+  default-server inter 3s fall 3 rise 2
+  ${backends}
+

--- a/ci/infra/lxd/variables.tf
+++ b/ci/infra/lxd/variables.tf
@@ -1,0 +1,55 @@
+#####################
+# Cluster variables #
+#####################
+
+variable "img" {
+  type        = "string"
+  default     = "opensuse-caasp"
+  description = "image name"
+}
+
+variable "force_img" {
+  type        = "string"
+  default     = ""
+  description = "force the image re-creation"
+}
+
+variable "master_count" {
+  default     = 1
+  description = "Number of masters to be created"
+}
+
+variable "worker_count" {
+  default     = 2
+  description = "Number of workers to be created"
+}
+
+variable "name_prefix" {
+  type        = "string"
+  default     = "ag-"
+  description = "Optional prefix to be able to have multiple clusters on one host"
+}
+
+variable "authorized_keys" {
+  type        = "list"
+  default     = []
+  description = "ssh keys to inject into all the nodes"
+}
+
+variable "ssh_user" {
+  type        = "string"
+  default     = "root"
+  description = "The SSH user"
+}
+
+variable "ssh_pass" {
+  type        = "string"
+  default     = "linux"
+  description = "The SSH password"
+}
+
+variable "domain_name" {
+  type        = "string"
+  default     = "test.net"
+  description = "The domain name"
+}


### PR DESCRIPTION
LXD can be used for for running containers for CaaSP. This PR implements a Terraform script for using the [Terraform LXD](https://github.com/sl1pm4t/terraform-provider-lxd) provider for creating the cluster. 

It uses [`distrobuilder`](https://github.com/lxc/distrobuilder) for bulding (only the first time) an image with all the necessary stuff, and then just lunches the containers (so there is no need to do any cloud-init configuration).

Compared to the other infra platforms, LXD is blazing fast, with minimal memory footprint and other goodies like snapshots.

