### PR TITLE
ci: testrunner: Provide sensible defaults for git configuration

### DIFF
--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -64,8 +64,8 @@ class BaseConfig:
     class Git:
         def __init__(self):
             super().__init__()
-            self.change_author = None
-            self.change_author_email = None
+            self.change_author = os.getenv('GIT_COMMITTER_NAME', 'CaaSP Jenkins')
+            self.change_author_email = os.getenv('GIT_COMMITTER_EMAIL', 'containers-bugowner@suse.de')
             self.github_token = None
             self.branch_name = "master"
 


### PR DESCRIPTION
The magic git variables from Jenkins are only populated when we are
testing a PR which means that regular daily builds will fail since these
variables are not populated by jenkins. As such, lets add some sensible
default values to these.