### PR TITLE
Add build type to version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GOBINPATH    := $(shell $(GO) env GOPATH)/bin
 VERSION      := $(shell cat VERSION)
 COMMIT       := $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE   := $(shell date +%Y%m%d-%H:%M:%S)
-TAGS         := devel
+TAGS         := development
 CAASPCTL_LDFLAGS = -ldflags "-X=github.com/SUSE/caaspctl/internal/app/caaspctl.Version=$(VERSION) \
                              -X=github.com/SUSE/caaspctl/internal/app/caaspctl.Commit=$(COMMIT) \
                              -X=github.com/SUSE/caaspctl/internal/app/caaspctl.BuildDate=$(BUILD_DATE)"
@@ -35,7 +35,7 @@ install: build
 
 .PHONY: staging
 staging:
-	 make TAGS=staging install
+	make TAGS=staging install
 
 .PHONY: release
 release:

--- a/internal/app/caaspctl/version.go
+++ b/internal/app/caaspctl/version.go
@@ -23,6 +23,8 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+
+	"github.com/SUSE/caaspctl/pkg/caaspctl"
 )
 
 var (
@@ -36,7 +38,7 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(os.Stderr, "caaspctl version: %s %s %s %s\n", Version, Commit, BuildDate, runtime.Version())
+			fmt.Fprintf(os.Stderr, "caaspctl version: %s (%s) %s %s %s\n", Version, caaspctl.BuildType, Commit, BuildDate, runtime.Version())
 		},
 	}
 }

--- a/pkg/caaspctl/development_constants.go
+++ b/pkg/caaspctl/development_constants.go
@@ -20,5 +20,6 @@
 package caaspctl
 
 const (
+	BuildType       = "development"
 	ImageRepository = "registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4"
 )

--- a/pkg/caaspctl/release_constants.go
+++ b/pkg/caaspctl/release_constants.go
@@ -20,5 +20,6 @@
 package caaspctl
 
 const (
+	BuildType       = "release"
 	ImageRepository = "registry.suse.com/caasp/v4"
 )

--- a/pkg/caaspctl/staging_constants.go
+++ b/pkg/caaspctl/staging_constants.go
@@ -20,5 +20,6 @@
 package caaspctl
 
 const (
+	BuildType       = "staging"
 	ImageRepository = "registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4"
 )


### PR DESCRIPTION
## Why is this PR needed?

Since each build type points to different registries, along with the
version of caaspctl is important to also print the build type of the
binary used to deploy a cluster. This helps in debugging, so we know
what exact registry was used (and potentially other build type
dependant settings in the future) by the user.

This is required to univocally determine the exact conditions when
debugging a problem in a given system.