### PR TITLE
Remove newlines from klog calls

### DIFF
--- a/internal/app/caaspctl/node/bootstrap.go
+++ b/internal/app/caaspctl/node/bootstrap.go
@@ -56,7 +56,7 @@ func NewBootstrapCmd() *cobra.Command {
 				),
 			)
 			if err != nil {
-				klog.Fatalf("error bootstraping node: %s\n", err)
+				klog.Fatalf("error bootstraping node: %s", err)
 			}
 		},
 		Args: cobra.ExactArgs(1),

--- a/internal/app/caaspctl/node/join.go
+++ b/internal/app/caaspctl/node/join.go
@@ -52,7 +52,7 @@ func NewJoinCmd() *cobra.Command {
 			case "worker":
 				joinConfiguration.Role = deployments.WorkerRole
 			default:
-				klog.Fatalf("[join] invalid role provided: %q, 'master' or 'worker' are the only accepted roles\n", joinOptions.role)
+				klog.Fatalf("[join] invalid role provided: %q, 'master' or 'worker' are the only accepted roles", joinOptions.role)
 			}
 
 			err := node.Join(joinConfiguration,
@@ -65,7 +65,7 @@ func NewJoinCmd() *cobra.Command {
 				),
 			)
 			if err != nil {
-				klog.Fatalf("error joining node %s: %s\n", nodenames[0], err)
+				klog.Fatalf("error joining node %s: %s", nodenames[0], err)
 			}
 		},
 		Args: cobra.ExactArgs(1),

--- a/internal/app/caaspctl/node/remove.go
+++ b/internal/app/caaspctl/node/remove.go
@@ -30,7 +30,7 @@ func NewRemoveCmd() *cobra.Command {
 		Short: "Removes a node from the cluster",
 		Run: func(cmd *cobra.Command, nodenames []string) {
 			if err := node.Remove(nodenames[0]); err != nil {
-				klog.Fatalf("error removing node %s: %s\n", nodenames[0], err)
+				klog.Fatalf("error removing node %s: %s", nodenames[0], err)
 			}
 		},
 		Args: cobra.ExactArgs(1),

--- a/internal/pkg/caaspctl/deployments/ssh/ssh.go
+++ b/internal/pkg/caaspctl/deployments/ssh/ssh.go
@@ -127,7 +127,7 @@ func readerStreamer(reader io.Reader, outputChan chan<- string, description stri
 	for scanner.Scan() {
 		result.Write([]byte(scanner.Text()))
 		if !silent {
-			klog.V(1).Infof("%s | %s\n", description, scanner.Text())
+			klog.V(1).Infof("%s | %s", description, scanner.Text())
 		}
 	}
 	outputChan <- result.String()

--- a/internal/pkg/caaspctl/deployments/ssh/states.go
+++ b/internal/pkg/caaspctl/deployments/ssh/states.go
@@ -32,12 +32,12 @@ type Runner func(t *Target, data interface{}) error
 
 func (t *Target) Apply(data interface{}, states ...string) error {
 	for _, stateName := range states {
-		klog.V(1).Infof("=== applying state %s ===\n", stateName)
+		klog.V(1).Infof("=== applying state %s ===", stateName)
 		if state, stateExists := stateMap[stateName]; stateExists {
 			if err := state(t, data); err != nil {
 				return errors.Wrapf(err, "failed to apply state %s", stateName)
 			} else {
-				klog.V(1).Infof("=== state %s applied successfully ===\n", stateName)
+				klog.V(1).Infof("=== state %s applied successfully ===", stateName)
 			}
 		} else {
 			return errors.New(fmt.Sprintf("state does not exist: %s", stateName))

--- a/internal/pkg/caaspctl/etcd/member.go
+++ b/internal/pkg/caaspctl/etcd/member.go
@@ -38,12 +38,12 @@ func RemoveMember(node *v1.Node) error {
 	// Remove etcd member if target is a master
 	klog.V(1).Info("removing etcd member from the etcd cluster")
 	for _, masterNode := range masterNodes.Items {
-		klog.V(1).Infof("trying to remove etcd member from master node %s\n", masterNode.ObjectMeta.Name)
+		klog.V(1).Infof("trying to remove etcd member from master node %s", masterNode.ObjectMeta.Name)
 		if err := RemoveMemberFrom(node, &masterNode); err == nil {
-			klog.V(1).Infof("etcd member for node %s removed from master node %s\n", node.ObjectMeta.Name, masterNode.ObjectMeta.Name)
+			klog.V(1).Infof("etcd member for node %s removed from master node %s", node.ObjectMeta.Name, masterNode.ObjectMeta.Name)
 			break
 		} else {
-			klog.V(1).Infof("could not remove etcd member from master node %s\n", masterNode.ObjectMeta.Name)
+			klog.V(1).Infof("could not remove etcd member from master node %s", masterNode.ObjectMeta.Name)
 		}
 	}
 

--- a/internal/pkg/caaspctl/kubernetes/jobs.go
+++ b/internal/pkg/caaspctl/kubernetes/jobs.go
@@ -64,13 +64,13 @@ func CreateAndWaitForJob(name string, spec batchv1.JobSpec) error {
 		}
 		job, err := clientSet.BatchV1().Jobs(metav1.NamespaceSystem).Get(name, metav1.GetOptions{})
 		if err != nil {
-			klog.V(1).Infof("failed to get status for job %s, continuing...\n", name)
+			klog.V(1).Infof("failed to get status for job %s, continuing...", name)
 		} else {
 			if job.Status.Active > 0 {
-				klog.V(1).Infof("job %s is active, waiting...\n", name)
+				klog.V(1).Infof("job %s is active, waiting...", name)
 			} else {
 				if job.Status.Succeeded > 0 {
-					klog.V(1).Infof("job %s executed successfully\n", name)
+					klog.V(1).Infof("job %s executed successfully", name)
 					return nil
 				}
 			}

--- a/internal/pkg/caaspctl/kubernetes/nodes.go
+++ b/internal/pkg/caaspctl/kubernetes/nodes.go
@@ -53,10 +53,10 @@ func DrainNode(node *v1.Node) error {
 		"drain", "--delete-local-data=true", "--force=true", "--ignore-daemonsets=true", node.ObjectMeta.Name)
 
 	if err := cmd.Run(); err != nil {
-		klog.V(1).Infof("could not drain node %s, aborting (use --force if you want to ignore this error)\n", node.ObjectMeta.Name)
+		klog.V(1).Infof("could not drain node %s, aborting (use --force if you want to ignore this error)", node.ObjectMeta.Name)
 		return err
 	} else {
-		klog.V(1).Infof("node %s correctly drained\n", node.ObjectMeta.Name)
+		klog.V(1).Infof("node %s correctly drained", node.ObjectMeta.Name)
 	}
 
 	return nil


### PR DESCRIPTION
## Why is this PR needed?

klog will already take care of adding carriage returns to the
messages, so remove redundant newlines on the messages.