### PR TITLE
ci/jenkins: don't clone repo 2 times

### DIFF
--- a/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             sh "cp ${JENKINS_JOB_CONFIG} caaspctl/ci/jenkins/jenkins_jobs.ini"
         } }
         stage('Test Jobs') { steps {
-            dir('caaspctl/ci/jenkins') {
+            dir('ci/jenkins') {
                 sh """
                    source ${WORKSPACE}/venv/bin/activate
                    make test_jobs
@@ -25,7 +25,7 @@ pipeline {
             }
         } }
         stage('Update Jobs') { steps {
-            dir('caaspctl/ci/jenkins') {
+            dir('ci/jenkins') {
                 sh """
                    source ${WORKSPACE}/venv/bin/activate
                    make update_jobs

--- a/ci/jenkins/pipelines/caaspctl-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/caaspctl-nightly.Jenkinsfile
@@ -12,34 +12,29 @@ pipeline {
    }
 
    stages {
-        stage('Git Clone') { steps {
-            sh "rm ${WORKSPACE}/* -rf"
-            sh "git clone https://${GITHUB_TOKEN}@github.com/SUSE/caaspctl"
-        } }
-
         stage('Getting Ready For Cluster Deployment') { steps {
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=info ${PARAMS}"
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=github_collaborator_check ${PARAMS}"
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=initial_cleanup ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=info ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=github_collaborator_check ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=initial_cleanup ${PARAMS}"
         } }
 
         stage('Cluster Deployment') { steps {
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=create_environment ${PARAMS}"
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=configure_environment ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=create_environment ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=configure_environment ${PARAMS}"
         } }
 
         stage('Bootstrap Cluster') { steps {
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=bootstrap_environment ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=bootstrap_environment ${PARAMS}"
         } }
 
         stage('Add Nodes in Cluster') { steps {
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=grow_environment ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=grow_environment ${PARAMS}"
         } }
    }
    post {
         always {
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=gather_logs ${PARAMS}"
-            sh "caaspctl/ci/infra/testrunner/testrunner stage=final_cleanup ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=gather_logs ${PARAMS}"
+            sh "ci/infra/testrunner/testrunner stage=final_cleanup ${PARAMS}"
             cleanWs()
         }
     }

--- a/ci/jenkins/pipelines/prs/caaspctl-code-lint.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/caaspctl-code-lint.Jenkinsfile
@@ -12,20 +12,6 @@ pipeline {
     }
 
     stages {
-        stage('Git Clone') { steps {
-            checkout([$class: 'GitSCM',
-                      branches: [[name: "*/pr/${CHANGE_ID}"], [name: '*/master']],
-                      doGenerateSubmoduleConfigurations: false,
-                      extensions: [[$class: 'LocalBranch'],
-                                   [$class: 'WipeWorkspace'],
-                                   [$class: 'PreBuildMerge', options: [mergeRemote: 'origin', mergeTarget: 'master']],
-                                   [$class: 'RelativeTargetDirectory', relativeTargetDir: 'caaspctl']],
-                      submoduleCfg: [],
-                      userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/pr/*',
-                                           credentialsId: 'github-token',
-                                           url: 'https://github.com/SUSE/caaspctl']]])
-        } }
-
         stage('Running go vet') { steps {
             sh("make vet")
         } }

--- a/ci/jenkins/pipelines/prs/caaspctl-integration.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/caaspctl-integration.Jenkinsfile
@@ -12,44 +12,30 @@ pipeline {
     }
 
     stages {
-        stage('Git Clone') { steps {
-            deleteDir()
-            checkout([$class: 'GitSCM',
-                      branches: [[name: "*/${BRANCH_NAME}"], [name: '*/master']],
-                      doGenerateSubmoduleConfigurations: false,
-                      extensions: [[$class: 'LocalBranch'],
-                                   [$class: 'WipeWorkspace'],
-                                   [$class: 'RelativeTargetDirectory', relativeTargetDir: 'caaspctl']],
-                      submoduleCfg: [],
-                      userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/PR-*',
-                                           credentialsId: 'github-token',
-                                           url: 'https://github.com/SUSE/caaspctl']]])
-        }}
-
         stage('Getting Ready For Cluster Deployment') { steps {
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=info ${PARAMS}", label: "Info")
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=github_collaborator_check ${PARAMS}", label: "GitHub Collaborator Check")
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=git_rebase branch-name=${env.BRANCH_NAME} ${PARAMS}", label: "Git Rebase Check")
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=initial_cleanup ${PARAMS}", label: "Initial Cleanup")
+            sh(script: "ci/infra/testrunner/testrunner stage=info ${PARAMS}", label: "Info")
+            sh(script: "ci/infra/testrunner/testrunner stage=github_collaborator_check ${PARAMS}", label: "GitHub Collaborator Check")
+            sh(script: "ci/infra/testrunner/testrunner stage=git_rebase branch-name=${env.BRANCH_NAME} ${PARAMS}", label: "Git Rebase Check")
+            sh(script: "ci/infra/testrunner/testrunner stage=initial_cleanup ${PARAMS}", label: "Initial Cleanup")
         } }
 
         stage('Cluster Deployment') { steps {
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=create_environment ${PARAMS}", label: "Create Environment")
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=configure_environment ${PARAMS}", label: "Configure Environment")
+            sh(script: "ci/infra/testrunner/testrunner stage=create_environment ${PARAMS}", label: "Create Environment")
+            sh(script: "ci/infra/testrunner/testrunner stage=configure_environment ${PARAMS}", label: "Configure Environment")
         } }
 
         stage('Bootstrap Cluster') { steps {
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=bootstrap_environment ${PARAMS}", label: "Bootstrap Environment")
+            sh(script: "ci/infra/testrunner/testrunner stage=bootstrap_environment ${PARAMS}", label: "Bootstrap Environment")
         } }
 
         stage('Add Nodes in Cluster') { steps {
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=grow_environment ${PARAMS}", label: "Grow Environment")
+            sh(script: "ci/infra/testrunner/testrunner stage=grow_environment ${PARAMS}", label: "Grow Environment")
         } }
     }
     post {
         always {
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=gather_logs ${PARAMS}", label: "Gather Logs")
-            sh(script: "caaspctl/ci/infra/testrunner/testrunner stage=final_cleanup ${PARAMS}", label: "Final Cleanup")
+            sh(script: "ci/infra/testrunner/testrunner stage=gather_logs ${PARAMS}", label: "Gather Logs")
+            sh(script: "ci/infra/testrunner/testrunner stage=final_cleanup ${PARAMS}", label: "Final Cleanup")
         }
         cleanup {
             dir("${WORKSPACE}") {


### PR DESCRIPTION
the pipeline logic already clones into the workspace
no need to explicitly clone a 2nd time

Signed-off-by: Maximilian Meister <mmeister@suse.de>

## Why is this PR needed?

The repo is already cloned through the template configuration. No need to clone a 2nd time explicitly

## What does this PR do?

Removes the explicit 2nd clone procedure