### PR TITLE
Add the terraform templates copying to the specfile.

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -63,13 +63,45 @@ make %{?_smp_mflags} %{caasp_build_environment}
 make %{?_smp_mflags} docs
 
 %install
+# Copy openstack terraform templates
+install -d -m 0755 %{buildroot}/%{_datadir}/caasp/terraform/openstack
+install -d -m 0755 ci/infra/openstack/cloud-init %{buildroot}/%{_datadir}/caasp/terraform/openstack/cloud-init
+for file in ci/infra/openstack/*.*; do
+  # Do not copy file with only internal information
+  if [[ $file =~ terraform.tfvars.ci.example$ ]]; then
+      continue
+  fi
+  install -p -m 0644 $file %{buildroot}/%{_datadir}/caasp/terraform/openstack/
+done
+for file in ci/infra/openstack/cloud-init/*.*; do
+  install -p -m 0644 $file %{buildroot}/%{_datadir}/caasp/terraform/openstack/cloud-init
+done
+
+# Copy vmware terraform templates
+install -d -m 0755 %{buildroot}/%{_datadir}/caasp/terraform/vmware
+install -d -m 0755 ci/infra/vmware/cloud-init %{buildroot}/%{_datadir}/caasp/terraform/vmware/cloud-init
+for file in ci/infra/vmware/*.*; do
+  # Load balancer is not supported by us, so the code will be stripped.
+  if [[ $file =~ lb-instance.tf$ ]]; then
+      continue
+  fi
+  install -p -m 0644 $file %{buildroot}/%{_datadir}/caasp/terraform/vmware/
+done
+for file in ci/infra/vmware/cloud-init/*.*; do
+  # Load balancer is not supported by us, so the code will be stripped.
+  if [[ $file =~ lb.tpl$ ]]; then
+      continue
+  fi
+  install -p -m 0644 $file %{buildroot}/%{_datadir}/caasp/terraform/vmware/cloud-init
+done
+
 cd $HOME/go/bin
 install -D -m 0755 skuba %{buildroot}/%{_bindir}/skuba
 install -D -m 0755 kubectl-caasp %{buildroot}/%{_bindir}/kubectl-caasp
 
 # Install docs
 for file in $HOME/go/src/%{go_project}/docs/man/*.1; do
- install -D -m 0644 $file "%{buildroot}/%{_mandir}/man1/$(basename $file)"
+  install -D -m 0644 $file "%{buildroot}/%{_mandir}/man1/$(basename $file)"
 done
 
 %files -n kubectl-caasp
@@ -83,5 +115,12 @@ done
 %{_mandir}/man1/skuba*
 # License
 %license LICENSE.md
+# Terraform files
+%dir %{_datadir}/caasp/
+%dir %{_datadir}/caasp/terraform/
+%{_datadir}/caasp/terraform/openstack
+%{_datadir}/caasp/terraform/openstack/cloud-init
+%{_datadir}/caasp/terraform/vmware
+%{_datadir}/caasp/terraform/vmware/cloud-init
 
 %changelog


### PR DESCRIPTION
- Copies the `openstack` terraform files except `ci` tfvars
- Copies the `vmware` terraform files except `load-balancer` files

## Why is this PR needed?

Updates the specfile template to include the copying of the terraform templates.

Fixes bsc#1136218