### PR TITLE
ci: jenkins: Add the handle-pr job

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -8,6 +8,7 @@
         - '{name}-integration'
         - '{name}-code-lint'
         - '{name}-code-author'
+        - '{name}-handle-pr'
 
 - job:
     name: caasp-jobs/caasp-jjb


### PR DESCRIPTION
We need to add the handle-pr job to the existing list of jobs in
order to activate it to the CI.