### PR TITLE
ci: jenkins: Disable pr notifications in jjb

### DIFF
--- a/ci/jenkins/pipelines/prs/caaspctl-code-lint.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/caaspctl-code-lint.Jenkinsfile
@@ -23,6 +23,10 @@ pipeline {
     }
 
     stages {
+        stage('Setting GitHub in-progress status') { steps {
+            setBuildStatus('jenkins/caaspctl-code-lint', 'in-progress', 'pending')
+        } }
+
         stage('Running go vet') { steps {
             sh(script: 'make vet', label: 'Go Vet')
         } }

--- a/ci/jenkins/pipelines/prs/caaspctl-integration.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/caaspctl-integration.Jenkinsfile
@@ -23,6 +23,10 @@ pipeline {
     }
 
     stages {
+        stage('Setting GitHub in-progress status') { steps {
+            setBuildStatus('jenkins/caaspctl-integration', 'in-progress', 'pending')
+        } }
+
         stage('Git Clone') { steps {
             deleteDir()
             checkout([$class: 'GitSCM',

--- a/ci/jenkins/templates/code-lint.yaml
+++ b/ci/jenkins/templates/code-lint.yaml
@@ -11,6 +11,7 @@
           repo-owner: '{repo-owner}'
           credentials-id: '{repo-credentials}'
           branch-discovery: no-pr
+          disable-pr-notifications: true
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current

--- a/ci/jenkins/templates/integration-template.yaml
+++ b/ci/jenkins/templates/integration-template.yaml
@@ -11,6 +11,7 @@
           repo-owner: '{repo-owner}'
           credentials-id: '{repo-credentials}'
           branch-discovery: no-pr
+          disable-pr-notifications: true
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current


### PR DESCRIPTION
The PR notifications are now being handled in the respective Jenkinsfile
files with the correct context so we should not be managing them into
two places.