### PR TITLE
Remove the default ntp servers from the vmware configuration.

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -16,6 +16,9 @@ workers = 3
 masters = 3
 load-balancers = 1
 
+# IMPORTANT: Replace these ntp servers with ones from your infrastructure
+ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]
+
 repositories = [
   { caasp_sle15_sp1 = "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/"},
   { basesystem_module_sle15_sp1 = "http://download.suse.de/install/SLP/SLE-15-SP1-Module-Basesystem-RC2/x86_64/DVD1/" },

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -18,7 +18,7 @@ variable "guest_id" {
 
 variable "ntp_servers" {
   type        = "list"
-  default     = ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org", "3.pool.ntp.org"]
+  default     = []
   description = "list of ntp servers to configure"
 }
 


### PR DESCRIPTION
The current servers do not comply with the usage instructions from ntppool.

## Why is this PR needed?

According to https://www.ntppool.org/en/vendors.html#vendor-zone we should not use the default ntp servers from ntppool.org.

This PR makes it explicit that this must be configured by introducing the `ntp_servers` as a tfvar.

Fixes #205 