### PR TITLE
ci: openstack: Ensure cloud-init provisioner has correct dependency

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -65,6 +65,8 @@ resource "null_resource" "master_wait_cloudinit" {
     type     = "ssh"
   }
 
+  depends_on = ["openstack_compute_instance_v2.master"]
+
   provisioner "remote-exec" {
     inline = [
       "cloud-init status --wait",

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -77,6 +77,8 @@ resource "null_resource" "worker_wait_cloudinit" {
     type     = "ssh"
   }
 
+  depends_on = ["openstack_compute_instance_v2.worker"]
+
   provisioner "remote-exec" {
     inline = [
       "cloud-init status --wait",


### PR DESCRIPTION
The cloud-init provisioner depends on the nodes to be fully created
and booted so add the proper dependency