### PR TITLE
Fix build makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,15 @@ install:
 	$(RM) -f $(GOBINPATH)/kubectl-caasp
 	$(LN) -s $(GOBINPATH)/caaspctl $(GOBINPATH)/kubectl-caasp
 
+.PHONY: clean
+clean:
+	$(GO) clean -i
+	$(RM) -f ./caaspctl
+
+.PHONY: distclean
+distclean: clean
+	$(GO) clean -i -cache -testcache -modcache
+
 .PHONY: staging
 staging:
 	make TAGS=staging install


### PR DESCRIPTION
## Why is this PR needed?

This PR improves the Makefile as follows

- Drops H/M/S from build information
- Fixes build and install targets
- Implements clean targets

## What does this PR do?

Improve the makefile to be more robust and also clean up leftovers.