### PR TITLE
ci: jenkins: jjb: Fix Makefile target

### DIFF
--- a/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     }
     stages {
         stage('Info') { steps {
-            sh(script: "make -f caaspctl/ci/Makefile stage=info ${PARAMS}", label: 'Info')
+            sh(script: "make -f caaspctl/ci/Makefile info ${PARAMS}", label: 'Info')
         } }
         stage('Setup Environment') { steps {
             sh(script: 'python3 -m venv venv', label: 'Setup Python Virtualenv')


### PR DESCRIPTION
The correct target name is 'info' instead of 'stage=info'. The former
led to a full blown testrunner call which resulted to failures because
the script was trying to deploy an OpenStack cluster.