### PR TITLE
Fix output on libvirt provider

### DIFF
--- a/ci/infra/libvirt/cluster.tf
+++ b/ci/infra/libvirt/cluster.tf
@@ -94,7 +94,7 @@ resource "libvirt_domain" "lb" {
 }
 
 output "ip_lb" {
-  value = "${libvirt_domain.lb.network_interface.0.addresses[0]}"
+  value = "${libvirt_domain.lb.network_interface.0.addresses.0}"
 }
 
 #####################
@@ -179,7 +179,7 @@ resource "libvirt_domain" "master" {
 }
 
 output "masters" {
-  value = ["${libvirt_domain.master.*.network_interface.0.addresses[0]}"]
+  value = ["${libvirt_domain.master.*.network_interface.0.addresses.0}"]
 }
 
 ####################
@@ -254,5 +254,5 @@ resource "libvirt_domain" "worker" {
 }
 
 output "workers" {
-  value = ["${libvirt_domain.worker.*.network_interface.0.addresses[0]}"]
+  value = ["${libvirt_domain.worker.*.network_interface.0.addresses.0}"]
 }


### PR DESCRIPTION
Creating cluster with `multiple workers & masters` shows `only first ip in output`.
Output in example was produced what creating 3 master & 2 worker cluster.

Current terraform output:
```yaml
ip_lb = 10.17.1.0
masters = [
    10.17.2.0
]
workers = [
    10.17.3.0
]
```

Expected terraform output:
```yaml
ip_lb = 10.17.1.0
masters = [
    10.17.2.0,
    10.17.2.1,
    10.17.2.2
]
workers = [
    10.17.3.0,
    10.17.3.1
]
```