### PR TITLE
ci/infra/libvirt: fixed settings on cri-o

### DIFF
--- a/ci/infra/libvirt/README.md
+++ b/ci/infra/libvirt/README.md
@@ -39,6 +39,16 @@ The worker nodes will be named `ag-worker-{N}.ag-test.net` and will always have 
 
 All the nodes can ping each other and can resolve their FQDN.
 
+## Further customization with cloud-init
+
+There are two cloud-init files inside of the `cloud-init` directory that you can
+use to further customize your image: master.cfg.tpl and worker.cfg.tpl. These
+two files will automatically set some of the variables defined in your
+`terraform.tfvars` file (e.g. `packages` or `repositories`).
+
+Moreover, in some repository distributions the CRI-O package will require to run
+on top of BTRFS. If this is not the case for your images, you can uncomment a
+`runcmd` instruction that disables just that in the CRI-O configuration.
 
 # PRO-tip
 

--- a/ci/infra/libvirt/cloud-init/master.cfg.tpl
+++ b/ci/infra/libvirt/cloud-init/master.cfg.tpl
@@ -38,6 +38,7 @@ packages:
   - kubernetes-kubelet
   - kubernetes-client
   - cri-o
+  - cri-tools
   - cni-plugins
   - "-docker"
   - "-containerd"
@@ -47,5 +48,11 @@ ${packages}
 
 bootcmd:
   - ip link set dev eth0 mtu 1400
+
+# NOTE: Uncomment the following code if the CRI-O that you are using is
+# expecting to be working on top of BTRFS. This may happen in packages from
+# repositories which haven't fixed this issue.
+#runcmd:
+  #- /usr/bin/sed -i -e 's/btrfs/overlay2/g' /etc/crio/crio.conf
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/libvirt/cloud-init/worker.cfg.tpl
+++ b/ci/infra/libvirt/cloud-init/worker.cfg.tpl
@@ -37,6 +37,7 @@ packages:
   - kubernetes-kubelet
   - kubernetes-client
   - cri-o
+  - cri-tools
   - cni-plugins
   - "-docker"
   - "-containerd"
@@ -46,5 +47,11 @@ ${packages}
 
 bootcmd:
   - ip link set dev eth0 mtu 1400
+
+# NOTE: Uncomment the following code if the CRI-O that you are using is
+# expecting to be working on top of BTRFS. This may happen in packages from
+# repositories which haven't fixed this issue.
+#runcmd:
+  #- /usr/bin/sed -i -e 's/btrfs/overlay2/g' /etc/crio/crio.conf
 
 final_message: "The system is finally up, after $UPTIME seconds"


### PR DESCRIPTION
- Install cri-tools, as it's done in other backends.
- Make sure that crio.conf doesn't force the filesystem to be BTRFS (which is
  not the case in our qcow2 images).

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>