### PR TITLE
Automate registration nodes against SCC

### DIFF
--- a/ci/infra/openstack/README.md
+++ b/ci/infra/openstack/README.md
@@ -42,3 +42,8 @@ exposed by a load balancer managed by OpenStack.
 
 Copy the `terraform.tfvars.example` to `terraform.tfvars` and
 provide reasonable values.
+
+## Variables
+
+`caasp_registry_code` - Provide SUSE CaaSP Product Registration Code in 
+`registration.auto.tfvars` file to register product against official repositories

--- a/ci/infra/openstack/cloud-init/commands.tpl
+++ b/ci/infra/openstack/cloud-init/commands.tpl
@@ -1,0 +1,1 @@
+  - [ zypper, install, -y, ${packages} ]

--- a/ci/infra/openstack/cloud-init/master.tpl
+++ b/ci/infra/openstack/cloud-init/master.tpl
@@ -36,10 +36,16 @@ ${repositories}
 # need to remove the standard docker packages that are pre-installed on the
 # cloud image because they conflict with the kubic- ones that are pulled by
 # the kubernetes packages
-packages:
-${packages}
+# WARNING!!! Do not use cloud-init packages module when SUSE CaaSP Registraion
+# Code is provided. In this case repositories will be added in runcmd module 
+# with SUSEConnect command after packages module is ran
+#packages:
 
 bootcmd:
   - ip link set dev eth0 mtu 1400
+
+runcmd:
+${registration}
+${commands}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/openstack/cloud-init/registration.tpl
+++ b/ci/infra/openstack/cloud-init/registration.tpl
@@ -1,0 +1,3 @@
+  - [ SUSEConnect, -r, ${caasp_registry_code} ]
+  - [ SUSEConnect, -p, sle-module-containers/15.1/x86_64 ]
+  - [ SUSEConnect, -p, caasp/4.0/x86_64, -r, ${caasp_registry_code} ]

--- a/ci/infra/openstack/cloud-init/worker.tpl
+++ b/ci/infra/openstack/cloud-init/worker.tpl
@@ -36,10 +36,16 @@ ${repositories}
 # need to remove the standard docker packages that are pre-installed on the
 # cloud image because they conflict with the kubic- ones that are pulled by
 # the kubernetes packages
-packages:
-${packages}
+# WARNING!!! Do not use cloud-init packages module when SUSE CaaSP Registraion
+# Code is provided. In this case repositories will be added in runcmd module
+# with SUSEConnect command after packages module is ran
+#packages:
 
 bootcmd:
   - ip link set dev eth0 mtu 1400
+
+runcmd:
+${registration}
+${commands}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/openstack/registration.auto.tfvars
+++ b/ci/infra/openstack/registration.auto.tfvars
@@ -1,0 +1,3 @@
+
+# SUSE CaaSP Product Registration Code
+#caasp_registry_code = ""

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -126,3 +126,8 @@ variable "password" {
   default     = "linux"
   description = "Password for the cluster nodes"
 }
+
+variable "caasp_registry_code" {
+  default     = ""
+  description = "SUSE CaaSP Product Registration Code"
+}

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -8,13 +8,32 @@ data "template_file" "worker_repositories" {
   }
 }
 
