### PR TITLE
[openstack] Add health-monitor to load-balancer

### DIFF
--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -32,3 +32,13 @@ resource "openstack_networking_floatingip_v2" "lb_ext" {
   pool  = "${var.external_net}"
   port_id = "${openstack_lb_loadbalancer_v2.lb.vip_port_id}"
 }
+
+resource "openstack_lb_monitor_v2" "monitor" {
+  pool_id        = "${openstack_lb_pool_v2.pool.id}"
+  type           = "HTTPS"
+  url_path       = "/healthz"
+  expected_codes = 200
+  delay          = 10
+  timeout        = 5
+  max_retries    = 3
+}


### PR DESCRIPTION
## Why is this PR needed?

There is currently no monitor on the instances which
results in the nodes to be always seen as online in
the load-balancer pool even if the apiserver is not running.
A consequence of that is that traffic can be directed to
a node which is not able to ensure the service as it should.

## What does this PR do?

The monitor will perform an HTTPS check on $MASTER:6443/healthz
an expect a 200 code. If the apiserver is not running on the master,
the node will be mark as offline so no traffic will be redirected to it.

Signed-off-by: lcavajani <lcavajani@suse.com>