### PR TITLE
CODEOWNERS: Add initial codeowners file to facilitate reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# docs: https://help.github.com/en/articles/about-code-owners
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# Instead of maching the individual skuba directories,
+# we can look for *.go files instead.
+*.go @ereslibre @nirmoy
+
+/skuba-update/ @MaximilianMeister @mssola
+
+/ci/ @hwoarang @tdaines42
+/ci/infra/testrunner/ @pablochacin @tdaines42
+
+/docs/ @r0ckarong
+
+/test/ @MalloZup @pablochacin
+
+/tools/ @MalloZup @ereslibre


### PR DESCRIPTION
**New PR opened at #353**

GitHub supports the CODEOWNERS[1] concept to facilitate reviews by
requesting reviews from people who are interested in reviewing
commits in a specific area. We can use that to ensure that each
PR gets an initial number of people to look at it.

[1] https://help.github.com/en/articles/about-code-owners

The initial data was generated by the following command

```
for i in ci skuba-update pkg internal test docs cmd tools; do echo $i; git shortlog -s -n $i | head -n 2; done
```

The list only contains people interested in reviewing stuff. It has no other powers or responsibilities so you can opt-in and opt-out as you wish.