### PR TITLE
Remove default username and password.

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -7,6 +7,15 @@ template_name = "SLES15-SP1-JeOS-cloud-init"
 # IMPORTANT, please enter unique identifier bellow as value of stack_name variable to not interfere with other deployments
 stack_name = "caasp-v4"
 
+# Username that allows:
+# - ssh access to the machine
+# - has passwordless sudo
+username = ""
+# Password for the user with:
+# - ssh access to the machine
+# - used only for initial access before the ssh-key is copied to the machine
+password = ""
+
 # ssh keys to inject into all the nodes
 authorized_keys = [
   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf Unsafe Shared Key"

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -35,12 +35,12 @@ variable "repositories" {
 }
 
 variable "username" {
-  default     = "sles"
+  default     = ""
   description = "Username for the cluster nodes"
 }
 
 variable "password" {
-  default     = "sles"
+  default     = ""
   description = "Password for the cluster nodes"
 }
 


### PR DESCRIPTION
Instead of using a default username and password, which might lead to security
problem, the user should always set the username / password that was set during
installation.

## Why is this PR needed?

Right now the terraform states assume a default username and password.

This might lead to security problems, assuming customer won't change those - so instead of setting a default the username and password should be supplied.