### PR TITLE
Updated job names to v4 instead of vnext

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -1,5 +1,5 @@
 - project:
-    name: caasp-jobs/caasp-vnext
+    name: caasp-jobs/caasp-v4
     repo-name: caaspctl
     repo-owner: SUSE
     repo-credentials: github-token


### PR DESCRIPTION
## Why is this PR needed?

The job names in Jenkins use vnext instead of v4. 
The old jobs may need to be deleted after this is merged.