### PR TITLE
Require go.12 in module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
+go 1.12
+
 module github.com/SUSE/caaspctl
 
 require (


### PR DESCRIPTION
avoid checksum errors that could be present and require minimal golang
version for fixing it. see (https://github.com/golang/go/issues/29278)

IF we don't have this we will have some issues with the `go.sum` checksum

# info:

On the OBS side, i dunno if this can cause issue I don' think
