### PR TITLE
Added path to cert for Jenkins

### DIFF
--- a/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
     agent { node { label 'caasp-team-private' } }
     environment {
         JENKINS_JOB_CONFIG = credentials('jenkins-job-config')
+        REQUESTS_CA_BUNDLE = "/var/lib/ca-certificates/ca-bundle.pem"
         PARAMS = "openrc=."
     }
     stages {


### PR DESCRIPTION
## Why is this PR needed?

For some reason the requests package that Jenkins Job builder uses doesn't seem to find the cert for Jenkins on our workers. This makes it fail while trying to update the job. This adds a env variable that has the path to the cert bundle needed.