### PR TITLE
Add way to get external IP from Jenkins workers

### DIFF
--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -160,9 +160,9 @@ def info():
         r.raise_for_status()
     except (requests.HTTPError, requests.Timeout) as err:
         print(err)
-        print('Meta Data service unavailable could not get external IP')
+        print('Meta Data service unavailable could not get external IP addr')
     else:
-        print('External IP: {}'.format(r.text))
+        print('External IP addr: {}'.format(r.text))
 
 
 @timeout(125)


### PR DESCRIPTION
## Why is this PR needed?
The Jenkins workers on OpenStack don't report their external IP in the logs.

Fixes #
Uses the meta data service (if available) to get the external IP

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->