### PR TITLE
[VMWare] Setup machine-id after starting the machines.

### DIFF
--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -60,6 +60,12 @@ runcmd:
   # deadlock. Instead, we have to use the `--no-block-` flag.
   - [ systemctl, enable, --now, --no-block, haproxy ]
   - [ systemctl, disable, --now, --no-block, firewalld ]
+  # The template machine should have been cleaned up, so no machine-id exists
+  - [ dbus-uuidgen, --ensure ]
+  - [ systemd-machine-id-setup ]
+  # With a new machine-id generated the journald daemon will work and can be restarted
+  # Without a new machine-id it should be in a failed state
+  - [ systemctl, restart, systemd-journald ]
 
 bootcmd:
   # Hostnames from DHCP - otherwise localhost will be used

--- a/ci/infra/vmware/cloud-init/master.tpl
+++ b/ci/infra/vmware/cloud-init/master.tpl
@@ -37,6 +37,12 @@ runcmd:
   # start another service by either `enable --now` or `start` will create a
   # deadlock. Instead, we have to use the `--no-block-` flag.
   - [ systemctl, disable, --now, --no-block, firewalld ]
+  # The template machine should have been cleaned up, so no machine-id exists
+  - [ dbus-uuidgen, --ensure ]
+  - [ systemd-machine-id-setup ]
+  # With a new machine-id generated the journald daemon will work and can be restarted
+  # Without a new machine-id it should be in a failed state
+  - [ systemctl, restart, systemd-journald ]
 
 bootcmd:
   # Hostnames from DHCP - otherwise `localhost` will be used

--- a/ci/infra/vmware/cloud-init/worker.tpl
+++ b/ci/infra/vmware/cloud-init/worker.tpl
@@ -37,6 +37,12 @@ runcmd:
   # start another service by either `enable --now` or `start` will create a
   # deadlock. Instead, we have to use the `--no-block-` flag.
   - [ systemctl, disable, --now, --no-block, firewalld ]
+  # The template machine should have been cleaned up, so no machine-id exists
+  - [ dbus-uuidgen, --ensure ]
+  - [ systemd-machine-id-setup ]
+  # With a new machine-id generated the journald daemon will work and can be restarted
+  # Without a new machine-id it should be in a failed state
+  - [ systemctl, restart, systemd-journald ]
 
 bootcmd:
   # Hostnames from DHCP - otherwise `localhost` will be used


### PR DESCRIPTION
The machine-id should be removed before turning a machine into VM.
However without a machine-id running `systemd-journald` is not working, so it
must first be generated and the `journald` restarted.

## Why is this PR needed?

As describe https://github.com/SUSE/caaspctl/pull/196#issuecomment-491710622 it is required
to reset the machine-id after the machines are started.

## What does this PR do?

Recreate a systemd-machine-id for the newly created machines.