### PR TITLE
ci: jenkins: jjb: Fix directory for generated jenkins jobs

### DIFF
--- a/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/caaspctl-jjb.Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                    source ${WORKSPACE}/venv/bin/activate
                    make -f caaspctl/ci/Makefile test_jenkins_jobs
                 """, label: 'Test Jenkins Jobs')
-            zip archive: true, dir: 'jobs', zipFile: 'jenkins_jobs.zip'
+            zip archive: true, dir: 'caaspctl/ci/jenkins/jobs', zipFile: 'jenkins_jobs.zip'
         } }
         stage('Update Jobs') { steps {
             sh(script: """


### PR DESCRIPTION
The 'jobs' directory is under the caaspctl/ci/jenkins directory so
we should adjust the path otherwise the 'zip' operation fails leading
to broken pipelines.