### PR TITLE
ci: jenkins: Fix case where GITHUB_TOKEN is a user:token pair

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/handle-prs.sh
+++ b/ci/jenkins/pipelines/prs/helpers/handle-prs.sh
@@ -33,7 +33,8 @@ setup_credentials() {
     # It's not pretty but it will get the job done
     cat > "${token_file}" <<EOF
 #!/bin/bash
-echo ${GITHUB_TOKEN}
+# If the GITHUB_TOKEN is a user:token pair, then we only want the token part of it
+echo ${GITHUB_TOKEN} | cut -d ':' -f 2
 EOF
     chmod a+x "${token_file}"
     export GIT_ASKPASS="${token_file}"


### PR DESCRIPTION
It's possible that GITHUB_TOKEN is stored as user:token pair but
GIT_ASKPASS expects only the token so we need to filter the user
part of it out.