### PR TITLE
cilium: create cilium service account before daemonset

### DIFF
--- a/pkg/caaspctl/actions/cluster/init/manifests.go
+++ b/pkg/caaspctl/actions/cluster/init/manifests.go
@@ -56,6 +56,12 @@ discovery:
 `
 
 	ciliumManifest = `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium
+  namespace: kube-system
+---
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:
@@ -224,12 +230,6 @@ spec:
       - key: node.kubernetes.io/not-ready
         operator: Exists
         effect: NoSchedule
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cilium
-  namespace: kube-system
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Why is this PR needed?
cilium daemonset and rbad depends on cilium service account
which might cause issue with PSP
```
cni$ kcs describe ds cilium|grep Error
  Warning  FailedCreate      9m36s (x7 over 9m36s)  daemonset-controller
  Error creating: pods "cilium-" is forbidden: error looking up service
  account kube-system/cilium: serviceaccount "cilium" not found
cni$ kcs get serviceaccount
  cilium
  NAME     SECRETS   AGE
  cilium   1         10m
```