### PR TITLE
Use caaspctl tooling image for node removal

### DIFF
--- a/images/tooling/Dockerfile
+++ b/images/tooling/Dockerfile
@@ -1,4 +1,0 @@
-FROM opensuse/leap
-
-RUN zypper ref
-RUN zypper -n in dbus-1

--- a/images/tooling/Makefile
+++ b/images/tooling/Makefile
@@ -1,2 +1,0 @@
-all:
-	docker build -t ereslibre/opensuse-tooling .

--- a/internal/pkg/caaspctl/cni/cilium.go
+++ b/internal/pkg/caaspctl/cni/cilium.go
@@ -165,7 +165,7 @@ func CreateOrUpdateCiliumConfigMap() error {
 
 func FillCiliumManifestFile(target, file string) error {
 	ciliumImage := images.GetGenericImage(caaspctl.ImageRepository, "cilium",
-		kubernetes.CurrentComponentVersion(kubernetes.Cilium))
+		kubernetes.CurrentAddonVersion(kubernetes.Cilium))
 	ciliumConfig := ciliumConfiguration{CiliumImage: ciliumImage}
 
 	return renderCiliumTemplate(ciliumConfig, filepath.Join("addons", "cni", "cilium.yaml"))

--- a/internal/pkg/caaspctl/kubernetes/kubelet.go
+++ b/internal/pkg/caaspctl/kubernetes/kubelet.go
@@ -23,6 +23,9 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+
+	"github.com/SUSE/caaspctl/pkg/caaspctl"
 )
 
 func DisarmKubelet(node *v1.Node) error {
@@ -43,9 +46,8 @@ func disarmKubeletJobSpec(node *v1.Node) batchv1.JobSpec {
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
-						Name: disarmKubeletJobName(node),
-						// This can be simplified to use `go-systemd` or `godbus` and embedding this calling logic in a possible separate smally containerized binary
-						Image: "ereslibre/opensuse-tooling:latest",
+						Name:  disarmKubeletJobName(node),
+						Image: images.GetGenericImage(caaspctl.ImageRepository, "caaspctl-tooling", CurrentAddonVersion(Tooling)),
 						Command: []string{
 							"/bin/bash", "-c",
 							strings.Join(

--- a/internal/pkg/caaspctl/kubernetes/versions.go
+++ b/internal/pkg/caaspctl/kubernetes/versions.go
@@ -21,29 +21,37 @@ import (
 	"log"
 )
 
+type Addon string
 type Component string
 
 const (
+	Cilium  Addon = "cilium"
+	Tooling Addon = "tooling"
+
 	Etcd    Component = "etcd"
 	CoreDNS Component = "coredns"
 	Pause   Component = "pause"
-	Cilium  Component = "cilium"
 )
 
 type ControlPlaneComponentsVersion struct {
 	EtcdVersion    string
 	CoreDNSVersion string
 	PauseVersion   string
-	CiliumVersion  string
 }
 
 type ComponentsVersion struct {
 	KubeletVersion string
 }
 
+type AddonsVersion struct {
+	CiliumVersion  string
+	ToolingVersion string
+}
+
 type KubernetesVersion struct {
 	ControlPlaneComponentsVersion ControlPlaneComponentsVersion
 	ComponentsVersion             ComponentsVersion
+	AddonsVersion                 AddonsVersion
 }
 
 const (
@@ -57,10 +65,13 @@ var (
 				EtcdVersion:    "3.3.11",
 				CoreDNSVersion: "1.2.6",
 				PauseVersion:   "3.1",
-				CiliumVersion:  "1.4.2",
 			},
 			ComponentsVersion: ComponentsVersion{
 				KubeletVersion: "1.14.0",
+			},
+			AddonsVersion: AddonsVersion{
+				CiliumVersion:  "1.4.2",
+				ToolingVersion: "0.1.0",
 			},
 		},
 	}
@@ -75,9 +86,19 @@ func CurrentComponentVersion(component Component) string {
 		return currentKubernetesVersion.ControlPlaneComponentsVersion.CoreDNSVersion
 	case Pause:
 		return currentKubernetesVersion.ControlPlaneComponentsVersion.PauseVersion
-	case Cilium:
-		return currentKubernetesVersion.ControlPlaneComponentsVersion.CiliumVersion
 	}
 	log.Fatalf("unknown component %q", component)
+	panic("unreachable")
+}
+
+func CurrentAddonVersion(addon Addon) string {
+	currentKubernetesVersion := Versions[CurrentVersion]
+	switch addon {
+	case Tooling:
+		return currentKubernetesVersion.AddonsVersion.ToolingVersion
+	case Cilium:
+		return currentKubernetesVersion.AddonsVersion.CiliumVersion
+	}
+	log.Fatalf("unknown addon %q", addon)
 	panic("unreachable")
 }


### PR DESCRIPTION
## Why is this PR needed?

Instead of using an external tooling image when performing node removal
use one that will be in our registries and that will depend on the build
type of caaspctl.

Since this change included creating an Addons concept in the image
versioning logic, refactor it to also include Cilium as well, since it's
more an addon than a control plane component.

Fixes https://github.com/SUSE/avant-garde/issues/143