### PR TITLE
ci: jenkins: integration-template: Fix filtering for CI testing branches

### DIFF
--- a/ci/jenkins/templates/integration-template.yaml
+++ b/ci/jenkins/templates/integration-template.yaml
@@ -15,4 +15,4 @@
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
-          head-filter-regex: ^(master|release\-\d\.\d|PR\-\d+|ci-merge-pr-\d+)$
+          head-filter-regex: ^(master|release\-\d\.\d|PR\-\d+|ci\-test\-pr\-\d+)$


### PR DESCRIPTION
We need to escape the dashes otherwise they are treated as special
characters and the pipeline fails to see the CI testing branches.