### PR TITLE
ci: jenkins: handle-prs: Merge the 'clean' and 'behind' states

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/handle-prs.sh
+++ b/ci/jenkins/pipelines/prs/helpers/handle-prs.sh
@@ -214,13 +214,8 @@ for pr_info in $(curl -s -X GET -H "Content-Type: application/json" -d '{"state"
     # blocked: The PR either failed the CI tests or it does not have enough approvals
     # dirty: The PR has conflicts that need manual resolving
     case ${merge_status} in
-        clean)
-            echo "PR-${pr} is now being merged..."
-            merge_pr ${pr}
-            need_sleep 10
-            ;;
-        behind)
-            echo "PR-${pr} is outdated. Rebasing..."
+        behind|clean)
+            echo "PR-${pr} is now being rebased and merged..."
             ci_update_pr ${pr} ${base_ref}
             need_sleep 10
             ;;


### PR DESCRIPTION
Now that the 'PR needs to be rebased' restriction has been removed from
GitHub, every approved PR is reported as 'clean' so we do not actually
test it against the last master. As such, we should merge the previously
reported 'behind' state with the 'clean' one to ensure that we run the
PR against the latest master before we actually merge it.