### PR TITLE
ci: jenkins: check-valid-author: Do not fail if CHANGE_ID is not set

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/check-valid-author.sh
+++ b/ci/jenkins/pipelines/prs/helpers/check-valid-author.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 [[ ! -n ${GITHUB_TOKEN} ]] && echo "GITHUB_TOKEN env variable must be set" && exit 1
-[[ ! -n ${CHANGE_ID} ]] && echo "CHANGE_ID env variable must be set" && exit 1
+[[ ! -n ${CHANGE_ID} ]] && echo "CHANGE_ID env variable must be set" && exit 0
 
 # This for loop uses the GitHub API to fetch all commits in a PR and outputs the information in the following format
 # $sha,$github_username,$author_email_address. If the author is using a SUSE address, then no further checks are necessary and we


### PR DESCRIPTION
CHANGE_ID is normally set by Jenkins when we are testing a PR. But,
that means that this variable is not set when we are testing master
branch so we can just exit with 0 there to avoid having a red dashboard.