### PR TITLE
Warn when removing the last master node

### DIFF
--- a/internal/app/caaspctl/node/remove.go
+++ b/internal/app/caaspctl/node/remove.go
@@ -23,15 +23,20 @@ import (
 	node "github.com/SUSE/caaspctl/pkg/caaspctl/actions/node/remove"
 )
 
+type removeOptions struct {
+	isForced bool
+}
+
 func NewRemoveCmd() *cobra.Command {
+	removeOptions := removeOptions{}
 	cmd := &cobra.Command{
 		Use:   "remove <node-name>",
 		Short: "Removes a node from the cluster",
 		Run: func(cmd *cobra.Command, nodenames []string) {
-			node.Remove(nodenames[0])
+			node.Remove(nodenames[0], removeOptions.isForced)
 		},
 		Args: cobra.ExactArgs(1),
 	}
-
+	cmd.Flags().BoolVarP(&removeOptions.isForced, "force", "f", false, "Remove the node without prompting for confirmation.")
 	return cmd
 }


### PR DESCRIPTION
## Why is this PR needed?

Removing the last master node will keep worker node in unknown state. 
It is a responsible choice to want user about that

## What does this PR do?
- 1 Ask for confirmation when removing last master 
- 2 Add new option to override that confirmation prompt.