### PR TITLE
ci: jenkins: Add some sensible job timeouts

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -16,6 +16,10 @@
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30
+    wrappers:
+      - timeout:
+          timeout: 10
+          fail: true
     triggers:
       - timed: 'H * * * *'
     pipeline-scm:

--- a/ci/jenkins/templates/code-author.yaml
+++ b/ci/jenkins/templates/code-author.yaml
@@ -5,6 +5,10 @@
     number-to-keep: 30
     days-to-keep: 30
     script-path: ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
+    wrappers:
+      - timeout:
+          timeout: 10
+          fail: true
     scm:
       - github:
           repo: '{repo-name}'

--- a/ci/jenkins/templates/code-lint.yaml
+++ b/ci/jenkins/templates/code-lint.yaml
@@ -5,6 +5,10 @@
     number-to-keep: 30
     days-to-keep: 30
     script-path: ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
+    wrappers:
+      - timeout:
+          timeout: 10
+          fail: true
     scm:
       - github:
           repo: '{repo-name}'

--- a/ci/jenkins/templates/integration-template.yaml
+++ b/ci/jenkins/templates/integration-template.yaml
@@ -5,6 +5,10 @@
     number-to-keep: 30
     days-to-keep: 30
     script-path: ci/jenkins/pipelines/prs/skuba-integration.Jenkinsfile
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
     scm:
       - github:
           repo: '{repo-name}'

--- a/ci/jenkins/templates/jjb-validation.yaml
+++ b/ci/jenkins/templates/jjb-validation.yaml
@@ -5,6 +5,10 @@
     number-to-keep: 30
     days-to-keep: 30
     script-path: ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
+    wrappers:
+      - timeout:
+          timeout: 10
+          fail: true
     scm:
       - github:
           repo: '{repo-name}'

--- a/ci/jenkins/templates/nightly-template.yaml
+++ b/ci/jenkins/templates/nightly-template.yaml
@@ -4,6 +4,10 @@
     number-to-keep: 30
     days-to-keep: 30
     branch: master
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
     triggers:
         - timed: 'H H(3-5) * * *'
     parameters:


### PR DESCRIPTION
Add some sensible job timeouts to each of the current job templates
to avoid them run forever in case something goes wrong on the CI side.