### PR TITLE
Add `suse-package` and `suse-changelog` Makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Binary folder
 /bin
+
+# RPM files folder
+ci/packaging/suse/obs_files

--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,11 @@ lint:
 	$(GO) tool vet ${CAASPCTL_SRCS}
 	test -z `$(GOFMT) -l $(CAASPCTL_SRCS)` || { $(GOFMT) -d $(CAASPCTL_SRCS) && false; }
 	$(TERRAFORM) fmt -check=true -write=false -diff=true ci/infra
+
+.PHONY: suse-package
+suse-package:
+	ci/packaging/suse/rpmfiles_maker.sh $(VERSION)
+
+.PHONY: suse-changelog
+suse-changelog:
+	ci/packaging/suse/changelog_maker.sh "$(CHANGES)"

--- a/ci/packaging/suse/caaspctl_spec_template
+++ b/ci/packaging/suse/caaspctl_spec_template
@@ -1,0 +1,87 @@
+#
+# spec file for package caaspctl
+#
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%define go_project github.com/SUSE/caaspctl
+Name:           caaspctl
+Version:        %%VERSION
+Release:        0
+Summary:        CLI tool used to deploy CaaS Platform v4
+License:        Apache-2.0
+Group:          System/Management
+URL:            https://github.com/SUSE/caaspctl
+Source0:        %{name}.tar.gz
+BuildRequires:  go-go-md2man
+BuildRequires:  golang-packaging
+BuildRequires:  golang(API) >= 1.11
+%{go_nostrip}
+%{go_provides}
+
+%description
+caaspctl is a CLI tool that is used to initialize a CaaSP cluster and
+bootstrap/add/remove nodes.
+
+%package -n kubectl-caasp
+Summary:        A caaspctl plugin for kubectl
+Group:          System/Management
+Requires:       caaspctl
+Supplements:    caaspctl
+
+%description -n kubectl-caasp
+kubectl plugin that has the same layout as caaspctl. You can call to
+the same commands presented in caaspctl as kubectl caasp when installing
+the kubectl-caasp binary in your path.
+
+%prep
+%setup -q -n %{name}
+
+%build
+mkdir -pv $HOME/go/src/%{go_project}
+cp -avr * $HOME/go/src/%{go_project}
+cd $HOME/go/src/%{go_project}
+%if %{caasp_build_environment} == "devel"
+echo "Build with devel repos registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4"
+make %{?_smp_mflags}
+%else
+echo "Build with %{caasp_build_environment} repos"
+make %{?_smp_mflags} %{caasp_build_environment}
+%endif
+make %{?_smp_mflags} docs
+
+%install
+cd $HOME/go/bin
+install -D -m 0755 caaspctl %{buildroot}/%{_bindir}/caaspctl
+install -D -m 0755 kubectl-caasp %{buildroot}/%{_bindir}/kubectl-caasp
+
+# Install docs
+for file in $HOME/go/src/%{go_project}/docs/man/*.1; do
+ install -D -m 0644 $file "%{buildroot}/%{_mandir}/man1/$(basename $file)"
+done
+
+%files -n kubectl-caasp
+%{_bindir}/kubectl-caasp
+
+%files
+# Binaries
+%{_bindir}/caaspctl
+# Manpages
+%doc README.md docs/*
+%{_mandir}/man1/caaspctl*
+# License
+%license LICENSE.md
+
+%changelog

--- a/ci/packaging/suse/changelog_maker.sh
+++ b/ci/packaging/suse/changelog_maker.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+dashes="-------------------------------------------------------------------"
+header="${dashes}%n%cd - %an <%ae>"
+datef="%a %b %e %H:%M:%S %Z %Y"
+changes=${1:-caaspctl.changes.append}
+
+[ -f "${changes}" ] && rm "${changes}"
+
+mapfile -t tags < <( git tag --merged | sort -r | head -n2 )
+scope="${tags[1]}..${tags[0]}"
+
+{
+	git show --format="${header}%n%n- Update to ${tags[0]}:" \
+		--date="format-local:${datef}" -s "${tags[0]}^{commit}"
+	git log -s --format="%w(77,2,12)* %h %s" --no-merges "${scope}"
+	# Add empty line
+	echo
+} >> "${changes}"

--- a/ci/packaging/suse/rpmfiles_maker.sh
+++ b/ci/packaging/suse/rpmfiles_maker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+
+mkfile_dir=$(pwd)
+susepkg_dir=$(cd "$( dirname "$0" )" && pwd)
+tmp_dir=$(mktemp -d -t caaspctl_XXXX)
+rpm_files="${susepkg_dir}/obs_files"
+version=$1
+
+log()   { (>&2 echo ">>> $*") ; }
+clean() { log "Cleaning temporary directory ${tmp_dir}"; rm -rf "${tmp_dir}"; }
+
+if [ $# -ne 1 ]; then
+    log "missing caaspctl package version parameter"
+    exit 1
+fi
+
+trap clean ERR
+
+rm -rf "${rpm_files}"
+mkdir -p "${rpm_files}"
+tar --exclude=".*" -caf "${tmp_dir}/caaspctl.tar.gz" \
+    -C "$(dirname "${mkfile_dir}")" caaspctl
+sed -e s"|%%VERSION|${version}|" "${susepkg_dir}/caaspctl_spec_template" \
+    > "${tmp_dir}/caaspctl.spec"
+make CHANGES="${tmp_dir}/caaspctl.changes.append" suse-changelog
+cp "${tmp_dir}"/* "${rpm_files}"
+log "Find files for RPM package in ${rpm_files}"
+clean


### PR DESCRIPTION
## Why is this PR needed?

Related with SUSE/avant-garde#170

## What does this PR do?

This commit adds `package` and `changelog` Makefile targets. Those can be used to create the files required for caaspctl RPM in Open Build Service.

## Anything else a reviewer needs to know?

The current changes file generation causes some doubts since it uses the author email of committers but it appears that committers have been using non SUSE emails. Only commits with tags are relevant to the change log file.

Because of that I added the WIP