### PR TITLE
AutoYaST improvements

### DIFF
--- a/ci/infra/bare-metal/autoyast.xml
+++ b/ci/infra/bare-metal/autoyast.xml
@@ -17,6 +17,20 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
 ]]>
           </source>
       </script>
+      <!-- Workaround for bsc#1136861 -->
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <filename>add_ntp_server.sh</filename>
+        <interpreter>shell</interpreter>
+        <source>
+<![CDATA[
+#!/bin/sh
+# INFO: You may replace NTPPOOL value bellow with NTP server pool from your infrastructure
+NTPPOOL="0.novell.pool.ntp.org"
+sed -i "s/^! pool [^ ]*/pool ${NTPPOOL}/" /etc/chrony.conf
+]]>
+        </source>
+      </script>
     </chroot-scripts>
   </scripts>
   
@@ -129,13 +143,26 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
     </routing>
   </networking>
 
+  <!-- configure ntp client -->
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <!-- replace ntp server address value bellow with one from your infrastructure -->
+        <address>0.novell.pool.ntp.org</address>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">true</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>systemd</ntp_sync>
+  </ntp-client>
+
   <!-- install required packages -->
   <software>
     <image/>
     <products config:type="list">
       <product>SLES</product>
     </products>
-    <install_recommended config:type="boolean">false</install_recommended>
     <instsource/>
     <patterns config:type="list">
       <pattern>base</pattern>    
@@ -154,6 +181,7 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
       </disable>
       <enable config:type="list">
         <service>sshd</service>
+        <service>chronyd</service>
       </enable>
     </services>
   </services-manager>
@@ -179,8 +207,8 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
     <install_updates config:type="boolean">true</install_updates>
-    <email>[email]</email>
-    <reg_code>[sles-reg-code]</reg_code>
+    <email><!-- replace this comment with an email address used for registration --></email>
+    <reg_code><!-- replace this comment with a CaaSP registration code --></reg_code>
     <slp_discovery config:type="boolean">false</slp_discovery>
     <addons config:type="list">
       <addon>
@@ -192,7 +220,7 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
         <name>caasp</name>
         <version>4.0</version>
         <arch>x86_64</arch>
-        <reg_code>[caasp-reg-code]</reg_code>
+        <reg_code><!-- replace this comment with a CaaSP registration code --></reg_code>
       </addon>
     </addons>
   </suse_register>


### PR DESCRIPTION
## Why is this PR needed?

The initial commit https://github.com/SUSE/skuba/pull/197 for autoyast was kinda broken mainly due missing packages and missing NTP configuration and few more details (but it got fixed in meantime somehow).

This commit is addressing issues from https://github.com/SUSE/skuba/issues/279

Anyway I found out that NTP part in autoyast is broken, see https://bugzilla.suse.com/show_bug.cgi?id=1136861, so new NTP block is not taken into account - the issue is solved by another `<script/>` block

### Fixes
* enabled chronyd service and provided NTP configuration which should work once https://bugzilla.suse.com/show_bug.cgi?id=1136861 will be fixed (the profile is valid and I could deploy the machine but chronyd is not configured to use provided ntp servers)
* unifying of placeholders for regcodes, email
* uses CaaSP reg. code for SLES product

I tested on BIOS machine as well as on EFI on libvirt KVM with `ovmf-x86_64-ms-code.bin` fw with SecureBoot Enabled.