### PR TITLE
Add NTP configuration for openstack deployment

### DIFF
--- a/ci/infra/openstack/cloud-init/master.tpl
+++ b/ci/infra/openstack/cloud-init/master.tpl
@@ -16,6 +16,14 @@ chpasswd:
 ssh_authorized_keys:
 ${authorized_keys}
 
+ntp:
+  enabled: true
+  ntp_client: chrony
+  config:
+    confpath: /etc/chrony.conf
+  servers:
+${ntp_servers}
+
 # need to disable gpg checks because the cloud image has an untrusted repo
 zypper:
   repos:

--- a/ci/infra/openstack/cloud-init/worker.tpl
+++ b/ci/infra/openstack/cloud-init/worker.tpl
@@ -16,6 +16,14 @@ chpasswd:
 ssh_authorized_keys:
 ${authorized_keys}
 
+ntp:
+  enabled: true
+  ntp_client: chrony
+  config:
+    confpath: /etc/chrony.conf
+  servers:
+${ntp_servers}
+
 # need to disable gpg checks because the cloud image has an untrusted repo
 zypper:
   repos:

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -17,6 +17,7 @@ data "template_file" "master-cloud-init" {
     packages        = "${join("\n", formatlist("  - %s", var.packages))}"
     username        = "${var.username}"
     password        = "${var.password}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
 

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -18,3 +18,6 @@ stack_name = "testing"
 authorized_keys = [
   ""
 ]
+
+# IMPORTANT: Replace these ntp servers with ones from your infrastructure
+ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]

--- a/ci/infra/openstack/terraform.tfvars.sles.example
+++ b/ci/infra/openstack/terraform.tfvars.sles.example
@@ -49,3 +49,6 @@ packages = [
 authorized_keys = [
   ""
 ]
+
+# IMPORTANT: Replace these ntp servers with ones from your infrastructure
+ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -93,6 +93,12 @@ variable "authorized_keys" {
   description = "ssh keys to inject into all the nodes"
 }
 
+variable "ntp_servers" {
+  type        = "list"
+  default     = []
+  description = "list of ntp servers to configure"
+}
+
 variable "packages" {
   type = "list"
 

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -17,6 +17,7 @@ data "template_file" "worker-cloud-init" {
     packages        = "${join("\n", formatlist("  - %s", var.packages))}"
     username        = "${var.username}"
     password        = "${var.password}"
+    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
 


### PR DESCRIPTION
Provide the required configuration (TF) for adding NTP servers
during the deployment of an openstack infrastructure. The user
can set NTP servers via modifying variables.tf file. The default
setting is a list of four (0,1,2,3) NTP servers provided by Novell
separated by commas; suggested as an example.

## Why is this PR needed?

We need to have NTP configuration, especially in a cluster where there are several things going on in parallel (e.g. see ETCD) so we match the timestamps. Similar configuration is provided for the VMWAre deployment

See: https://github.com/SUSE/caaspctl/pull/229/commits

Fixes #205 

## What does this PR do?

Provide the required configuration (TF) for adding NTP servers during the deployment of an openstack infrastructure. The user can set NTP servers via modifying variables.tf file. The default setting is a list of four (0,1,2,3) NTP servers provided by Novell separated by commas; suggested as an example.

Edit `variables.tf` and change the default NTP servers with your own:

```tf
default     = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]
```

## Anything else a reviewer needs to know?

We need to add a test-case making sure that NTP is configured on the nodes. Some proposals:

* Check if Chronyd is running
```
caasp-master-drpaneas-0:~ # systemctl status chronyd
● chronyd.service - NTP client/server
   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: disabled)
   Active: active (running) since Mon 2019-05-20 12:13:25 UTC; 11min ago
     Docs: man:chronyd(8)
           man:chrony.conf(5)
 Main PID: 1149 (chronyd)
    Tasks: 1 (limit: 4915)
   CGroup: /system.slice/chronyd.service
           └─1149 /usr/sbin/chronyd

May 20 12:13:25 caasp-master-drpaneas-0 systemd[1]: Starting NTP client/server...
May 20 12:13:25 caasp-master-drpaneas-0 chronyd[1149]: chronyd version 3.2 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP -SCFILTER>
May 20 12:13:25 caasp-master-drpaneas-0 chronyd[1149]: Frequency 0.000 +/- 1000000.000 ppm read from /var/lib/chrony/drift
May 20 12:13:25 caasp-master-drpaneas-0 systemd[1]: Started NTP client/server.
May 20 12:13:30 caasp-master-drpaneas-0 chronyd[1149]: Selected source 199.102.46.75
May 20 12:22:10 caasp-master-drpaneas-0 chronyd[1149]: Received KoD RATE from 12.167.151.1
```

* Check if the configuration is correct (see the four `server` below):
```
sles@caasp-master-drpaneas-0:~> cat /etc/chrony.conf
# Use public servers from the pool.ntp.org project.
# Please consider joining the pool (http://www.pool.ntp.org/join.html).
# servers
server 0.novell.pool.ntp.org iburst
server 1.novell.pool.ntp.org iburst
server 2.novell.pool.ntp.org iburst
server 3.novell.pool.ntp.org iburst

# Record the rate at which the system clock gains/losses time.
driftfile /var/lib/chrony/drift

# In first three updates step the system clock instead of slew
# if the adjustment is larger than 1 second.
makestep 1.0 3

# Enable kernel synchronization of the real-time clock (RTC).
rtcsync

# Allow NTP client access from local network.
#allow 192.168/16

# Serve time even if not synchronized to any NTP server.
#local stratum 10

# Specify file containing keys for NTP authentication.
#keyfile /etc/chrony.keys

# Specify directory for log files.
logdir /var/log/chrony

# Select which information is logged.
#log measurements statistics tracking
```

* Check if the NTPs are online. This is more of a health check for the cluster. If the customer puts a problematic (e.g. typo) the system should flag him saying "Hey, the NTP you provided doesn't work".

```
caasp-master-drpaneas-0:~ # chronyc
chrony version 3.2
Copyright (C) 1997-2003, 2007, 2009-2017 Richard P. Curnow and others
chrony comes with ABSOLUTELY NO WARRANTY.  This is free software, and
you are welcome to redistribute it under certain conditions.  See the
GNU General Public License version 2 for details.

chronyc> activity
200 OK
4 sources online
0 sources offline
0 sources doing burst (return to online)
0 sources doing burst (return to offline)
0 sources with unknown address
chronyc> quit
```