### PR TITLE
reset: Make target a required flag

### DIFF
--- a/docs/man/caaspctl-node-reset.1.md
+++ b/docs/man/caaspctl-node-reset.1.md
@@ -19,7 +19,7 @@ to the state prior to join or bootstrap being run.
   Print usage statement.
 
 **--target, -t**
-  IP or host name of the node to connect to using SSH
+  (required) IP or host name of the node to connect to using SSH
 
 **--user, -u**
   User identity used to connect to target (default=root)

--- a/internal/app/caaspctl/node/reset.go
+++ b/internal/app/caaspctl/node/reset.go
@@ -24,16 +24,16 @@ func NewResetCmd() *cobra.Command {
 	resetOptions := resetOptions{}
 
 	cmd := cobra.Command{
-		Use:   "reset <node-name>",
+		Use:   "reset",
 		Short: "Resets the node to it's state prior to running join or bootstrap",
-		Run: func(cmd *cobra.Command, nodenames []string) {
+		Run: func(cmd *cobra.Command, args []string) {
 			resetConfiguration := deployments.ResetConfiguration{
 				KubeadmExtraArgs: map[string]string{"ignore-preflight-errors": resetOptions.ignorePreflightErrors},
 			}
 
 			err := node.Reset(resetConfiguration,
 				ssh.NewTarget(
-					nodenames[0],
+					"",
 					resetOptions.target,
 					resetOptions.user,
 					resetOptions.sudo,
@@ -48,6 +48,7 @@ func NewResetCmd() *cobra.Command {
 			fmt.Println("successfully reset node to state prior to running bootstrap or join")
 
 		},
+		Args: cobra.NoArgs,
 	}
 
 	cmd.Flags().StringVarP(&resetOptions.target, "target", "t", "", "IP or FQDN of the node to connect to using SSH")
@@ -55,6 +56,7 @@ func NewResetCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&resetOptions.sudo, "sudo", "s", false, "Run remote command via sudo")
 	cmd.Flags().IntVarP(&resetOptions.port, "port", "p", 22, "Port to connect to using SSH")
 	cmd.Flags().StringVar(&resetOptions.ignorePreflightErrors, "ignore-preflight-errors", "", "Comma separated list of preflight errors to ignore")
+	cmd.MarkFlagRequired("target")
 
 	return &cmd
 }


### PR DESCRIPTION
reset operation operation happens through
ssh which require target. Without target flag
reset operation will happen on the host(":22")
caaspctl runs.

This PR also passes empty string as node name in
ssh.NewTarget as nodename is not require. It would need
extra logic to verify nodename with target.

Fixes: #156

Signed-off-by: Nirmoy Das <ndas@suse.de>