### PR TITLE
Capitalized all of the nightly params

### DIFF
--- a/ci/jenkins/templates/nightly-template.yaml
+++ b/ci/jenkins/templates/nightly-template.yaml
@@ -12,7 +12,7 @@
         - timed: 'H H(3-5) * * *'
     parameters:
         - string:
-            name: branch
+            name: BRANCH
             default: '{branch}'
             description: The branch to checkout
         - string:

--- a/ci/jenkins/templates/update-nightly-template.yaml
+++ b/ci/jenkins/templates/update-nightly-template.yaml
@@ -12,11 +12,11 @@
         - timed: 'H H(3-5) * * *'
     parameters:
         - string:
-            name: branch
+            name: BRANCH
             default: '{branch}'
             description: The branch to checkout
         - string:
-              name: platform
+              name: PLATFORM
               default: '{platform}'
               description: The platform to perform the tests on
     pipeline-scm:


### PR DESCRIPTION
## Why is this PR needed?

Lower case params were being ignored in the new update nightly pipelines

Fixes #

## What does this PR do?

Capitalizes them

## Anything else a reviewer needs to know?
