### PR TITLE
add a nightly pipeline to run skuba-update os tests

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -6,6 +6,7 @@
     platform: openstack
     jobs:
         - '{name}-nightly'
+        - '{name}-update-nightly'
         - '{name}-integration'
         - '{name}-update-integration'
         - '{name}-code-lint'

--- a/ci/jenkins/pipelines/skuba-update-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-update-nightly.Jenkinsfile
@@ -1,0 +1,28 @@
+/**
+ * This pipeline verifies for the basic skuba-update os tests
+ */
+
+pipeline {
+   agent { node { label 'caasp-team-private' } }
+
+   environment {
+        OPENRC = credentials('ecp-openrc')
+        GITHUB_TOKEN = credentials('github-token')
+        ENV_FILE = credentials('vmware-env')
+   }
+
+   stages {
+        stage('skuba-update SUSE OS Tests') { steps {
+            sh(script: "make -f skuba/skuba-update/test/os/suse/Makefile test", label: 'skuba-update SUSE OS Tests')
+        } }
+   }
+   post {
+       cleanup {
+            dir("${WORKSPACE}") {
+                sh(script: 'sudo rm -rf skuba/skuba-update/build skuba/skuba-update/skuba_update.egg-info', label: 'Remove python artifacts created by root')
+                sh(script: 'sudo rm -rf skuba/skuba-update/test/os/suse/artifacts', label: 'Remove test artifacts created by root')
+                deleteDir()
+            }
+        }
+    }
+}

--- a/ci/jenkins/templates/update-nightly-template.yaml
+++ b/ci/jenkins/templates/update-nightly-template.yaml
@@ -1,0 +1,32 @@
+- job-template:
+    name: '{name}-update-nightly'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    branch: master
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
+    triggers:
+        - timed: 'H H(3-5) * * *'
+    parameters:
+        - string:
+            name: branch
+            default: '{branch}'
+            description: The branch to checkout
+        - string:
+              name: platform
+              default: '{platform}'
+              description: The platform to perform the tests on
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://github.com/{repo-owner}/{repo-name}.git'
+                credentials-id: '{repo-credentials}'
+                branches:
+                    - '{branch}'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+                basedir: skuba
+        script-path: skuba/ci/jenkins/pipelines/skuba-update-nightly.Jenkinsfile


### PR DESCRIPTION
this ensures that an underlying change in e.g. zypper on sle
is continuously tested on a nightly base

Signed-off-by: Maximilian Meister <mmeister@suse.de>