### PR TITLE
[VMWare] Setup ntp servers via cloud-init

### DIFF
--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -9,6 +9,14 @@ timezone: Etc/UTC
 ssh_authorized_keys:
 ${authorized_keys}
 
+ntp:
+  enabled: true
+  ntp_client: chrony
+  config:
+    confpath: /etc/chrony.conf
+  servers:
+${ntp_servers}
+
 # need to disable gpg checks because the cloud image has an untrusted repo
 zypper:
   repos:

--- a/ci/infra/vmware/cloud-init/master.tpl
+++ b/ci/infra/vmware/cloud-init/master.tpl
@@ -9,6 +9,14 @@ timezone: Etc/UTC
 ssh_authorized_keys:
 ${authorized_keys}
 
+ntp:
+  enabled: true
+  ntp_client: chrony
+  config:
+    confpath: /etc/chrony.conf
+  servers:
+${ntp_servers}
+
 # need to disable gpg checks because the cloud image has an untrusted repo
 zypper:
   repos:

--- a/ci/infra/vmware/cloud-init/worker.tpl
+++ b/ci/infra/vmware/cloud-init/worker.tpl
@@ -9,6 +9,14 @@ timezone: Etc/UTC
 ssh_authorized_keys:
 ${authorized_keys}
 
+ntp:
+  enabled: true
+  ntp_client: chrony
+  config:
+    confpath: /etc/chrony.conf
+  servers:
+${ntp_servers}
+
 # need to disable gpg checks because the cloud image has an untrusted repo
 zypper:
   repos:

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "lb-cloud-init" {
     packages        = "${join("\n", formatlist("  - %s", var.packages))}"
     username        = "${var.username}"
     password        = "${var.password}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
 

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -17,6 +17,7 @@ data "template_file" "master-cloud-init" {
     packages        = "${join("\n", formatlist("  - %s", var.packages))}"
     username        = "${var.username}"
     password        = "${var.password}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
 

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -21,6 +21,12 @@ variable "repositories" {
   description = "Urls of the repositories to mount via cloud-init"
 }
 
+variable "ntp_servers" {
+  type        = "list"
+  default     = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
+  description = "list of ntp servers to configure"
+}
+
 variable "packages" {
   type        = "list"
   default     = []

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -17,6 +17,7 @@ data "template_file" "worker-cloud-init" {
     packages        = "${join("\n", formatlist("  - %s", var.packages))}"
     username        = "${var.username}"
     password        = "${var.password}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
 


### PR DESCRIPTION
The setup assumes that the VMWare machines are running chronyd (default in
SLE15).

It also sets up the default list of ntp servers from ntppool.org.

## Why is this PR needed?

On VMWare machines installed from a SLES iso `ntp` might not be configured.

This ensures that `chronyd` (the new SLE 15 `ntp` client) is setup on the machines.
Otherwise joining nodes to the cluster might fail due to incorrect dates on the machines.