### PR TITLE
Fix typo in cilium output (annonated -> annotated)

### DIFF
--- a/internal/pkg/caaspctl/cni/cilium.go
+++ b/internal/pkg/caaspctl/cni/cilium.go
@@ -121,7 +121,7 @@ func AnnotateCiliumDaemonsetWithCurrentTimestamp() error {
 		return err
 	}
 
-	klog.Info("successfully annonated cilium daemonset with current timestamp, which will restart all cilium pods")
+	klog.Info("successfully annotated cilium daemonset with current timestamp, which will restart all cilium pods")
 	return nil
 }
 


### PR DESCRIPTION
## Why is this PR needed?

Fix typo in cilium output (annonated -> annotated)