### PR TITLE
Remove typo and shorten line length in vmware tfvars

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -24,7 +24,8 @@ vsphere_resource_pool = ""
 template_name = ""
 
 # prefix that all of the booted machines will use
-# IMPORTANT, please enter unique identifier bellow as value of stack_name variable to not interfere with other deployments
+# IMPORTANT, please enter unique identifier below as value of 
+# stack_name variable to not interfere with other deployments
 stack_name = "caasp-v4"
 
 # Number of master nodes


### PR DESCRIPTION
## Why is this PR needed?

The comment line in the file would overflow the typical documentation page width and looks ugly. It also was hard to read and contained a typo (below has only one l).

## What does this PR do?

Changes the offending line to be shorter and not contain the typo.

## Anything else a reviewer needs to know?

No