### PR TITLE
Add SUSE CA to allow downloads from registry.suse.de

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.ci.example
@@ -61,7 +61,8 @@ repositories = [
 # Minimum required packages. Do not remove them.
 # Feel free to add more packages
 packages = [
-    "patterns-caasp-Node"
+    "patterns-caasp-Node",
+    "ca-certificates-suse"
 ]
 
 # ssh keys to inject into all the nodes


### PR DESCRIPTION
Signed-off-by: lcavajani <lcavajani@suse.com>

## Why is this PR needed?

Without this, bootstrapping a cluster would fail on downloading the images.