### PR TITLE
cilium: Fix yaml tag

### DIFF
--- a/internal/pkg/caaspctl/cni/cilium.go
+++ b/internal/pkg/caaspctl/cni/cilium.go
@@ -47,7 +47,7 @@ var (
 )
 
 type EtcdConfig struct {
-	Endpoints []string `yaml:"endpoints,inline`
+	Endpoints []string `yaml:"endpoints"`
 	CAFile    string   `yaml:"ca-file"`
 	CertFile  string   `yaml:"cert-file"`
 	KeyFile   string   `yaml:"key-file"`


### PR DESCRIPTION
Add missing quote in the "endpoints" yaml tag
also remove inline tag which only accepts struct or map