### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing to skuba (formerly caaspctl)
+
+The following is a set of guidelines for contributing to this project, hosted by [SUSE](https://github.com/suse/caaspctl). 
+If you have a suggestion to these guidelines feel free to propose changes in a pull request. 
+
+
+## Pull requests
+
+Contributors: 
+* Adhere to the PR template. Fill out as many sections as possible with as much detail as possible. 
+* Adhere to the style guide as closely as possible, where a bot cannot do it for you.
+* The PR is ready for review only when the CI is green. Do not ask for people to review your code if the CI is failing.
+* If CI is not passing, or you need to make more improvements than expected, please add the wip label.
+* Once the CI is green, feel free to assign specific reviewers to your PR to signal it is ready.
+
+Maintainers: 
+* Devote time to regular code review and make your reviews impactful. Look at the big picture, don't get hung up on style alone. 
+* Veto only when there's is something really problematic, otherwise just comment. Otherwise you are forcing a new round of reviews including a new CI run.
+
+
+## Styleguides
+
+### git commit messages
+
+This list is not comprehensive, meaning if you want to include more detail than required that is fine as long as you meet these guidelines first. 
+
+* Title
+  * Always start with an upper-case letter
+  * Do not put a dot (period) at the end
+  * Use imperative verbs
+  * Maximum characters: 50
+* Body
+  * Start sentences with upper-case letter and finish with dot (period).
+  * Maximum characters per line is 72
+  * Explain what this commit is doing
+  * Explain why we have to do it
+  * Do not explain how unless the change is sufficiently large and needs further explanation
+    * Tracking issues from Github:
+      * __Do not track references (ID/URLs) to in the commit message__ but on the web-ui (yes you are forced to open your browser)
+    * Tracking issues from Bugzilla
+      * Add `Fixes bsc#123456` as part of the body
+
+
+## Go style
+
+This will be checked automatically by our CI linter bot. 
+
+


### PR DESCRIPTION
## Why is this PR needed?

Include our contribution guidelines with the code base instead of the wiki. Reorganized and changed structure a bit going from wiki to MD. 
It also makes more sense to include with code once we start adding more repositories which may have different guidelines. 

See the original Confluence page for reference. https://confluence.suse.com/display/SUSECaaSPlatform4/Contributing+Guide 