### PR TITLE
Added VMware to the config classes

### DIFF
--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -41,6 +41,7 @@ class BaseConfig:
             BaseConfig.Git,
             BaseConfig.Openstack,
             BaseConfig.Skuba,
+            BaseConfig.VMware
         )
 
         #vars get the values from yaml file


### PR DESCRIPTION
## Why is this PR needed?

VMware class wasn't included in the config classes so it was leaving it as a dict

Fixes #

## What does this PR do?

Adds VMware class to the config classes

## Anything else a reviewer needs to know?
