### PR TITLE
Fix README to refer to cri-o instead of docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ depending on your needs this setup can be as advanced as required.
 
 The target nodes must have some packages already preinstalled:
 
-  * docker
+  * cri-o
   * kubelet
   * kubeadm
 


### PR DESCRIPTION
Just fixing a reference in the README to read 'cri-o' instead of 'docker'.