### PR TITLE
ci: infra: Fix cloud-init locale

### DIFF
--- a/ci/infra/aws/cloud-init/common.tpl
+++ b/ci/infra/aws/cloud-init/common.tpl
@@ -1,7 +1,7 @@
 #cloud-config
 
 # set locale
-locale: en_GB.UTF-8
+locale: en_US.UTF-8
 
 # set timezone
 timezone: Etc/UTC

--- a/ci/infra/libvirt/cloud-init/lb.cfg.tpl
+++ b/ci/infra/libvirt/cloud-init/lb.cfg.tpl
@@ -1,7 +1,7 @@
 #cloud-config
 
 # set locale
-locale: en_GB.UTF-8
+locale: en_US.UTF-8
 
 # set timezone
 timezone: Etc/UTC

--- a/ci/infra/libvirt/cloud-init/master.cfg.tpl
+++ b/ci/infra/libvirt/cloud-init/master.cfg.tpl
@@ -1,7 +1,7 @@
 #cloud-config
 
 # set locale
-locale: en_GB.UTF-8
+locale: en_US.UTF-8
 
 # set timezone
 timezone: Etc/UTC

--- a/ci/infra/libvirt/cloud-init/worker.cfg.tpl
+++ b/ci/infra/libvirt/cloud-init/worker.cfg.tpl
@@ -1,7 +1,7 @@
 #cloud-config
 
 # set locale
-locale: en_GB.UTF-8
+locale: en_US.UTF-8
 
 # set timezone
 timezone: Etc/UTC

--- a/ci/infra/openstack/cloud-init/common.tpl
+++ b/ci/infra/openstack/cloud-init/common.tpl
@@ -1,7 +1,7 @@
 #cloud-config
 
 # set locale
-locale: en_GB.UTF-8
+locale: en_US.UTF-8
 
 # set timezone
 timezone: Etc/UTC


### PR DESCRIPTION
## Why is this PR needed?

Locale en_GB.UTF-8 cause following problem

```
-bash: warning: setlocale: LC_COLLATE: cannot change locale (en_GB.UTF-8): No such file or directory
-bash: warning: setlocale: LC_CTYPE: cannot change locale (en_GB.UTF-8): No such file or directory
```

This has to be changed to en_US.UTF-8

## What does this PR do?

It changes locale to `en_US.UTF-8` in cloud-init
