### PR TITLE
[WIP] SUSEConnect registration with openstack terraform

### DIFF
--- a/ci/infra/openstack/cloud-init/master.tpl
+++ b/ci/infra/openstack/cloud-init/master.tpl
@@ -34,4 +34,8 @@ ${packages}
 bootcmd:
   - ip link set dev eth0 mtu 1400
 
+# /usr/sbin/
+runcmd:
+${commands}
+
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/openstack/cloud-init/worker.tpl
+++ b/ci/infra/openstack/cloud-init/worker.tpl
@@ -34,4 +34,7 @@ ${packages}
 bootcmd:
   - ip link set dev eth0 mtu 1400
 
+runcmd:
+${commands}
+
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -15,6 +15,7 @@ data "template_file" "master-cloud-init" {
     authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
     repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
     packages = "${join("\n", formatlist("  - %s", var.packages))}"
+    commands = "${join("\n", formatlist("  - %s", var.commands))}"
     username = "${var.username}"
     password = "${var.password}"
   }

--- a/ci/infra/openstack/terraform.tfvars.sles.example
+++ b/ci/infra/openstack/terraform.tfvars.sles.example
@@ -8,7 +8,7 @@ stack_name = "testing"
 username = "sles"
 
 # define which image to use
-image_name = "SLES15-SP1-JeOS-RC1-with-fixed-kernel-default"
+image_name = "SLE-15-SP1-JeOS-GMC1"
 
 # Number of master nodes
 masters = 1
@@ -16,33 +16,30 @@ masters = 1
 # Number of worker nodes
 workers = 2
 
-# define the repositories to use
-repositories = [
-  {
-    caasp_40_devel_sle15sp1 = "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"
-  },
-  {
-    sle15sp1_pool = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/"
-  },
-  {
-    sle15sp1_update = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/"
-  },
-  {
-    sle15_pool = "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
-  },
-  {
-    sle15_update = "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/"
-  },
-  {
-    suse_ca = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/"
-  }
-]
+# Required repositories in case we don't register with cloud-init
+# suse_ca is required for registry.suse.de containers (devel|staging)
+# repositories = [
+#   { suse_ca       = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/" },
+#   { sle_server    = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Server-Applications-GMC1/x86_64/DVD1/"},
+#   { sle_base      = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Basesystem-GMC1/x86_64/DVD1/"},
+#   { sle_contaiers = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Containers-GMC1/x86_64/DVD1/"},
+#   { caasp_staging = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/" }
+# ]
 
-packages = [
-  "ca-certificates-suse",
-  "kubernetes-kubeadm",
-  "kubernetes-kubelet",
-  "kubernetes-client"
+# Required packages in case we don't register with cloud-init
+# ca-certificates-suse is required for registry.suse.de containers (devel|staging)
+# packages = [
+#   "ca-certificates-suse",
+#   "kubernetes-kubeadm",
+#   "kubernetes-client"
+# ]
+
+# Register using cloud-init if we want official repositories
+commands = [
+  "SUSEConnect -r <SLES_REG_KEY>",
+  "SUSEConnect -p sle-module-containers/15.1/x86_64",
+  "SUSEConnect -p caasp/4.0/x86_64 -r <CAASP_REG_KEY>",
+  "zypper -n install kubernetes-kubeadm kubernetes-client"
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -114,3 +114,9 @@ variable "password" {
   default = "linux"
   description = "Password for the cluster nodes"
 }
+
+variable "commands" {
+  type = "list"
+  default = []
+  description = "Commands to execute in cloud-final stage"
+}

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -15,6 +15,7 @@ data "template_file" "worker-cloud-init" {
     authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
     repositories = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
     packages = "${join("\n", formatlist("  - %s", var.packages))}"
+    commands = "${join("\n", formatlist("  - %s", var.commands))}"
     username = "${var.username}"
     password = "${var.password}"
   }


### PR DESCRIPTION
## Why is this PR needed?

Enables customers to use terraform with SUSEConnect registration

## What does this PR do?

Help with discussion whether we want to provide registration automation as a feature

## How to use?
For internal use of staging build terraform.tfvars:
```yaml
repositories = [
  { suse_ca       = "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/" },
  { sle_server    = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Server-Applications-GMC1/x86_64/DVD1/"},
  { sle_base      = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Basesystem-GMC1/x86_64/DVD1/"},
  { sle_contaiers = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Containers-GMC1/x86_64/DVD1/"},
  { caasp_staging = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/" }
]

packages = [
  "ca-certificates-suse",
  "kubernetes-kubeadm",
  "kubernetes-client"
]

commands = []
```

For customers use with suseconnect terraform.tfvars:
```yaml
repositories = []

packages = []

commands = [
  "SUSEConnect -r <SLES_REG_KEY>",
  "SUSEConnect -p sle-module-containers/15.1/x86_64",
  "SUSEConnect -p caasp/4.0/x86_64 -r <CAASP_REG_KEY>",
  "zypper -n install kubernetes-kubeadm kubernetes-client"
]
```