### PR TITLE
cilium: Use cilium-init and cilium-operator

### DIFF
--- a/internal/pkg/caaspctl/cni/cilium.go
+++ b/internal/pkg/caaspctl/cni/cilium.go
@@ -54,7 +54,9 @@ type EtcdConfig struct {
 }
 
 type ciliumConfiguration struct {
-	CiliumImage string
+	CiliumImage         string
+	CiliumInitImage     string
+	CiliumOperatorImage string
 }
 
 func renderCiliumTemplate(ciliumConfig ciliumConfiguration, file string) error {
@@ -179,7 +181,15 @@ func CreateOrUpdateCiliumConfigMap() error {
 func FillCiliumManifestFile(target, file string) error {
 	ciliumImage := images.GetGenericImage(caaspctl.ImageRepository, "cilium",
 		kubernetes.CurrentAddonVersion(kubernetes.Cilium))
-	ciliumConfig := ciliumConfiguration{CiliumImage: ciliumImage}
+	ciliumInitImage := images.GetGenericImage(caaspctl.ImageRepository, "cilium-init",
+		kubernetes.CurrentAddonVersion(kubernetes.Cilium))
+	ciliumOperatorImage := images.GetGenericImage(caaspctl.ImageRepository, "cilium-operator",
+		kubernetes.CurrentAddonVersion(kubernetes.Cilium))
+	ciliumConfig := ciliumConfiguration{
+		CiliumImage:         ciliumImage,
+		CiliumInitImage:     ciliumInitImage,
+		CiliumOperatorImage: ciliumOperatorImage,
+	}
 
 	return renderCiliumTemplate(ciliumConfig, filepath.Join("addons", "cni", "cilium.yaml"))
 }


### PR DESCRIPTION
Cilium since version 1.4 ships two additional components:

- init container (which runs a script)
- Kubernetes operator

Both of them take care of cleaning up the state and objects (in
Kubernetes API and BPFFS) which Cilium creates. Init container does the
initial cleanup and operator does the garbage collection.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>