### PR TITLE
CODEOWNERS: Add initial codeowners file to facilitate reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# docs: https://help.github.com/en/articles/about-code-owners
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence.
+
+# Instead of maching the individual skuba directories,
+# we can look for *.go files instead.
+*.go @ereslibre @nirmoy @klaven
+
+/skuba-update/ @davidcassany @mssola
+
+/ci/ @hwoarang @tdaines42
+/ci/infra/testrunner/ @pablochacin @tdaines42
+/ci/packaging/ @davidcassany @MaximilianMeister
+
+/test/ @pablochacin
+
+/tools/ @ereslibre


### PR DESCRIPTION
GitHub supports the CODEOWNERS[1] concept to facilitate reviews by
requesting reviews from people who are interested in reviewing
commits in a specific area. We can use that to ensure that each
PR gets an initial number of people to look at it.

[1] https://help.github.com/en/articles/about-code-owners