### PR TITLE
Cleanup the tfvars files for openstack and vmware

### DIFF
--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -1,6 +1,6 @@
 resource "openstack_compute_secgroup_v2" "secgroup_base" {
   name        = "caasp-base-${var.stack_name}"
-  description = "Basic security group for AG"
+  description = "Basic security group"
 
   rule {
     from_port   = -1
@@ -33,7 +33,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
 
 resource "openstack_compute_secgroup_v2" "secgroup_master" {
   name        = "caasp-master-${var.stack_name}"
-  description = "AG security group for masters"
+  description = "security group for masters"
 
   rule {
     from_port   = 2380
@@ -73,7 +73,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
 
 resource "openstack_compute_secgroup_v2" "secgroup_worker" {
   name        = "caasp-worker-${var.stack_name}"
-  description = "AG security group for workers"
+  description = "security group for workers"
 
   rule {
     from_port   = 80
@@ -141,7 +141,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
 
 resource "openstack_compute_secgroup_v2" "secgroup_master_lb" {
   name        = "caasp-master-lb-${var.stack_name}"
-  description = "AG security group for master load balancers"
+  description = "security group for master load balancers"
 
   rule {
     from_port   = 6443

--- a/ci/infra/openstack/terraform.tfvars.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.ci.example
@@ -1,14 +1,24 @@
+# Name of the image to use
+image_name = "SLE-15-SP1-JeOS-GMC"
+
 # Name of the internal network to be created
 internal_net = "testing"
 
-# identifier to make all your resources unique and avoid clashes with other users of this terraform project
+# Name of the external network to be used, the one used to allocate floating IPs
+external_net = "floating"
+
+# Identifier to make all your resources unique and avoid clashes with other users of this terraform project
 stack_name = "testing"
 
-# instance user name
-username = "sles"
+# CIDR of the subnet for the internal network
+subnet_cidr = "172.28.0.0/24"
 
-# define which image to use
-image_name = "SLE-15-SP1-JeOS-GMC"
+# DNS servers for the nodes
+"dns_nameservers" = [
+    "172.28.0.2",
+    "8.8.8.8",
+    "8.8.8.4"
+]
 
 # Number of master nodes
 masters = 1
@@ -16,7 +26,30 @@ masters = 1
 # Number of worker nodes
 workers = 2
 
-# define the repositories to use
+# Size of the master nodes
+master_size = "m1.medium"
+
+# Size of the worker nodes
+worker_size = "m1.medium"
+
+# Attach persistent volumes to workers
+workers_vol_enabled = 0
+
+# Size of the worker volumes in GB
+workers_vol_size = 5
+
+# Name of DNS domain
+dnsdomain = "testing.qa.caasp.suse.net"
+
+# Set DNS Entry (0 is false, 1 is true)
+dnsentry = 0
+
+# Username for the cluster nodes
+username = "sles"
+
+# Password for the cluster nodes
+password = "linux"
+
 repositories = [
   {
     caasp_40_devel_sle15sp1 = "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/"
@@ -41,10 +74,10 @@ repositories = [
 packages = [
   "kernel-default",
   "-kernel-default-base",
-  "ca-certificates-suse",
   "kubernetes-kubeadm",
   "kubernetes-kubelet",
-  "kubernetes-client"
+  "kubernetes-client",
+  "ca-certificates-suse",
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -1,20 +1,72 @@
+# Name of the image to use
+# EXAMPLE:
+# image_name = "SLE-15-SP1-JeOS-GMC"
+image_name = ""
+
 # Name of the internal network to be created
-internal_net = "testing"
+# EXAMPLE:
+# internal_net = "testing"
+internal_net = ""
 
-# identifier to make all your resources unique and avoid clashes with other users of this terraform project
-stack_name = "testing"
+# Name of the external network to be used, the one used to allocate floating IPs
+# EXAMPLE:
+# external_net = "floating"
+external_net = ""
 
-# instance user name
-username = "sles"
+# Identifier to make all your resources unique and avoid clashes with other users of this terraform project
+stack_name = "my-caasp-cluster"
 
-# define which image to use
-image_name = "SLE-15-SP1-JeOS-GMC"
+# CIDR of the subnet for the internal network
+# EXAMPLE:
+# subnet_cidr = "172.28.0.0/24"
+subnet_cidr = ""
+
+# DNS servers for the nodes
+# EXAMPLE:
+# "dns_nameservers" = [
+#     "172.28.0.2",
+#     "8.8.8.8"
+# ]
+"dns_nameservers" = []
 
 # Number of master nodes
 masters = 1
 
 # Number of worker nodes
 workers = 2
+
+# Size of the master nodes
+# EXAMPLE:
+# master_size = "m1.medium"
+master_size = ""
+
+# Size of the worker nodes
+# EXAMPLE:
+# worker_size = "m1.medium"
+worker_size = ""
+
+# Attach persistent volumes to workers
+workers_vol_enabled = 0
+
+# Size of the worker volumes in GB
+workers_vol_size = 5
+
+# Name of DNS domain
+# dnsdomain = "my.domain.com"
+dnsdomain = ""
+
+# Set DNS Entry (0 is false, 1 is true)
+dnsentry = 0
+
+# Username for the cluster nodes
+# EXAMPLE:
+# username = "sles"
+username = ""
+
+# Password for the cluster nodes
+# EXAMPLE:
+# password = "linux"
+password = ""
 
 # define the repositories to use
 # EXAMPLE:
@@ -24,6 +76,8 @@ workers = 2
 # ]
 repositories = []
 
+# Minimum required packages. Do not remove them.
+# Feel free to add more packages
 packages = [
   "kernel-default",
   "-kernel-default-base",
@@ -33,6 +87,10 @@ packages = [
 ]
 
 # ssh keys to inject into all the nodes
+# EXAMPLE:
+# authorized_keys = [
+#  "ssh-rsa <key-content>"
+# ]
 authorized_keys = [
   ""
 ]

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -1,40 +1,32 @@
 variable "image_name" {
-  default     = "openSUSE-Leap-15.0-OpenStack.x86_64"
+  default     = ""
   description = "Name of the image to use"
 }
 
 variable "repositories" {
-  type = "list"
-
-  default = []
-
+  type        = "list"
+  default     = []
   description = "Urls of the repositories to mount via cloud-init"
 }
 
 variable "internal_net" {
-  default     = "testing-net"
+  default     = ""
   description = "Name of the internal network to be created"
 }
 
 variable "subnet_cidr" {
-  default     = "172.28.0.0/24"
+  default     = ""
   description = "CIDR of the subnet for the internal network"
 }
 
 variable "dns_nameservers" {
-  type = "list"
-
-  default = [
-    "172.28.0.2",
-    "8.8.8.8",
-    "8.8.8.4",
-  ]
-
+  type        = "list"
+  default     = []
   description = "DNS servers for the nodes"
 }
 
 variable "external_net" {
-  default     = "floating"
+  default     = ""
   description = "Name of the external network to be used, the one used to allocate floating IPs"
 }
 
@@ -54,7 +46,7 @@ variable "worker_size" {
 }
 
 variable "workers" {
-  default     = 1
+  default     = 2
   description = "Number of worker nodes"
 }
 
@@ -69,52 +61,48 @@ variable "workers_vol_size" {
 }
 
 variable "dnsdomain" {
-  default     = "testing.qa.caasp.suse.net"
-  description = "TBD - leftover?"
+  default     = ""
+  description = "Name of DNS domain"
 }
 
 variable "dnsentry" {
   default     = 0
-  description = "TBD - leftover?"
+  description = "DNS Entry"
 }
 
 variable "stack_name" {
-  default     = "testing"
-  description = "identifier to make all your resources unique and avoid clashes with other users of this terraform project"
+  default     = ""
+  description = "Identifier to make all your resources unique and avoid clashes with other users of this terraform project"
 }
 
 variable "authorized_keys" {
   type        = "list"
   default     = []
-  description = "ssh keys to inject into all the nodes"
+  description = "SSH keys to inject into all the nodes"
 }
 
 variable "ntp_servers" {
   type        = "list"
   default     = []
-  description = "list of ntp servers to configure"
+  description = "List of ntp servers to configure"
 }
 
 variable "packages" {
   type = "list"
 
   default = [
+    "kernel-default",
+    "-kernel-default-base",
     "kubernetes-kubeadm",
     "kubernetes-kubelet",
     "kubernetes-client",
-    "cri-o",
-    "cni-plugins",
-    "-docker",
-    "-containerd",
-    "-docker-runc",
-    "-docker-libnetwork",
   ]
 
   description = "list of additional packages to install"
 }
 
 variable "username" {
-  default     = "opensuse"
+  default     = "sles"
   description = "Username for the cluster nodes"
 }
 

--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -59,7 +59,7 @@ Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable
 `vsphere_datacenter` - Provide the datacenter to use on the vSphere server
 `vsphere_network` - Provide the network to use on the vSphere server - this network must be able to access the ntp servers and the nodes must be able to reach each other
 `vsphere_resource_ppol` - Provide the resource pool the machines will be running in
-`template_name` - The template name the machines will be spawned from
+`template_name` - The template name the machines will be copied from
 `stack_name` - A prefix that all of the booted machines will use
 `authorized_keys` - A list of ssh public keys that will be installed on all nodes
 `repositories` - Additional repositories that will be added on all nodes

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -1,23 +1,47 @@
-vsphere_datastore = "3PAR"
-vsphere_datacenter = "PROVO"
-vsphere_network = "VM Network"
-vsphere_resource_pool = "CaaSP_RP"
-template_name = "SLES15-SP1-JeOS-cloud-init"
+# datastore to use on the vSphere server
+# EXAMPLE:
+# vsphere_datastore = "STORAGE-0"
+vsphere_datastore = ""
 
+# datacenter to use on the vSphere server
+# EXAMPLE:
+# vsphere_datacenter = "DATACENTER"
+vsphere_datacenter = ""
+
+# network to use on the vSphere server
+# EXAMPLE:
+# vsphere_network = "VM Network"
+vsphere_network = ""
+
+# resource pool the machines will be running in
+# EXAMPLE:
+# vsphere_resource_pool = "CaaSP_RP"
+vsphere_resource_pool = ""
+
+# template name the machines will be copied from
+# EXAMPLE:
+# template_name = "SLES15-SP1-cloud-init"
+template_name = ""
+
+# prefix that all of the booted machines will use
 # IMPORTANT, please enter unique identifier bellow as value of stack_name variable to not interfere with other deployments
 stack_name = "caasp-v4"
 
-# ssh keys to inject into all the nodes
-authorized_keys = [
-  "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf Unsafe Shared Key"
-]
+# Number of master nodes
+masters = 1
 
-workers = 3
-masters = 3
-load-balancers = 1
+# Number of worker nodes
+workers = 2
 
-# IMPORTANT: Replace these ntp servers with ones from your infrastructure
-ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]
+# Username for the cluster nodes
+# EXAMPLE:
+# username = "sles"
+username = ""
+
+# Password for the cluster nodes
+# EXAMPLE:
+# password = "linux"
+password = ""
 
 # define the repositories to use
 # EXAMPLE:
@@ -25,13 +49,24 @@ ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.
 #   { repository1 = "http://example.my.repo.com/repository1/" },
 #   { repository2 = "http://example.my.repo.com/repository2/" }
 # ]
-repositories = [
-]
+repositories = []
 
+# Minimum required packages. Do not remove them.
+# Feel free to add more packages
 packages = [
     "kubernetes-kubeadm",
     "kubernetes-kubelet",
     "kubernetes-client",
     "cri-o",
-    "cni-plugins",
+    "cni-plugins"
 ]
+
+# ssh keys to inject into all the nodes
+# EXAMPLE: 
+# authorized_keys = [
+#   "ssh-rsa <key-content>"
+# ]
+authorized_keys = []
+
+# IMPORTANT: Replace these ntp servers with ones from your infrastructure
+ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]


### PR DESCRIPTION
The default values are now empty and examples are provided as comments.

Remove infrastructure specific default values from variables.tf and move
to terraform.tfvars.ci.example.

## Why is this PR needed?

Right now the example file is pre-filled with internal-use values, which can provide a false sense of correctness to the end user. Instead leaving them blank makes it more apparent that they should be filled. Now both openstack and vmware example are aligned.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1135944


## What does this PR do?

When using this template all the values must be filled explicitly by hand and just copying the file and adjusting one or two values will no longer work.

## Anything else a reviewer needs to know?

