### PR TITLE
ci: jenkins: Add job to check for committers email address

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -7,6 +7,7 @@
         - '{name}-nightly'
         - '{name}-integration'
         - '{name}-code-lint'
+        - '{name}-code-author'
 
 - job:
     name: caasp-jobs/caasp-jjb

--- a/ci/jenkins/pipelines/prs/caaspctl-validate-pr-author.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/caaspctl-validate-pr-author.Jenkinsfile
@@ -1,0 +1,46 @@
+/**
+ * This pipeline performs various check for PR authors
+ */
+
+void setBuildStatus(String context, String description, String state) {
+    def body = "{\"state\": \"${state}\", " +
+               "\"target_url\": \"${BUILD_URL}/display/redirect\", " +
+               "\"description\": \"${description}\", " +
+               "\"context\": \"${context}\"}"
+    def headers = '-H "Content-Type: application/json" -H "Accept: application/vnd.github.v3+json"'
+    def url = "https://${GITHUB_TOKEN}@api.github.com/repos/SUSE/caaspctl/statuses/${GIT_COMMIT}"
+
+    sh(script: "curl -X POST ${headers} ${url} -d '${body}'", label: "Sending commit status")
+}
+
+pipeline {
+    agent { node { label 'caasp-team-private' } }
+
+    environment {
+        GITHUB_TOKEN = credentials('github-token')
+    }
+
+    stages {
+        stage('Setting GitHub in-progress status') { steps {
+            setBuildStatus('jenkins/caaspctl-validate-pr-author', 'in-progress', 'pending')
+        } }
+
+        stage('Validating PR author') { steps {
+            sh(script: 'ci/jenkins/pipelines/prs/helpers/check-valid-author.sh', label: 'checking valid PR author')
+        } }
+
+    }
+    post {
+        cleanup {
+            dir("${WORKSPACE}") {
+                deleteDir()
+            }
+        }
+        failure {
+            setBuildStatus('jenkins/caaspctl-validate-pr-author', 'failed', 'failure')
+        }
+        success {
+            setBuildStatus('jenkins/caaspctl-validate-pr-author', 'success', 'success')
+        }
+    }
+}

--- a/ci/jenkins/pipelines/prs/helpers/check-valid-author.sh
+++ b/ci/jenkins/pipelines/prs/helpers/check-valid-author.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ensure that all SUSE employees are using the correct email address.
+
+[[ ! -n ${GITHUB_TOKEN} ]] && echo "GITHUB_TOKEN env variable must be set" && exit 1
+GIT_BRANCH=${GIT_BRANCH:-origin/master}
+
+# Check all commits in PR for SUSE email address
+if ! git log --format=%ae --no-merges origin/master..HEAD | sort -n | uniq | grep -v -q '@suse\.\(com\|cz\|de\)'; then
+	echo "All commits are from SUSE employees. Skipping further author checks..."
+	exit 0
+fi
+
+for commit in $(git log --format=%H --no-merges ${GIT_BRANCH}..HEAD); do
+	author_email=$(curl -s https://${GITHUB_TOKEN}@api.github.com/repos/SUSE/caaspctl/commits/$commit | jq -cr '. | .author.login, .commit.author.email' | tr -d '"')
+	login=$(echo $author_email | awk '{print $1}')
+	author=$(echo $author_email | awk '{print $2}')
+	echo "Checking if $login($author) is part of the SUSE organization"
+	if curl -i -s https://${GITHUB_TOKEN}@api.github.com/orgs/SUSE/members/$login | grep Status | grep -q 204; then
+		echo "$login($author) is part of SUSE organization but a SUSE e-mail address was not used in commit: $commit"
+		exit 1
+	fi
+done
+
+

--- a/ci/jenkins/templates/code-author.yaml
+++ b/ci/jenkins/templates/code-author.yaml
@@ -1,0 +1,18 @@
+- job-template:
+    name: '{name}-code-author'
+    project-type: multibranch
+    periodic-folder-trigger: 5m
+    number-to-keep: 30
+    days-to-keep: 30
+    script-path: ci/jenkins/pipelines/prs/caaspctl-validate-pr-author.Jenkinsfile
+    scm:
+      - github:
+          repo: '{repo-name}'
+          repo-owner: '{repo-owner}'
+          credentials-id: '{repo-credentials}'
+          branch-discovery: no-pr
+          disable-pr-notifications: true
+          discover-pr-forks-strategy: current
+          discover-pr-forks-trust: contributors
+          discover-pr-origin: current
+          head-filter-regex: ^(master|release\-\d\.\d|PR\-\d+)$


### PR DESCRIPTION
All SUSE employees are expected to use their SUSE email address on git
commits so this job goes through the PR commits, fetches the author and
checks whether he/she is a member of the SUSE org. If they are, then
their email is checked for the correct domain. This job is run on the
PR level which means that PRs will be blocked if the wrong email is
being used