### PR TITLE
Replace password with key-based authentication

### DIFF
--- a/ci/infra/openstack/README.md
+++ b/ci/infra/openstack/README.md
@@ -30,8 +30,12 @@ terraform apply
 It is important to have your public ssh key within the `authorized_keys`,
 this is done by `cloud-init` through a terraform variable called `authorized_keys`.
 
-All the instances have a `root` and a `opensuse` user. The `opensuse` user can
+All the instances have a `root` and the user of your choice. The normal user user can
 perform `sudo` without specifying a password.
+
+Neither root nor the normal user will have password. Both `terraform` and `skuba`
+are using SSH key-based authentication. You can always set a password after the
+creation of the machines using `passwd` (for normal user) or `sudo passwd` (for root)
 
 ## Load balancer
 

--- a/ci/infra/openstack/cloud-init/common.tpl
+++ b/ci/infra/openstack/cloud-init/common.tpl
@@ -6,15 +6,18 @@ locale: en_GB.UTF-8
 # set timezone
 timezone: Etc/UTC
 
-# set root password
-chpasswd:
-  list: |
-    root:linux
-    ${username}:${password}
-  expire: False
+# Add groups to the system
+groups:
+  - users
 
-ssh_authorized_keys:
-${authorized_keys}
+# Add users to the system (users are added after groups are added)
+users:
+  - name: ${username}
+    groups: users
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: false
+    ssh-authorized-keys:
+      ${authorized_keys}
 
 ntp:
   enabled: true

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -44,7 +44,6 @@ data "template_file" "master-cloud-init" {
     register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
     commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
     username        = "${var.username}"
-    password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
@@ -88,10 +87,9 @@ resource "null_resource" "master_wait_cloudinit" {
   count = "${var.masters}"
 
   connection {
-    host     = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
-    type     = "ssh"
+    host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
+    user = "${var.username}"
+    type = "ssh"
   }
 
   depends_on = ["openstack_compute_instance_v2.master"]

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -63,11 +63,6 @@ dnsentry = 0
 # username = "sles"
 username = ""
 
-# Password for the cluster nodes
-# EXAMPLE:
-# password = "linux"
-password = ""
-
 # define the repositories to use
 # EXAMPLE:
 # repositories = {

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -33,7 +33,9 @@
         "ca-certificates-suse",
         "patterns-caasp-Node"
     ],
-    "authorized_keys": [],
+    "authorized_keys": [
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf Unsafe Shared Key"
+    ],
     "ntp_servers": [
         "0.novell.pool.ntp.org",
         "1.novell.pool.ntp.org",

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -104,11 +104,6 @@ variable "username" {
   description = "Username for the cluster nodes"
 }
 
-variable "password" {
-  default     = "linux"
-  description = "Password for the cluster nodes"
-}
-
 variable "caasp_registry_code" {
   default     = ""
   description = "SUSE CaaSP Product Registration Code"

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -44,7 +44,6 @@ data "template_file" "worker-cloud-init" {
     register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
     commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
     username        = "${var.username}"
-    password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
@@ -100,10 +99,9 @@ resource "null_resource" "worker_wait_cloudinit" {
   count = "${var.workers}"
 
   connection {
-    host     = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
-    type     = "ssh"
+    host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
+    user = "${var.username}"
+    type = "ssh"
   }
 
   depends_on = ["openstack_compute_instance_v2.worker"]


### PR DESCRIPTION
This PR is addressing the security aspect of creating machines
using Terraform and also connecting into them later on using
skuba. The preferred method is to avoid using any pre-configured
password no matter if they can be hashed or not. It is listed in
the cloud-init documentation.

Please note: while the use of a hashed password is better than
plain text, the use of this feature is not ideal. Also,
using a high number of salting rounds will help, but it should
not be relied upon.

To highlight this risk, running John the Ripper against the
example hash above, with a readily available wordlist, revealed
the true password in 12 seconds on a i7-2620QM.

In other words, this feature is a potential security risk and is
provided for your convenience only. If you do not fully trust the
medium over which your cloud-config will be transmitted, then you
should use SSH authentication only.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->