### PR TITLE
Enable ssh-agent in CI

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -47,6 +47,7 @@ class Terraform:
         """ Create and apply terraform plan"""
         print("Init terraform")
         self._check_tf_deployed()
+        self.utils.setup_ssh()
         self.runshellcommandterraform("terraform init")
         self.runshellcommandterraform("terraform version")
         self.generate_tfvars_file()
@@ -130,6 +131,12 @@ class Terraform:
     def runshellcommandterraform(self, cmd, env=None):
         """Running terraform command in {workspace}/ci/infra/{platform}"""
         cwd = self.conf.terraform_dir
+        # Terraform needs PATH and SSH_AUTH_SOCK
+        sock_fn = self.utils.ssh_sock_fn()
+        env = {
+            "SSH_AUTH_SOCK": sock_fn,
+            'PATH': os.environ['PATH']
+        }
         print(Format.alert("$ {} > {}".format(cwd, cmd)))
         subprocess.check_call(cmd, cwd=cwd, shell=True, env=env)
 

--- a/ci/infra/testrunner/tests/tests.py
+++ b/ci/infra/testrunner/tests/tests.py
@@ -14,7 +14,6 @@ class Tests:
     @step
     def bootstrap_environment(self):
         """Bootstrap Environment"""
-        self.utils.setup_ssh()
         self.skuba.cluster_init()
         self.skuba.node_bootstrap()
         self._num_master = 1
@@ -47,7 +46,6 @@ class Tests:
             self.skuba.node_remove(role="worker", nr=self._num_worker)
         except:
             self._num_worker += 1
-
 
     @timeout(600)
     @step

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -103,6 +103,9 @@ class Utils:
                 raise RuntimeError(Format.alert("Cannot run command {}{}\033[0m".format(cmd)))
         return output.decode()
 
+    def ssh_sock_fn(self):
+        return os.path.join(self.conf.workspace, "ssh-agent-sock")
+
     @timeout(60)
     @step
     def setup_ssh(self):
@@ -110,7 +113,7 @@ class Utils:
         self.runshellcommand("chmod 400 " + self.conf.ssh_key_option)
         print("Starting ssh-agent ")
         # use a dedicated agent to minimize stateful components
-        sock_fn = os.path.join(self.conf.workspace, "ssh-agent-sock")
+        sock_fn = self.ssh_sock_fn()
         try:
             self.runshellcommand("pkill -f 'ssh-agent -a {}'".format(sock_fn))
             print("Killed previous instance of ssh-agent")


### PR DESCRIPTION
## Why is this PR needed?

This PR enables the SSH Agent during the terraform apply. If you look at the previous CI runs, it says: `SSH-Agent: False`. After this PR is should be `true`.

## What does this PR do?

This is needed because we are planning to go away from password authentication. This is what is currently used by the CI, thus we need to fix the CI first otherwise the feature will fail to pass the testing automation.

## Anything else a reviewer needs to know?

Before this PR:

```
null_resource.worker_wait_cloudinit[2] (remote-exec): Connecting to remote host via SSH...
null_resource.worker_wait_cloudinit[2] (remote-exec):   Host: 10.86.0.212
null_resource.worker_wait_cloudinit[2] (remote-exec):   User: sles
null_resource.worker_wait_cloudinit[2] (remote-exec):   Password: true
null_resource.worker_wait_cloudinit[2] (remote-exec):   Private key: false
null_resource.worker_wait_cloudinit[2] (remote-exec):   SSH Agent: false
null_resource.worker_wait_cloudinit[2] (remote-exec):   Checking Host Key: false
```

After this PR:

```
null_resource.worker_wait_cloudinit[2] (remote-exec): Connecting to remote host via SSH...
null_resource.worker_wait_cloudinit[2] (remote-exec):   Host: 10.86.0.212
null_resource.worker_wait_cloudinit[2] (remote-exec):   User: sles
null_resource.worker_wait_cloudinit[2] (remote-exec):   Password: true
null_resource.worker_wait_cloudinit[2] (remote-exec):   Private key: false
null_resource.worker_wait_cloudinit[2] (remote-exec):   SSH Agent: true
null_resource.worker_wait_cloudinit[2] (remote-exec):   Checking Host Key: false
```