### PR TITLE
Moved .travis.yml from skuba-update to the root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - pip install --upgrade pip
   - pip install -r dev-requirements.txt
 script:
-  - tox
+  - cd skuba-update && tox


### PR DESCRIPTION
## Why is this PR needed?

We need to bring CI into the `skuba-update` component. We already had it with Travis when `skuba-update` was being developed in a separate repository, but we lost this capability when we moved the repo into the `skuba-update` directory. This PR adds a CI to this component.

## What does this PR do?

This PR moves the .travis.yml file that we had in the skuba-update directory into the root of the project. This does not bring any conflicts because we were testing the rest of skuba only in Jenkins.

## Anything else a reviewer needs to know?

We should enable Travis CI in order to fully see whether this works or not. This same configuration file worked fine back when `skuba-update` was in a different repository, so it should work here as well.