### PR TITLE
use errors package to format error

### DIFF
--- a/internal/pkg/caaspctl/deployments/os.go
+++ b/internal/pkg/caaspctl/deployments/os.go
@@ -52,7 +52,7 @@ func (t *Target) oSRelease() (map[string]string, error) {
 func (t *Target) hasOS(os string) (bool, error) {
 	osRelease, err := t.oSRelease()
 	if err != nil {
-		return false, errors.Errorf("could not retrieve OS release information: %v", err)
+		return false, errors.Wrap(err, "could not retrieve OS release information")
 	}
 
 	if strings.Contains(osRelease["ID_LIKE"], os) {

--- a/internal/pkg/caaspctl/deployments/ssh/states.go
+++ b/internal/pkg/caaspctl/deployments/ssh/states.go
@@ -33,7 +33,7 @@ func (t *Target) Apply(data interface{}, states ...string) error {
 		klog.Infof("=== applying state %s ===\n", stateName)
 		if state, stateExists := stateMap[stateName]; stateExists {
 			if err := state(t, data); err != nil {
-				return errors.Errorf("failed to apply state %s: %v", stateName, err)
+				return errors.Wrapf(err, "failed to apply state %s", stateName)
 			} else {
 				klog.Infof("=== state %s applied successfully ===\n", stateName)
 			}

--- a/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
+++ b/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
@@ -18,14 +18,12 @@
 package node
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 
-	"k8s.io/klog"
-
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
@@ -33,17 +31,17 @@ import (
 	"github.com/SUSE/caaspctl/internal/pkg/caaspctl/deployments"
 	"github.com/SUSE/caaspctl/internal/pkg/caaspctl/kubernetes"
 	"github.com/SUSE/caaspctl/pkg/caaspctl"
+	"github.com/pkg/errors"
 )
 
 // Bootstrap initializes the first master node of the cluster
 //
 // FIXME: being this a part of the go API accept the toplevel directory instead
 //        of using the PWD
-// FIXME: error handling with `github.com/pkg/errors`
 func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target *deployments.Target) error {
 	initConfiguration, err := LoadInitConfigurationFromFile(caaspctl.KubeadmInitConfFile())
 	if err != nil {
-		return fmt.Errorf("Could not parse %s file: %v", caaspctl.KubeadmInitConfFile(), err)
+		return errors.Wrapf(err, "could not parse %s file", caaspctl.KubeadmInitConfFile())
 	}
 	addTargetInformationToInitConfiguration(target, initConfiguration)
 	setHyperkubeImageToInitConfiguration(initConfiguration)
@@ -53,11 +51,11 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		Version: "v1beta1",
 	})
 	if err != nil {
-		return fmt.Errorf("Could not marshal configuration: %v", err)
+		return errors.Wrap(err, "could not marshal configuration")
 	}
 
 	if err := ioutil.WriteFile(caaspctl.KubeadmInitConfFile(), finalInitConfigurationContents, 0600); err != nil {
-		return fmt.Errorf("Error writing init configuration: %v", err)
+		return errors.Wrap(err, "error writing init configuration")
 	}
 
 	err = target.Apply(


### PR DESCRIPTION

## Why is this PR needed?
Use `errors.Errorf` to be consistent 

## What does this PR do?

Replace `fmt.Errorf` with `errors.Errorf`
