### PR TITLE
Handle pod security policy (PSP) deployment

### DIFF
--- a/internal/pkg/caaspctl/deployments/ssh/psp.go
+++ b/internal/pkg/caaspctl/deployments/ssh/psp.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2019 SUSE LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ssh
+
+import (
+	"io/ioutil"
+	"path"
+
+	"github.com/pkg/errors"
+
+	"github.com/SUSE/caaspctl/pkg/caaspctl"
+)
+
+func init() {
+	stateMap["psp.deploy"] = pspDeploy
+}
+
+func pspDeploy(t *Target, data interface{}) error {
+	pspFiles, err := ioutil.ReadDir(caaspctl.PspDir())
+	if err != nil {
+		return errors.Wrap(err, "could not read local psp directory")
+	}
+
+	defer t.ssh("rm -rf /tmp/psp.d")
+
+	for _, f := range pspFiles {
+		if err := t.target.UploadFile(path.Join(caaspctl.PspDir(), f.Name()), path.Join("/tmp/psp.d", f.Name())); err != nil {
+			return err
+		}
+	}
+
+	_, _, err = t.ssh("kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/psp.d")
+	return err
+
+}

--- a/pkg/caaspctl/actions/cluster/init/constants.go
+++ b/pkg/caaspctl/actions/cluster/init/constants.go
@@ -46,5 +46,13 @@ var (
 			// fields remain unknown while `cluster init`
 			DoNotRender: true,
 		},
+		{
+			Location: caaspctl.PspUnprivManifestFile(),
+			Content:  pspUnprivManifest,
+		},
+		{
+			Location: caaspctl.PspPrivManifestFile(),
+			Content:  pspPrivManifest,
+		},
 	}
 )

--- a/pkg/caaspctl/actions/cluster/init/manifests.go
+++ b/pkg/caaspctl/actions/cluster/init/manifests.go
@@ -55,6 +55,211 @@ discovery:
     unsafeSkipCAVerification: true
 `
 
+	pspPrivManifest = `---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.caasp.psp.privileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  # Privileged
+  privileged: true
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Kubernetes Host Volume Types
+    - hostPath
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - cinder
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  #allowedHostPaths: []
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  allowPrivilegeEscalation: true
+  defaultAllowPrivilegeEscalation: true
+  # Capabilities
+  allowedCapabilities:
+    - '*'
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: suse:caasp:psp:privileged
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    resourceNames: ['suse.caasp.psp.privileged']
+    verbs: ['use']
+---
+# Allow CaaSP nodes to use the privileged
+# PodSecurityPolicy.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: suse:caasp:psp:privileged
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+subjects:
+# Only authenticated users
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+# All ServiceAccounts in the 'kube-system' namespace
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts:kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:cilium
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: cilium
+  namespace: kube-system
+`
+
+	pspUnprivManifest = `---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.caasp.psp.unprivileged
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+spec:
+  # Privileged
+  privileged: false
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - cinder
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  allowedHostPaths:
+    # Note: We don't allow hostPath volumes above, but set this to a path we
+    # control anyway as a belt+braces protection. /dev/null may be a better
+    # option, but the implications of pointing this towards a device are
+    # unclear.
+    - pathPrefix: /opt/kubernetes-hostpath-volumes
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  allowPrivilegeEscalation: false
+  defaultAllowPrivilegeEscalation: false
+  # Capabilities
+  allowedCapabilities: []
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  hostPorts:
+  - min: 0
+    max: 65535
+  # SELinux
+  seLinux:
+    # SELinux is unused in CaaSP
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:caasp:psp:unprivileged
+rules:
+  - apiGroups: ['extensions']
+    resources: ['podsecuritypolicies']
+    verbs: ['use']
+    resourceNames: ['suse.caasp.psp.unprivileged']
+---
+# Allow all users and serviceaccounts to use the unprivileged
+# PodSecurityPolicy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:default
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:unprivileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:serviceaccounts
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:authenticated
+`
+
 	ciliumManifest = `---
 apiVersion: v1
 kind: ServiceAccount

--- a/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
+++ b/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
@@ -48,6 +48,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	addTargetInformationToInitConfiguration(target, initConfiguration)
 	setHyperkubeImageToInitConfiguration(initConfiguration)
 	setContainerImages(initConfiguration)
+	setApiserverAdmissionPlugins(initConfiguration)
 	finalInitConfigurationContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(initConfiguration, schema.GroupVersion{
 		Group:   "kubeadm.k8s.io",
 		Version: "v1beta1",
@@ -71,7 +72,9 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.init",
+		"psp.deploy",
 	)
+
 	if err != nil {
 		return err
 	}
@@ -144,4 +147,11 @@ func setContainerImages(initConfiguration *kubeadmapi.InitConfiguration) {
 		ImageRepository: caaspctl.ImageRepository,
 		ImageTag:        kubernetes.CurrentComponentVersion(kubernetes.CoreDNS),
 	}
+}
+
+func setApiserverAdmissionPlugins(initConfiguration *kubeadmapi.InitConfiguration) {
+	if initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs == nil {
+		initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs = map[string]string{}
+	}
+	initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = "NodeRestriction,PodSecurityPolicy"
 }

