### PR TITLE
Add parameter for terraform plugin dir

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -26,6 +26,7 @@ skuba:        # skuba locations
   srcpath:    # Path to skuba srch project (defaults to `./skuba`)
   binpath     # Path to skuba bin directory (defaults to `<workspace>/go/bin/`)
 terraform:
+  plugin_dir: # Path to directory used for installing providers 
   tfdir:      # Path to the directory with terraform templates (defaults to <skuba.srcpath>/ci/infra/`)
               # under this directory there must be a subdirectory per platform (openstack, vmware, baremetal)
   tfvars:     # name of the tfvars file to be used (defatuls to `terraform.tfvars.ci.example`)

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -49,8 +49,15 @@ class Terraform:
         """ Create and apply terraform plan"""
         print("Init terraform")
         self._check_tf_deployed()
+        
         self.utils.setup_ssh()
-        self._runshellcommandterraform("terraform init")
+
+        init_cmd = "terraform init"
+        if self.conf.terraform.plugin_dir:
+            print("Installing plugins from {}".format(self.conf.terraform.plugin_dir))
+            init_cmd = init_cmd+" -plugin-dir="+self.conf.terraform.plugin_dir
+        self._runshellcommandterraform(init_cmd)
+
         self._runshellcommandterraform("terraform version")
         self._generate_tfvars_file()
         plan_cmd = ("{env_setup};"

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -88,6 +88,7 @@ class BaseConfig:
             super().__init__()
             self.tfdir = None
             self.tfvars = Constant.TERRAFORM_EXAMPLE 
+            self.plugin_dir = None
 
     class Skuba:
         def __init__(self):


### PR DESCRIPTION
## Why is this PR needed?

During cluster bootstrap testrunner executes the `terraform init` command which install the required providers. However, depending on the environment (development, ci, qa) the providers can be located in different locations.

## What does this PR do?

Add a terraform configuration parameter for specifying the directory where the plugins will be loaded from. If not specified, the default plugin search mechanism is used [1]

[1] https://www.terraform.io/docs/commands/init.html#plugin-installation
