### PR TITLE
replace explicit package list with pattern

### DIFF
--- a/ci/infra/aws/cloud-init/common.tpl
+++ b/ci/infra/aws/cloud-init/common.tpl
@@ -27,13 +27,7 @@ ${authorized_keys}
 # cloud image because they conflict with the kubic- ones that are pulled by
 # the kubernetes packages
 #packages:
-#  - kubernetes-kubeadm
-#  - kubernetes-kubelet
-#  - kubectl
-#  - "-docker"
-#  - "-containerd"
-#  - "-docker-runc"
-#  - "-docker-libnetwork"
+#  - patterns-caasp-Node
 
 # need to resort to that because something is messing up the module
 # order and actication on EC2. I've already reached out to Robert
@@ -41,7 +35,7 @@ ${authorized_keys}
 runcmd:
   - /usr/bin/zypper ar -G ${repo_baseurl} caasp
   - /usr/bin/zypper ref
-  - /usr/bin/zypper in -y kubernetes-kubeadm kubernetes-kubelet kubernetes-client cri-o cni-plugins -docker -containerd -docker-runc -docker-libnetwork 
+  - /usr/bin/zypper in -y patterns-caasp-Node
   - /usr/bin/sed -i -e 's/btrfs/overlay2/g' /etc/crio/crio.conf
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/libvirt/terraform.tfvars.sles.example
+++ b/ci/infra/libvirt/terraform.tfvars.sles.example
@@ -39,9 +39,7 @@ repositories = [
 # Additional packages that you may want to install in the initialization process.
 packages = [
   "ca-certificates-suse", # Required for registry.suse.de
-  "kubernetes-kubeadm",
-  "kubernetes-kubelet",
-  "kubernetes-client"
+  "patterns-caasp-Node"
 ]
 
 # Add your key here as you would do for the `~/.ssh/authorized_keys` file. They

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -108,15 +108,7 @@ variable "packages" {
   type = "list"
 
   default = [
-    "kubernetes-kubeadm",
-    "kubernetes-kubelet",
-    "kubernetes-client",
-    "cri-o",
-    "cni-plugins",
-    "-docker",
-    "-containerd",
-    "-docker-runc",
-    "-docker-libnetwork",
+    "patterns-caasp-Node",
   ]
 
   description = "list of additional packages to install"

--- a/ci/infra/openstack/terraform.tfvars.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.ci.example
@@ -74,11 +74,8 @@ repositories = [
 packages = [
   "kernel-default",
   "-kernel-default-base",
-  "kubernetes-kubeadm",
-  "kubernetes-kubelet",
-  "kubernetes-client",
   "ca-certificates-suse",
-  "skuba-update",
+  "patterns-caasp-Node",
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -81,10 +81,7 @@ repositories = []
 packages = [
   "kernel-default",
   "-kernel-default-base",
-  "kubernetes-kubeadm",
-  "kubernetes-kubelet",
-  "kubernetes-client",
-  "skuba-update",
+  "patterns-caasp-Node"
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -93,10 +93,7 @@ variable "packages" {
   default = [
     "kernel-default",
     "-kernel-default-base",
-    "kubernetes-kubeadm",
-    "kubernetes-kubelet",
-    "kubernetes-client",
-    "skuba-update",
+    "patterns-caasp-Node",
   ]
 
   description = "list of additional packages to install"

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -54,12 +54,7 @@ repositories = []
 # Minimum required packages. Do not remove them.
 # Feel free to add more packages
 packages = [
-    "kubernetes-kubeadm",
-    "kubernetes-kubelet",
-    "kubernetes-client",
-    "cri-o",
-    "cni-plugins",
-    "skuba-update"
+  "patterns-caasp-Node"
 ]
 
 # ssh keys to inject into all the nodes


### PR DESCRIPTION
the upside is that we'll only have to change once central place where to
add/remove dependent packages

Signed-off-by: Maximilian Meister <mmeister@suse.de>

## Why is this PR needed?

reduce duplication in the package lists

## What does this PR do?

implicitly get the package list from the pattern

## Anything else a reviewer needs to know?

* the pattern doesn't exist e.g. on opensuse leap
* the PR would need to be tested on all platforms