--- a/pkg/caaspctl/constants.go
+++ b/pkg/caaspctl/constants.go
@@ -71,6 +71,18 @@ func CiliumManifestFile() string {
 	return path.Join(CniDir(), "cilium.yaml")
 }
 
+func PspDir() string {
+	return path.Join(AddonsDir(), "psp")
+}
+
+func PspUnprivManifestFile() string {
+	return path.Join(PspDir(), "podsecuritypolicy-unprivileged.yaml")
+}
+
+func PspPrivManifestFile() string {
+	return path.Join(PspDir(), "podsecuritypolicy-privileged.yaml")
+}
+
 func KubeConfigAdminFile() string {
 	return "admin.conf"
 }


### PR DESCRIPTION
The caaspctl cluster init command should create the deployment files
of v3 pod security policies and later apply them during cluster
bootstrap.

Fixes SUSE/avant-garde#15

## Why is this PR needed?

https://github.com/SUSE/avant-garde/issues/15


## What does this PR do?

It deploys two PSP policies (taken from v3). One is allowing everything and the other one is blocking everything.

## Anything else a reviewer needs to know?

#### Possible documentation:

```
suse.caasp.psp.privileged: the privileged PodSecurityPolicy is intended to be given only to trusted workloads. It provides for as few restrictions as possible and should only be assigned to highly trusted users.

suse.caasp.psp.unprivileged: the unprivileged PodSecurityPolicy is intended to be a reasonable compromise between the reality of Kubernetes workloads. By default, we'll grant this PSP to all users and service accounts.
```

#### Possible Testing:

###### Test for the psp folder locally:
```
~/go/bin/caaspctl cluster init --control-plane 10.86.3.179 my-cluster
$ ls -l my-cluster/addons/psp/
total 8
-rw-r--r-- 1 tux users 1654 Apr  9 12:23 podsecuritypolicy-privileged.yaml
-rw-r--r-- 1 tux users 2000 Apr  9 12:23 podsecuritypolicy-unprivileged.yaml
```

###### Test that it uploads the files:
```
~/go/bin/caaspctl node bootstrap --user sles --sudo --target 10.86.1.46 master-one
[. . . ]
states.go:33] === applying state psp.deploy === 
deployments.go:50] uploading local file "addons/psp/podsecuritypolicy-privileged.yaml" to remote file "/tmp/psp.d/podsecuritypolicy-privileged.yaml"
files.go:29] uploading to remote file "/tmp/psp.d/podsecuritypolicy-privileged.yaml" with contents
deployments.go:50] uploading local file "addons/psp/podsecuritypolicy-unprivileged.yaml" to remote file "/tmp/psp.d/podsecuritypolicy-unprivileged.yaml"
files.go:29] uploading to remote file "/tmp/psp.d/podsecuritypolicy-unprivileged.yaml" with contents
ssh.go:102] running command: "sudo sh -c 'kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/psp.d'"
ssh.go:125] stdout | podsecuritypolicy.extensions/suse.caasp.psp.privileged created
ssh.go:125] stdout | clusterrole.rbac.authorization.k8s.io/suse:caasp:psp:privileged created
ssh.go:125] stdout | podsecuritypolicy.extensions/suse.caasp.psp.unprivileged created
ssh.go:125] stdout | clusterrole.rbac.authorization.k8s.io/suse:caasp:psp:unprivileged created
ssh.go:102] running command: "sudo sh -c 'rm -rf /tmp/psp.d'"
states.go:38] === state psp.deploy applied successfully ===
[. . .]
```

###### Check if they are deployed on the k8s cluster:
```
$ kubectl get psp
NAME                          PRIV    CAPS   SELINUX    RUNASUSER   FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
suse.caasp.psp.privileged     true    *      RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            configMap,secret,emptyDir,downwardAPI,projected,persistentVolumeClaim,hostPath,nfs,rbd,cephFS,glusterfs,fc,iscsi,cinder,gcePersistentDisk,awsElasticBlockStore,azureDisk,azureFile,vsphereVolume
suse.caasp.psp.unprivileged   false          RunAsAny   RunAsAny    RunAsAny   RunAsAny   false            configMap,secret,emptyDir,downwardAPI,projected,persistentVolumeClaim,nfs,rbd,cephFS,glusterfs,fc,iscsi,cinder,gcePersistentDisk,awsElasticBlockStore,azureDisk,azureFile,vsphereVolume
```

