### PR TITLE
Fixed Authorized keys variable in vmware tfvar 

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.ci.example
@@ -70,7 +70,9 @@ packages = [
 # authorized_keys = [
 #   "ssh-rsa <key-content>"
 # ]
-authorized_keys = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2G7k0zGAjd+0LzhbPcGLkdJrJ/LbLrFxtXe+LPAkrphizfRxdZpSC7Dvr5Vewrkd/kfYObiDc6v23DHxzcilVC2HGLQUNeUer/YE1mL4lnXC1M3cb4eU+vJ/Gyr9XVOOReDRDBCwouaL7IzgYNCsm0O5v2z/w9ugnRLryUY180/oIGeE/aOI1HRh6YOsIn7R3Rv55y8CYSqsbmlHWiDC6iZICZtvYLYmUmCgPX2Fg2eT+aRbAStUcUERm8h246fs1KxywdHHI/6o3E1NNIPIQ0LdzIn5aWvTCd6D511L4rf/k5zbdw/Gql0AygHBR/wnngB5gSDERLKfigzeIlCKf Unsafe Shared Key"]
+authorized_keys = [
+    ""
+]
 
 # IMPORTANT: Replace these ntp servers with ones from your infrastructure
 ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]


### PR DESCRIPTION
## Why is this PR needed?

Authorized keys wasn't formatted correctly in the vmware tfvar. Also the key was being injected so no need to provided it in the file.

Fixes #

## What does this PR do?

Fixes the formatting to match the openstack tfvars

## Anything else a reviewer needs to know?
