### PR TITLE
Use filepath.Join instead of path.Join for better consistency

### DIFF
--- a/internal/pkg/caaspctl/deployments/ssh/cni.go
+++ b/internal/pkg/caaspctl/deployments/ssh/cni.go
@@ -19,7 +19,7 @@ package ssh
 
 import (
 	"io/ioutil"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -55,7 +55,7 @@ func cniDeploy(t *Target, data interface{}) error {
 	defer t.ssh("rm -rf /tmp/cni.d")
 
 	for _, f := range cniFiles {
-		if err := t.target.UploadFile(path.Join(caaspctl.CniDir(), f.Name()), path.Join("/tmp/cni.d", f.Name())); err != nil {
+		if err := t.target.UploadFile(filepath.Join(caaspctl.CniDir(), f.Name()), filepath.Join("/tmp/cni.d", f.Name())); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/caaspctl/deployments/ssh/kubernetes.go
+++ b/internal/pkg/caaspctl/deployments/ssh/kubernetes.go
@@ -18,7 +18,7 @@
 package ssh
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/SUSE/caaspctl/internal/pkg/caaspctl/deployments"
 )
@@ -38,7 +38,7 @@ func init() {
 func kubernetesUploadSecrets(errorHandling KubernetesUploadSecretsErrorBehavior) Runner {
 	return func(t *Target, data interface{}) error {
 		for _, file := range deployments.Secrets {
-			if err := t.target.UploadFile(file, path.Join("/etc/kubernetes", file)); err != nil {
+			if err := t.target.UploadFile(file, filepath.Join("/etc/kubernetes", file)); err != nil {
 				if errorHandling == KubernetesUploadSecretsFailOnError {
 					return err
 				}

--- a/internal/pkg/caaspctl/deployments/ssh/psp.go
+++ b/internal/pkg/caaspctl/deployments/ssh/psp.go
@@ -19,7 +19,7 @@ package ssh
 
 import (
 	"io/ioutil"
-	"path"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 
@@ -39,7 +39,7 @@ func pspDeploy(t *Target, data interface{}) error {
 	defer t.ssh("rm -rf /tmp/psp.d")
 
 	for _, f := range pspFiles {
-		if err := t.target.UploadFile(path.Join(caaspctl.PspDir(), f.Name()), path.Join("/tmp/psp.d", f.Name())); err != nil {
+		if err := t.target.UploadFile(filepath.Join(caaspctl.PspDir(), f.Name()), filepath.Join("/tmp/psp.d", f.Name())); err != nil {
 			return err
 		}
 	}

--- a/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
+++ b/pkg/caaspctl/actions/node/bootstrap/bootstrap.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"
@@ -97,11 +97,11 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 }
 
 func downloadSecrets(target *deployments.Target) error {
-	os.MkdirAll(path.Join("pki", "etcd"), 0700)
+	os.MkdirAll(filepath.Join("pki", "etcd"), 0700)
 
 	fmt.Printf("[bootstrap] downloading secrets from bootstrapped node %q\n", target.Target)
 	for _, secretLocation := range deployments.Secrets {
-		secretData, err := target.DownloadFileContents(path.Join("/etc/kubernetes", secretLocation))
+		secretData, err := target.DownloadFileContents(filepath.Join("/etc/kubernetes", secretLocation))
 		if err != nil {
 			return err
 		}

--- a/pkg/caaspctl/constants.go
+++ b/pkg/caaspctl/constants.go
@@ -19,7 +19,7 @@ package caaspctl
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 
 	"github.com/SUSE/caaspctl/internal/pkg/caaspctl/deployments"
 )
@@ -38,15 +38,15 @@ func JoinConfDir() string {
 }
 
 func MasterConfTemplateFile() string {
-	return path.Join(JoinConfDir(), "master.conf.template")
+	return filepath.Join(JoinConfDir(), "master.conf.template")
 }
 
 func WorkerConfTemplateFile() string {
-	return path.Join(JoinConfDir(), "worker.conf.template")
+	return filepath.Join(JoinConfDir(), "worker.conf.template")
 }
 
 func MachineConfFile(target string) string {
-	return path.Join(JoinConfDir(), fmt.Sprintf("%s.conf", target))
+	return filepath.Join(JoinConfDir(), fmt.Sprintf("%s.conf", target))
 }
 
 func TemplatePathForRole(role deployments.Role) string {
@@ -64,23 +64,23 @@ func AddonsDir() string {
 }
 
 func CniDir() string {
-	return path.Join(AddonsDir(), "cni")
+	return filepath.Join(AddonsDir(), "cni")
 }
 
 func CiliumManifestFile() string {
-	return path.Join(CniDir(), "cilium.yaml")
+	return filepath.Join(CniDir(), "cilium.yaml")
 }
 
 func PspDir() string {
-	return path.Join(AddonsDir(), "psp")
+	return filepath.Join(AddonsDir(), "psp")
 }
 
 func PspUnprivManifestFile() string {
-	return path.Join(PspDir(), "podsecuritypolicy-unprivileged.yaml")
+	return filepath.Join(PspDir(), "podsecuritypolicy-unprivileged.yaml")
 }
 
 func PspPrivManifestFile() string {
-	return path.Join(PspDir(), "podsecuritypolicy-privileged.yaml")
+	return filepath.Join(PspDir(), "podsecuritypolicy-privileged.yaml")
 }
 
 func KubeConfigAdminFile() string {


### PR DESCRIPTION
## Why is this PR needed?

This PR is to unify file path handling in caaspctl. We should just stick to filepath.Join() 