### PR TITLE
Improve CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,20 @@
 # Contributing to skuba (formerly caaspctl)
 
-The following is a set of guidelines for contributing to this project, hosted by [SUSE](https://github.com/suse/caaspctl). 
-If you have a suggestion to these guidelines feel free to propose changes in a pull request. 
+The following is a set of guidelines for contributing to this project, hosted by [SUSE](https://github.com/suse/caaspctl).
+If you have a suggestion to these guidelines feel free to propose changes in a pull request.
 
 
 ## Pull requests
 
-Contributors: 
-* Adhere to the PR template. Fill out as many sections as possible with as much detail as possible. 
+Contributors:
+* Adhere to the PR template. Fill out as many sections as possible with as much detail as possible.
 * Adhere to the style guide as closely as possible, where a bot cannot do it for you.
 * The PR is ready for review only when the CI is green. Do not ask for people to review your code if the CI is failing.
 * If CI is not passing, or you need to make more improvements than expected, please add the wip label.
 * Once the CI is green, feel free to assign specific reviewers to your PR to signal it is ready.
 
-Maintainers: 
-* Devote time to regular code review and make your reviews impactful. Look at the big picture, don't get hung up on style alone. 
+Maintainers:
+* Devote time to regular code review and make your reviews impactful. Look at the big picture, don't get hung up on style alone.
 * Veto only when there's is something really problematic, otherwise just comment. Otherwise you are forcing a new round of reviews including a new CI run.
 
 
@@ -22,13 +22,16 @@ Maintainers:
 
 ### git commit messages
 
-This list is not comprehensive, meaning if you want to include more detail than required that is fine as long as you meet these guidelines first. 
+This list is not comprehensive, meaning if you want to include more detail than required that is fine as long as you meet these guidelines first.
 
 * Title
   * Always start with an upper-case letter
   * Do not put a dot (period) at the end
   * Use imperative verbs
   * Maximum characters: 50
+  * Tracking issues from Bugzilla
+    * Add `(bsc#123456)` as part of the title
+
 * Body
   * Start sentences with upper-case letter and finish with dot (period).
   * Maximum characters per line is 72
@@ -37,12 +40,7 @@ This list is not comprehensive, meaning if you want to include more detail than 
   * Do not explain how unless the change is sufficiently large and needs further explanation
     * Tracking issues from Github:
       * __Do not track references (ID/URLs) to in the commit message__ but on the web-ui (yes you are forced to open your browser)
-    * Tracking issues from Bugzilla
-      * Add `Fixes bsc#123456` as part of the body
-
 
 ## Go style
 
-This will be checked automatically by our CI linter bot. 
-
-
+This will be checked automatically by our CI linter bot.


### PR DESCRIPTION
Instead of adding the bugzilla IDs in body message we should take care
to include them in the commit title. We mostly use commit titles to
create the change log between releases, thus if we want to get bugfix
traces automated in OBS the bugzilla ID should be included in the
commit title.

## Why is this PR needed?

This is just small fix to align the usage of bugzilla IDs with the way we create the change log for releases.

## What does this PR do?

Advice contributors to include bugzilla issues IDs (if any) in the commit title rather than (or in addition to) the commit message body.

## Anything else a reviewer needs to know?

No

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->