### PR TITLE
Enable go vet via makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ BUILD_DATE := $(shell date +%Y%m%d-%H:%M:%S)
 CAASPCTL_LDFLAGS = -ldflags "-X=github.com/SUSE/caaspctl/internal/app/caaspctl.Version=$(VERSION) \
                              -X=github.com/SUSE/caaspctl/internal/app/caaspctl.Commit=$(COMMIT) \
                              -X=github.com/SUSE/caaspctl/internal/app/caaspctl.BuildDate=$(BUILD_DATE)"
+
+CAASPCTL_DIRS    = cmd pkg internal test
+
+# go source files, ignore vendor directory
+CAASPCTL_SRCS = $(shell find $(CAASPCTL_DIRS) -type f -name '*.go')
+
 .PHONY: all
 all: build
 
@@ -31,3 +37,7 @@ staging:
 .PHONY: release
 release:
 	$(GO) install $(CAASPCTL_LDFLAGS) -tags release ./cmd/...
+
+.PHONY: vet
+vet:
+	$(GO) tool vet ${CAASPCTL_SRCS} 


### PR DESCRIPTION
## Why is this PR needed?

this PR adress https://github.com/SUSE/avant-garde/issues/140  (partially)

## What does this PR do?
- Add make vet target so that we can run go vet locally and in remote ci
in future using go vet
- Create logic for ignoring go vendors so that we ignore them because
this is a commong golang issue

The goal of this PR is to have everything in the `makefile` so we can use remotely what we have locally

## How to test this PR?

for testing this PR just add a `return` before some code executed, so it is an `unreachable` code and go vet will complain
