### PR TITLE
Fixed the path JJB pipeline uses for Makefile

### DIFF
--- a/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
     stages {
         stage('Info') { steps {
-            sh(script: "make -f ci/Makefile stage=info ${PARAMS}", label: 'Info')
+            sh(script: "make -f caaspctl/ci/Makefile stage=info ${PARAMS}", label: 'Info')
         } }
         stage('Setup Environment') { steps {
             sh(script: 'python3 -m venv venv', label: 'Setup Python Virtualenv')
@@ -17,14 +17,14 @@ pipeline {
         stage('Test Jobs') { steps {
             sh(script: """
                    source ${WORKSPACE}/venv/bin/activate
-                   make -f ci/Makefile test_jenkins_jobs
+                   make -f caaspctl/ci/Makefile test_jenkins_jobs
                 """, label: 'Test Jenkins Jobs')
             zip archive: true, dir: 'jobs', zipFile: 'jenkins_jobs.zip'
         } }
         stage('Update Jobs') { steps {
             sh(script: """
                    source ${WORKSPACE}/venv/bin/activate
-                   make -f ci/Makefile update_jenkins_jobs
+                   make -f caaspctl/ci/Makefile update_jenkins_jobs
                 """, label: 'Update Jenkins Jobs')
         } }
     }


### PR DESCRIPTION
## Why is this PR needed?
Fixes the path JJB pipeline uses for Makefile

Fixes #

## What does this PR do?

The JJB pipeline needs to use this path because
we are checking out to caaspctl/.
This is due to using hardcoded paths in testrunner.