### PR TITLE
Added required env variable

### DIFF
--- a/ci/jenkins/pipelines/skuba-handle-pr.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-handle-pr.Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
        GITHUB_TOKEN = credentials('github-token')
        JENKINS_JOB_CONFIG = credentials('jenkins-job-config')
        PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
+       REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
    }
 
    stages {


### PR DESCRIPTION
## Why is this PR needed?

REQUESTS_CA_BUNDLE is needed for the jenkins server to be trusted

## What does this PR do?

sets the REQUESTS_CA_BUNDLE env var

## Anything else a reviewer needs to know?
