### PR TITLE
caaspctl: make sure vxlan module is loaded

### DIFF
--- a/internal/pkg/caaspctl/deployments/ssh/kernel.go
+++ b/internal/pkg/caaspctl/deployments/ssh/kernel.go
@@ -24,6 +24,7 @@ import (
 var (
 	modules = []string{
 		"br_netfilter",
+		"vxlan",
 	}
 
 	parameters = map[string]struct {


### PR DESCRIPTION

## Why is this PR needed?

Vxlan kernel module is needed for cilium to work.
This should make sure vxlan module is/(can be) loaded. 
