### PR TITLE
switch to a different base image

### DIFF
--- a/ci/infra/openstack/terraform.tfvars.sles.example
+++ b/ci/infra/openstack/terraform.tfvars.sles.example
@@ -8,7 +8,7 @@ stack_name = "testing"
 username = "sles"
 
 # define which image to use
-image_name = "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-RC1"
+image_name = "SLES15-SP1-JeOS-RC1-with-fixed-kernel-default"
 
 # define the repositories to use
 repositories = [

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -728,7 +728,7 @@ def generate_tfvars_file():
 internal_net = "{job_name}"
 stack_name = "{job_name}"
 
-image_name = "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-RC1"
+image_name = "SLES15-SP1-JeOS-RC1-with-fixed-kernel-default"
 
 repositories = [
   {{


### PR DESCRIPTION
bsc#1132083. This image is built using the kernel-default package

Signed-off-by: Maximilian Meister <mmeister@suse.de>

## Why is this PR needed?

currently the vxlan module needs to be present, but is not in the old image

## What does this PR do?

switch to another temporary image that has the module

