### PR TITLE
updated logging to use v flag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1053,6 +1053,7 @@
     "github.com/go-yaml/yaml",
     "github.com/pkg/errors",
     "github.com/spf13/cobra",
+    "github.com/spf13/pflag",
     "golang.org/x/crypto/ssh",
     "golang.org/x/crypto/ssh/agent",
     "k8s.io/api/batch/v1",

--- a/cmd/caaspctl/caaspctl.go
+++ b/cmd/caaspctl/caaspctl.go
@@ -18,6 +18,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/SUSE/caaspctl/internal/app/caaspctl"
 )
@@ -41,6 +43,8 @@ func newRootCmd() *cobra.Command {
 		caaspctl.NewNodeCmd(),
 	)
 
+	register(cmd.PersistentFlags(), "v")
+
 	return cmd
 }
 
@@ -50,5 +54,15 @@ func main() {
 	cmd := newRootCmd()
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
+	}
+}
+
+// register adds a flag to local that targets the Value associated with the Flag named globalName in flag.CommandLine.
+func register(local *pflag.FlagSet, globalName string) {
+	if f := flag.CommandLine.Lookup(globalName); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		local.AddFlag(pflagFlag)
+	} else {
+		klog.Fatalf("failed to find flag in global flagset (flag): %s", globalName)
 	}
 }

--- a/docs/man/caaspctl-node-reset.1.md
+++ b/docs/man/caaspctl-node-reset.1.md
@@ -7,7 +7,7 @@ reset - Reset a node to a state prior to join or bootstrap
 **reset**
 [**--help**|**-h**] [**--target**|**-t**] [**--user**|**-u**]
 [**--sudo**|**-s**] [**--port**|**-p**] [**--ignore-preflight-errors**]
-*reset* *-t <fqdn>* [-hsp] [-u user] [-p port]
+*reset* *-t <fqdn>* [-hsp] [-u user] [-p port] [-v level]
 
 # DESCRIPTION
 **reset** is a command that enables you to reset a node 
@@ -17,6 +17,9 @@ to the state prior to join or bootstrap being run.
 
 **--help, -h**
   Print usage statement.
+
+**-v**
+  set verbosity level.
 
 **--target, -t**
   (required) IP or host name of the node to connect to using SSH

--- a/docs/man/caaspctl.1.md
+++ b/docs/man/caaspctl.1.md
@@ -4,7 +4,7 @@ caaspctl - tool to manage the full lifecycle of a Kubernetes cluster
 
 # SYNOPSIS
 **caaspctl**
-[**--help**|**-h**]
+[**--help**|**-h**] [**-v**]
 *command* [*args*]
 
 # DESCRIPTION
@@ -15,6 +15,9 @@ reconfiguration in an easy way.
 
 **--help, -h**
   Print usage statement.
+
+**-v**
+  set verbosity level.
 
 # COMMANDS
 

--- a/internal/pkg/caaspctl/cni/cilium.go
+++ b/internal/pkg/caaspctl/cni/cilium.go
@@ -123,7 +123,7 @@ func AnnotateCiliumDaemonsetWithCurrentTimestamp() error {
 		return err
 	}
 
-	klog.Info("successfully annotated cilium daemonset with current timestamp, which will restart all cilium pods")
+	klog.V(1).Info("successfully annotated cilium daemonset with current timestamp, which will restart all cilium pods")
 	return nil
 }
 