+data "template_file" "worker_registration" {
+  template = "${file("cloud-init/registration.tpl")}"
+  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+
+  vars {
+    caasp_registry_code = "${var.caasp_registry_code}"
+    packages            = "${join(", ", var.packages)}"
+  }
+}
+
+data "template_file" "worker_commands" {
+  template = "${file("cloud-init/commands.tpl")}"
+
+  vars {
+    packages = "${join(", ", var.packages)}"
+  }
+}
+
 data "template_file" "worker-cloud-init" {
   template = "${file("cloud-init/worker.tpl")}"
 
   vars {
     authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
     repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
-    packages        = "${join("\n", formatlist("  - %s", var.packages))}"
+    registration    = "${join("\n", data.template_file.worker_registration.*.rendered)}"
+    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
     username        = "${var.username}"
     password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"

--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -49,3 +49,8 @@ IMPORTANT, please define unique `stack_name` value in `terrafrom.tfvars` file to
 
 Copy the `terraform.tfvars.example` to `terraform.tfvars` and
 provide reasonable values.
+
+## Variables
+
+`caasp_registry_code` - Provide SUSE CaaSP Product Registration Code in
+`registration.auto.tfvars` file to register product against official repositories

--- a/ci/infra/vmware/cloud-init/commands.tpl
+++ b/ci/infra/vmware/cloud-init/commands.tpl
@@ -1,0 +1,1 @@
+  - [ zypper, install, -y, ${packages} ]

--- a/ci/infra/vmware/cloud-init/master.tpl
+++ b/ci/infra/vmware/cloud-init/master.tpl
@@ -29,8 +29,10 @@ ${repositories}
 # need to remove the standard docker packages that are pre-installed on the
 # cloud image because they conflict with the kubic- ones that are pulled by
 # the kubernetes packages
-packages:
-${packages}
+# WARNING!!! Do not use cloud-init packages module when SUSE CaaSP Registraion
+# Code is provided. In this case repositories will be added in runcmd module
+# with SUSEConnect command after packages module is ran
+#packages:
 
 runcmd:
   # Since we are currently inside of the cloud-init systemd unit, trying to
@@ -43,6 +45,8 @@ runcmd:
   # With a new machine-id generated the journald daemon will work and can be restarted
   # Without a new machine-id it should be in a failed state
   - [ systemctl, restart, systemd-journald ]
+${registration}
+${commands}
 
 bootcmd:
   # Hostnames from DHCP - otherwise `localhost` will be used

--- a/ci/infra/vmware/cloud-init/registration.tpl
+++ b/ci/infra/vmware/cloud-init/registration.tpl
@@ -1,0 +1,3 @@
+  - [ SUSEConnect, -r, ${caasp_registry_code} ]
+  - [ SUSEConnect, -p, sle-module-containers/15.1/x86_64 ]
+  - [ SUSEConnect, -p, caasp/4.0/x86_64, -r, ${caasp_registry_code} ]

--- a/ci/infra/vmware/cloud-init/worker.tpl
+++ b/ci/infra/vmware/cloud-init/worker.tpl
@@ -29,8 +29,10 @@ ${repositories}
 # need to remove the standard docker packages that are pre-installed on the
 # cloud image because they conflict with the kubic- ones that are pulled by
 # the kubernetes packages
-packages:
-${packages}
+# WARNING!!! Do not use cloud-init packages module when SUSE CaaSP Registraion
+# Code is provided. In this case repositories will be added in runcmd module
+# with SUSEConnect command after packages module is ran
+#packages:
 
 runcmd:
   # Since we are currently inside of the cloud-init systemd unit, trying to
@@ -43,6 +45,8 @@ runcmd:
   # With a new machine-id generated the journald daemon will work and can be restarted
   # Without a new machine-id it should be in a failed state
   - [ systemctl, restart, systemd-journald ]
+${registration}
+${commands}
 
 bootcmd:
   # Hostnames from DHCP - otherwise `localhost` will be used

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -8,6 +8,24 @@ data "template_file" "master_repositories" {
   }
 }
 
+data "template_file" "master_registration" {
+  template = "${file("cloud-init/registration.tpl")}"
+  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+
+  vars {
+    caasp_registry_code = "${var.caasp_registry_code}"
+    packages            = "${join(", ", var.packages)}"
+  }
+}
+
+data "template_file" "master_commands" {
+  template = "${file("cloud-init/commands.tpl")}"
+
+  vars {
+    packages = "${join(", ", var.packages)}"
+  }
+}
+
 data "template_file" "master_cloud_init_metadata" {
   template = "${file("cloud-init/metadata.tpl")}"
 
@@ -23,7 +41,8 @@ data "template_file" "master_cloud_init_userdata" {
   vars {
     authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
     repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
-    packages        = "${join("\n", formatlist("  - %s", var.packages))}"
+    registration    = "${join("\n", data.template_file.master_registration.*.rendered)}"
+    commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
     username        = "${var.username}"
     password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"

--- a/ci/infra/vmware/registration.auto.tfvars
+++ b/ci/infra/vmware/registration.auto.tfvars
@@ -1,0 +1,3 @@
+
+# SUSE CaaSP Product Registration Code
+#caasp_registry_code = ""

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -89,6 +89,11 @@ variable "lb_memory" {
   description = "Amount of memory used on load-balancer node"
 }
 
+variable "caasp_registry_code" {
+  default     = ""
+  description = "SUSE CaaSP Product Registration Code"
+}
+
 #### To be moved to separate vsphere.tf? ####
 
 provider "vsphere" {}

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -8,6 +8,24 @@ data "template_file" "worker_repositories" {
   }
 }
 
+data "template_file" "worker_registration" {
+  template = "${file("cloud-init/registration.tpl")}"
+  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+
+  vars {
+    caasp_registry_code = "${var.caasp_registry_code}"
+    packages            = "${join(", ", var.packages)}"
+  }
+}
+
+data "template_file" "worker_commands" {
+  template = "${file("cloud-init/commands.tpl")}"
+
+  vars {
+    packages = "${join(", ", var.packages)}"
+  }
+}
+
 data "template_file" "worker_cloud_init_metadata" {
   template = "${file("cloud-init/metadata.tpl")}"
 
@@ -23,7 +41,8 @@ data "template_file" "worker_cloud_init_userdata" {
   vars {
     authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
     repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
-    packages        = "${join("\n", formatlist("  - %s", var.packages))}"
+    registration    = "${join("\n", data.template_file.worker_registration.*.rendered)}"
+    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
     username        = "${var.username}"
     password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"


### PR DESCRIPTION
Right now our users have to perform a manual registration against all the cluster nodes to be able to install our packages.

## Why is this PR needed?

We would like automate node registration against SUSE Customer Center

## What does this PR do?

This change is automating OpenStack deployment nodes product registration against SCC
https://github.com/SUSE/avant-garde/issues/289

## How to use?

To use it just provide SUSE CaaSP Product Registration Code in `registration.auto.tfvars`
```
# SUSE CaaSP Product Registration Code
caasp_registry_code = "CAASP_REGISTRATION_CODE"
```
