### PR TITLE
ci: infra: Update JeOS image to GMC2

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.sles.example
+++ b/ci/infra/libvirt/terraform.tfvars.sles.example
@@ -23,8 +23,9 @@ username = "sles"
 #network = "172.30.0.0/22"
 #net_mode = "route"
 
-# Image url - can be local file downloaded in advance
-img_source_url = "SLES15-SP1-JeOS-RC1-with-fixed-kernel-default.qcow2"
+# Image url - can be local file downloaded in advance.
+# This build is for JeOS GMC2
+img_source_url = "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-Build35.28.qcow2"
 
 # Define the repositories to use.
 repositories = [

--- a/ci/infra/openstack/terraform.tfvars.sles.example
+++ b/ci/infra/openstack/terraform.tfvars.sles.example
@@ -8,7 +8,7 @@ stack_name = "testing"
 username = "sles"
 
 # define which image to use
-image_name = "SLES15-SP1-JeOS-RC1-with-fixed-kernel-default"
+image_name = "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-GMC2"
 
 # Number of master nodes
 masters = 1


### PR DESCRIPTION
Move away from our custom built JeOS image and use the GMC2 one
which should contain all the related fixes in the kernel.

Also fixes: #218 