### PR TITLE
Do not use intermediate functions to return runners, just use the functions directly

### DIFF
--- a/internal/pkg/caaspctl/deployments/ssh/cni.go
+++ b/internal/pkg/caaspctl/deployments/ssh/cni.go
@@ -27,25 +27,23 @@ import (
 )
 
 func init() {
-	stateMap["cni.deploy"] = cniDeploy()
+	stateMap["cni.deploy"] = cniDeploy
 }
 
-func cniDeploy() Runner {
-	return func(t *Target, data interface{}) error {
-		cniFiles, err := ioutil.ReadDir(caaspctl.CniDir())
-		if err != nil {
-			return errors.Wrap(err, "could not read local cni directory")
-		}
-
-		defer t.ssh("rm -rf /tmp/cni.d")
-
-		for _, f := range cniFiles {
-			if err := t.target.UploadFile(path.Join(caaspctl.CniDir(), f.Name()), path.Join("/tmp/cni.d", f.Name())); err != nil {
-				return err
-			}
-		}
-
-		_, _, err = t.ssh("kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/cni.d")
-		return err
+func cniDeploy(t *Target, data interface{}) error {
+	cniFiles, err := ioutil.ReadDir(caaspctl.CniDir())
+	if err != nil {
+		return errors.Wrap(err, "could not read local cni directory")
 	}
+
+	defer t.ssh("rm -rf /tmp/cni.d")
+
+	for _, f := range cniFiles {
+		if err := t.target.UploadFile(path.Join(caaspctl.CniDir(), f.Name()), path.Join("/tmp/cni.d", f.Name())); err != nil {
+			return err
+		}
+	}
+
+	_, _, err = t.ssh("kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/cni.d")
+	return err
 }

--- a/internal/pkg/caaspctl/deployments/ssh/cri.go
+++ b/internal/pkg/caaspctl/deployments/ssh/cri.go
@@ -18,12 +18,10 @@
 package ssh
 
 func init() {
-	stateMap["cri.start"] = criStart()
+	stateMap["cri.start"] = criStart
 }
 
-func criStart() Runner {
-	return func(t *Target, data interface{}) error {
-		_, _, err := t.ssh("systemctl", "enable", "--now", "crio")
-		return err
-	}
+func criStart(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "enable", "--now", "crio")
+	return err
 }

--- a/internal/pkg/caaspctl/deployments/ssh/kernel.go
+++ b/internal/pkg/caaspctl/deployments/ssh/kernel.go
@@ -18,26 +18,22 @@
 package ssh
 
 func init() {
-	stateMap["kernel.load-modules"] = kernelLoadModules()
-	stateMap["kernel.configure-parameters"] = kernelConfigureParameters()
+	stateMap["kernel.load-modules"] = kernelLoadModules
+	stateMap["kernel.configure-parameters"] = kernelConfigureParameters
 }
 
-func kernelLoadModules() Runner {
-	return func(t *Target, data interface{}) error {
-		if _, _, err := t.ssh("modprobe br_netfilter"); err != nil {
-			return err
-		}
-		err := t.UploadFileContents("/etc/modules-load.d/br_netfilter.conf", "br_netfilter")
+func kernelLoadModules(t *Target, data interface{}) error {
+	if _, _, err := t.ssh("modprobe br_netfilter"); err != nil {
 		return err
 	}
+	err := t.UploadFileContents("/etc/modules-load.d/br_netfilter.conf", "br_netfilter")
+	return err
 }
 
-func kernelConfigureParameters() Runner {
-	return func(t *Target, data interface{}) error {
-		if _, _, err := t.ssh("sysctl -w net.ipv4.ip_forward=1"); err != nil {
-			return err
-		}
-		_, _, err := t.ssh("sysctl -w net.bridge.bridge-nf-call-iptables=1")
+func kernelConfigureParameters(t *Target, data interface{}) error {
+	if _, _, err := t.ssh("sysctl -w net.ipv4.ip_forward=1"); err != nil {
 		return err
 	}
+	_, _, err := t.ssh("sysctl -w net.bridge.bridge-nf-call-iptables=1")
+	return err
 }

--- a/internal/pkg/caaspctl/deployments/ssh/kubelet.go
+++ b/internal/pkg/caaspctl/deployments/ssh/kubelet.go
@@ -24,42 +24,38 @@ import (
 )
 
 func init() {
-	stateMap["kubelet.configure"] = kubeletConfigure()
-	stateMap["kubelet.enable"] = kubeletEnable()
+	stateMap["kubelet.configure"] = kubeletConfigure
+	stateMap["kubelet.enable"] = kubeletEnable
 }
 
-func kubeletConfigure() Runner {
-	return func(t *Target, data interface{}) error {
-		osRelease, err := t.target.OSRelease()
-		if err != nil {
+func kubeletConfigure(t *Target, data interface{}) error {
+	osRelease, err := t.target.OSRelease()
+	if err != nil {
+		return err
+	}
+	if strings.Contains(osRelease["ID_LIKE"], "suse") {
+		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
 			return err
 		}
-		if strings.Contains(osRelease["ID_LIKE"], "suse") {
-			if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
-				return err
-			}
-			if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
-				return err
-			}
-			if err := t.UploadFileContents("/etc/sysconfig/kubelet", assets.KubeletSysconfig); err != nil {
-				return err
-			}
-		} else {
-			if err := t.UploadFileContents("/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
-				return err
-			}
-			if err := t.UploadFileContents("/etc/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
-				return err
-			}
+		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
+			return err
 		}
-		_, _, err = t.ssh("systemctl", "daemon-reload")
-		return err
+		if err := t.UploadFileContents("/etc/sysconfig/kubelet", assets.KubeletSysconfig); err != nil {
+			return err
+		}
+	} else {
+		if err := t.UploadFileContents("/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
+			return err
+		}
+		if err := t.UploadFileContents("/etc/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
+			return err
+		}
 	}
+	_, _, err = t.ssh("systemctl", "daemon-reload")
+	return err
 }
 
-func kubeletEnable() Runner {
-	return func(t *Target, data interface{}) error {
-		_, _, err := t.ssh("systemctl", "enable", "kubelet")
-		return err
-	}
+func kubeletEnable(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "enable", "kubelet")
+	return err
 }


### PR DESCRIPTION
Change the pattern when building the state map so we point directly to the runners instead of having intermediate functions that return those runners.

The only one that is kept is on the `kubernetes` state, so `kubernetes.bootstrap.upload-secrets` and `kubernetes.join.upload-secrets` behave slightly different while using the same logic.