--- a/internal/pkg/caaspctl/deployments/deployments.go
+++ b/internal/pkg/caaspctl/deployments/deployments.go
@@ -47,7 +47,7 @@ func (t *Target) Apply(data interface{}, states ...string) error {
 }
 
 func (t *Target) UploadFile(sourcePath, targetPath string) error {
-	klog.Infof("uploading local file %q to remote file %q", sourcePath, targetPath)
+	klog.V(1).Infof("uploading local file %q to remote file %q", sourcePath, targetPath)
 	if contents, err := ioutil.ReadFile(sourcePath); err == nil {
 		return t.UploadFileContents(targetPath, string(contents))
 	}

--- a/internal/pkg/caaspctl/deployments/ssh/files.go
+++ b/internal/pkg/caaspctl/deployments/ssh/files.go
@@ -26,7 +26,7 @@ import (
 )
 
 func (t *Target) UploadFileContents(targetPath, contents string) error {
-	klog.Infof("uploading to remote file %q with contents", targetPath)
+	klog.V(1).Infof("uploading to remote file %q with contents", targetPath)
 	dir, _ := path.Split(targetPath)
 	encodedContents := base64.StdEncoding.EncodeToString([]byte(contents))
 	if _, _, err := t.silentSsh("mkdir", "-p", dir); err != nil {
@@ -37,7 +37,7 @@ func (t *Target) UploadFileContents(targetPath, contents string) error {
 }
 
 func (t *Target) DownloadFileContents(sourcePath string) (string, error) {
-	klog.Infof("downloading remote file %q contents", sourcePath)
+	klog.V(1).Infof("downloading remote file %q contents", sourcePath)
 	if stdout, _, err := t.silentSsh("base64", "-w0", sourcePath); err == nil {
 		decodedStdout, err := base64.StdEncoding.DecodeString(stdout)
 		if err != nil {

--- a/internal/pkg/caaspctl/deployments/ssh/ssh.go
+++ b/internal/pkg/caaspctl/deployments/ssh/ssh.go
@@ -104,7 +104,7 @@ func (t *Target) internalSshWithStdin(silent bool, stdin string, command string,
 		finalCommand = fmt.Sprintf("sudo sh -c '%s'", finalCommand)
 	}
 	if !silent {
-		klog.Infof("running command: %q", finalCommand)
+		klog.V(1).Infof("running command: %q", finalCommand)
 	}
 	if err := session.Start(finalCommand); err != nil {
 		return "", "", err
@@ -127,7 +127,7 @@ func readerStreamer(reader io.Reader, outputChan chan<- string, description stri
 	for scanner.Scan() {
 		result.Write([]byte(scanner.Text()))
 		if !silent {
-			klog.Infof("%s | %s\n", description, scanner.Text())
+			klog.V(1).Infof("%s | %s\n", description, scanner.Text())
 		}
 	}
 	outputChan <- result.String()

--- a/internal/pkg/caaspctl/deployments/ssh/states.go
+++ b/internal/pkg/caaspctl/deployments/ssh/states.go
@@ -30,12 +30,12 @@ type Runner func(t *Target, data interface{}) error
 
 func (t *Target) Apply(data interface{}, states ...string) error {
 	for _, stateName := range states {
-		klog.Infof("=== applying state %s ===\n", stateName)
+		klog.V(1).Infof("=== applying state %s ===\n", stateName)
 		if state, stateExists := stateMap[stateName]; stateExists {
 			if err := state(t, data); err != nil {
 				return errors.Wrapf(err, "failed to apply state %s", stateName)
 			} else {
-				klog.Infof("=== state %s applied successfully ===\n", stateName)
+				klog.V(1).Infof("=== state %s applied successfully ===\n", stateName)
 			}
 		} else {
 			klog.Fatalf("state does not exist: %s", stateName)

--- a/internal/pkg/caaspctl/etcd/member.go
+++ b/internal/pkg/caaspctl/etcd/member.go
@@ -36,14 +36,14 @@ func RemoveMember(node *v1.Node) error {
 	}
 
 	// Remove etcd member if target is a master
-	klog.Info("removing etcd member from the etcd cluster")
+	klog.V(1).Info("removing etcd member from the etcd cluster")
 	for _, masterNode := range masterNodes.Items {
-		klog.Infof("trying to remove etcd member from master node %s\n", masterNode.ObjectMeta.Name)
+		klog.V(1).Infof("trying to remove etcd member from master node %s\n", masterNode.ObjectMeta.Name)
 		if err := RemoveMemberFrom(node, &masterNode); err == nil {
-			klog.Infof("etcd member for node %s removed from master node %s\n", node.ObjectMeta.Name, masterNode.ObjectMeta.Name)
+			klog.V(1).Infof("etcd member for node %s removed from master node %s\n", node.ObjectMeta.Name, masterNode.ObjectMeta.Name)
 			break
 		} else {
-			klog.Infof("could not remove etcd member from master node %s\n", masterNode.ObjectMeta.Name)
+			klog.V(1).Infof("could not remove etcd member from master node %s\n", masterNode.ObjectMeta.Name)
 		}
 	}
 

--- a/internal/pkg/caaspctl/kubernetes/jobs.go
+++ b/internal/pkg/caaspctl/kubernetes/jobs.go
@@ -50,13 +50,13 @@ func CreateAndWaitForJob(name string, spec batchv1.JobSpec) error {
 	for i := 0; i < 60; i++ {
 		job, err := GetAdminClientSet().BatchV1().Jobs(metav1.NamespaceSystem).Get(name, metav1.GetOptions{})
 		if err != nil {
-			klog.Infof("failed to get status for job %s, continuing...\n", name)
+			klog.V(1).Infof("failed to get status for job %s, continuing...\n", name)
 		} else {
 			if job.Status.Active > 0 {
-				klog.Infof("job %s is active, waiting...\n", name)
+				klog.V(1).Infof("job %s is active, waiting...\n", name)
 			} else {
 				if job.Status.Succeeded > 0 {
-					klog.Infof("job %s executed successfully\n", name)
+					klog.V(1).Infof("job %s executed successfully\n", name)
 					return nil
 				}
 			}

--- a/internal/pkg/caaspctl/kubernetes/nodes.go
+++ b/internal/pkg/caaspctl/kubernetes/nodes.go
@@ -19,8 +19,9 @@ package kubernetes
 
 import (
 	"fmt"
-	"k8s.io/klog"
 	"os/exec"
+
+	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,10 +48,10 @@ func DrainNode(node *v1.Node) error {
 		"drain", "--delete-local-data=true", "--force=true", "--ignore-daemonsets=true", node.ObjectMeta.Name)
 
 	if err := cmd.Run(); err != nil {
-		klog.Infof("could not drain node %s, aborting (use --force if you want to ignore this error)\n", node.ObjectMeta.Name)
+		klog.V(1).Infof("could not drain node %s, aborting (use --force if you want to ignore this error)\n", node.ObjectMeta.Name)
 		return err
 	} else {
-		klog.Infof("node %s correctly drained\n", node.ObjectMeta.Name)
+		klog.V(1).Infof("node %s correctly drained\n", node.ObjectMeta.Name)
 	}
 
 	return nil


### PR DESCRIPTION
## Why is this PR needed?
Currently logging does not respect a verbosity and will print all log messages.
this change updates that so that a user can pass the v flag to change the 
verbosity of the cli tool. By default Info messages will no longer be printed
to the cli

Fixes #https://github.com/SUSE/avant-garde/issues/190

## What does this PR do?
Updated `klog.Info` to `klog.V(level).Info` to observe the new flag that enabled setting the verbosity level.

## Anything else a reviewer needs to know?
none