### PR TITLE
Removed PLATFORM env variables

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-integration.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-integration.Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         stage('Run end-to-end tests') { steps {
            dir("skuba") {
              sh(script: 'make build-ginkgo', label: 'build ginkgo binary')
-             sh(script: "make setup-ssh && SKUBA_BIN_PATH=\"${WORKSPACE}/go/bin/skuba\" GINKGO_BIN_PATH=\"${WORKSPACE}/skuba/ginkgo\" IP_FROM_TF_STATE=TRUE PLATFORM=openstack make test-e2e", label: "End-to-end tests")
+             sh(script: "make setup-ssh && SKUBA_BIN_PATH=\"${WORKSPACE}/go/bin/skuba\" GINKGO_BIN_PATH=\"${WORKSPACE}/skuba/ginkgo\" IP_FROM_TF_STATE=TRUE make test-e2e", label: "End-to-end tests")
        } } }
     }
     post {

--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
        stage('Run end-to-end tests') { steps {
            dir("skuba") {
              sh(script: 'make build-ginkgo', label: 'build ginkgo binary')
-             sh(script: "make setup-ssh && SKUBA_BIN_PATH=\"${WORKSPACE}/go/bin/skuba\" GINKGO_BIN_PATH=\"${WORKSPACE}/skuba/ginkgo\" IP_FROM_TF_STATE=TRUE PLATFORM=openstack make test-e2e", label: "End-to-end tests")
+             sh(script: "make setup-ssh && SKUBA_BIN_PATH=\"${WORKSPACE}/go/bin/skuba\" GINKGO_BIN_PATH=\"${WORKSPACE}/skuba/ginkgo\" IP_FROM_TF_STATE=TRUE make test-e2e", label: "End-to-end tests")
        } } }
  
    }


### PR DESCRIPTION
## Why is this PR needed?

This is set by the job and doesn't need to be set again was also
messing up the VMware job.

Fixes https://github.com/SUSE/avant-garde/issues/439
## What does this PR do?


## Anything else a reviewer needs to know?
