### PR TITLE
ci: infra: Make openstack subnet and router names configurable

### DIFF
--- a/ci/infra/openstack/network.tf
+++ b/ci/infra/openstack/network.tf
@@ -4,7 +4,7 @@ resource "openstack_networking_network_v2" "network" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet" {
-  name            = "${var.internal_net}-subnet"
+  name            = "${var.internal_subnet}"
   network_id      = "${openstack_networking_network_v2.network.id}"
   cidr            = "${var.subnet_cidr}"
   ip_version      = 4
@@ -16,7 +16,7 @@ data "openstack_networking_network_v2" "external_network" {
 }
 
 resource "openstack_networking_router_v2" "router" {
-  name                = "${var.internal_net}-router"
+  name                = "${var.internal_router}"
   external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
 }
 

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -8,6 +8,16 @@ image_name = ""
 # internal_net = "testing"
 internal_net = ""
 
+# Name of the internal subnet to be created
+# EXAMPLE:
+# internal_subnet = "${var.internal_net}-subnet"
+internal_subnet = "${var.internal_net}-subnet"
+
+# Name of the internal router to be created
+# EXAMPLE:
+# internal_router = "${var.internal_net}-router"
+internal_router = "${var.internal_net}-router"
+
 # Name of the external network to be used, the one used to allocate floating IPs
 # EXAMPLE:
 # external_net = "floating"

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -1,6 +1,8 @@
 {
     "image_name": "SLE-15-SP1-JeOS-GM",
     "internal_net": "testing",
+    "internal_subnet": "testing-subnet",
+    "internal_router": "testing-router",
     "external_net": "floating",
     "stack_name": "testing",
     "subnet_cidr": "172.28.0.0/24",

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -14,6 +14,16 @@ variable "internal_net" {
   description = "Name of the internal network to be created"
 }
 
+variable "internal_subnet" {
+  default     = ""
+  description = "Name of the internal subnet to be created"
+}
+
+variable "internal_router" {
+  default     = ""
+  description = "Name of the internal router to be created"
+}
+
 variable "subnet_cidr" {
   default     = ""
   description = "CIDR of the subnet for the internal network"


### PR DESCRIPTION
The Cloud team wants to integrate the terraform code into existing
infrastructure to deploy CaaSP. But we already have a network stack
deployed (via Heat) and want to reuse the available resources (with
"terraform import ...").
For that, the available resource names (in this case for subnet and
router) must match the names use in terraform. So make these variables
configurable.
