### PR TITLE
Add go vet to makefile as target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ CAASPCTL_LDFLAGS = -ldflags "-X=github.com/SUSE/caaspctl/internal/app/caaspctl.V
                              -X=github.com/SUSE/caaspctl/internal/app/caaspctl.Commit=$(COMMIT) \
                              -X=github.com/SUSE/caaspctl/internal/app/caaspctl.BuildDate=$(BUILD_DATE)"
 
+CAASPCTL_DIRS    = cmd pkg internal test
+
+# go source files, ignore vendor directory
+CAASPCTL_SRCS = $(shell find $(CAASPCTL_DIRS) -type f -name '*.go')
+
 .PHONY: all
 all: install
 
@@ -40,3 +45,7 @@ staging:
 .PHONY: release
 release:
 	make TAGS=release install
+
+.PHONY: vet
+vet:
+	$(GO) tool vet ${CAASPCTL_SRCS}


### PR DESCRIPTION
Enable go vet in makefile.
Exclude vendor directories since they are not always vet compliant

## Why is this PR needed?

Part of govet unit-test enablement/story

## What does this PR do?

Enable go vet for caaspctl codebase

## Anything else a reviewer needs to know?

`make vet` run go vet. there is no need to test this