### PR TITLE
testrunner: Fix replacement logic for workers and masters

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import subprocess
 from shutil import copyfile
 
@@ -134,10 +135,10 @@ class Terraform:
             elif line.startswith("username"):
                 lines[i] = 'username = "{}"'.format(self.conf.nodeuser)
 
-            elif line.startswith("masters"):
+            elif re.match('^masters\b', line):
                 lines[i] = 'masters = {}'.format(self.conf.master.count)
 
-            elif line.startswith("workers"):
+            elif re.match('^workers\b', line):
                 lines[i] = 'workers = {}'.format(self.conf.worker.count)
 
             elif line.startswith("authorized_keys"):


### PR DESCRIPTION
## Why is this PR needed?

Fixes https://github.com/SUSE/avant-garde/issues/435

## What does this PR do?

Improves the replacement logic for workers and masters so the correct string is being replaced. This is being achieved by using regular expressions instead of hardcoded strings.