### PR TITLE
ci: Don't wait for exit code from reboot command

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -90,7 +90,7 @@ resource "null_resource" "master_wait_cloudinit" {
   provisioner "remote-exec" {
     inline = [
       "cloud-init status --wait > /dev/null",
-      "sudo shutdown -r +0",
+      "sudo reboot&",
     ]
   }
 }

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -102,7 +102,7 @@ resource "null_resource" "worker_wait_cloudinit" {
   provisioner "remote-exec" {
     inline = [
       "cloud-init status --wait > /dev/null",
-      "sudo shutdown -r +0",
+      "sudo reboot&",
     ]
   }
 }


### PR DESCRIPTION
## Why is this PR needed?

It looks like provisioner waits for exit code from shutdown command and fails.
Sometimes reboot is performed too fast and provisioner fails.

I did 3 test passes locally, seems like it fixes the issue.

Fixes #
```
null_resource.worker_wait_cloudinit (remote-exec): Shutdown scheduled for Wed 2019-05-22 10:57:31 UTC, use 'shutdown -c' to cancel.
null_resource.worker_wait_cloudinit: Creation complete after 2m18s (ID: 1185499403880775947)

Error: Error applying plan:

1 error(s) occurred:

* null_resource.master_wait_cloudinit: error executing "/tmp/terraform_1466055993.sh": wait: remote command exited without exit status or exit signal
```

## What does this PR do?

Applies suggestion from https://github.com/hashicorp/terraform/issues/17844#issuecomment-382537989