### PR TITLE
Adding the --annotate-only flag

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -92,8 +92,7 @@ make %{?_smp_mflags} docs
 
 pushd skuba-update
 python3 setup.py install --root %{buildroot} \
-    --install-script %{_sbindir} \
-    --install-data %{_unitdir}
+    --install-script %{_sbindir}
 popd
 
 #
@@ -150,6 +149,7 @@ ln -sf service %{buildroot}%{_sbindir}/rcskuba-update
 %service_add_pre skuba-update.timer
 
 %post update
+%{fillup_only -n skuba-update}
 %service_add_post skuba-update.timer
 
 %preun update
@@ -169,6 +169,7 @@ ln -sf service %{buildroot}%{_sbindir}/rcskuba-update
 %{_unitdir}/skuba-update.service
 %{_unitdir}/skuba-update.timer
 %{_sbindir}/rcskuba-update
+%{_fillupdir}/sysconfig.skuba-update
 
 %files
 # Binaries

--- a/skuba-update/setup.py
+++ b/skuba-update/setup.py
@@ -16,6 +16,7 @@
 
 from setuptools import setup
 import os
+import sys
 
 def version():
     """Return the version. Pass when VERSION file not found"""
@@ -41,10 +42,15 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache License 2.0',
         'Operating System :: POSIX :: Linux',
-    ], data_files={
-        'skuba_update/skuba-update.timer',
-        'skuba_update/skuba-update.service'
-    }, entry_points = {
+    ], data_files=[
+        (
+            'lib/systemd/system', [
+                'skuba_update/skuba-update.timer',
+                'skuba_update/skuba-update.service'
+            ]
+        ),
+        ('share/fillup-templates', ['skuba_update/sysconfig.skuba-update'])
+    ], entry_points = {
         'console_scripts': [
             'skuba-update = skuba_update.skuba_update:main'
         ]

--- a/skuba-update/skuba_update/skuba-update.service
+++ b/skuba-update/skuba_update/skuba-update.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/sbin/skuba-update
+EnvironmentFile=-/etc/sysconfig/skuba-update
+ExecStart=/usr/sbin/skuba-update $SKUBA_UPDATE_OPTIONS
 IOSchedulingClass=best-effort
 IOSchedulingPriority=7

--- a/skuba-update/skuba_update/skuba_update.py
+++ b/skuba-update/skuba_update/skuba_update.py
@@ -19,6 +19,8 @@ import os
 import subprocess
 import re
 import json
+import argparse
+import pkg_resources
 from collections import namedtuple
 from datetime import datetime
 from pathlib import Path
@@ -41,13 +43,17 @@ REBOOT_REQUIRED_PATH = '/var/run/reboot-required'
 
 # Exit codes as defined by zypper.
 
+ZYPPER_EXIT_INF_UPDATE_NEEDED = 100
+ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED = 101
 ZYPPER_EXIT_INF_REBOOT_NEEDED = 102
 ZYPPER_EXIT_INF_RESTART_NEEDED = 103
 
 # The path to the kubelet config used for running kubectl commands
 KUBECONFIG_PATH = '/etc/kubernetes/kubelet.conf'
 
-# The key for the annotation on the Kubernetes node for disruptive updates.
+# Updates annotation keys on the Kubernetes node.
+KUBE_UPDATES_KEY = 'caasp.suse.com/has-updates'
+KUBE_SECURITY_UPDATES_KEY = 'caasp.suse.com/has-security-updates'
 KUBE_DISRUPTIVE_UPDATES_KEY = 'caasp.suse.com/has-disruptive-updates'
 
 
@@ -56,7 +62,9 @@ def main():
     main-entry point for program.
     """
 
-    # First of all, check that we have the proper zypper version.
+    args = parse_args()
+
+    # Check that we have the proper zypper version.
     if not check_version('zypper', REQUIRED_ZYPPER_VERSION):
         raise Exception('zypper version {0} or higher is required'.format(
             '.'.join([str(x) for x in REQUIRED_ZYPPER_VERSION])
@@ -65,9 +73,39 @@ def main():
     if os.geteuid() != 0:
         raise Exception('root privileges are required to run this tool')
 
-    update()
-    restart_services()
-    annotate_resources()
+    run_zypper_command(['zypper', 'ref', '-s'])
+    if not args.annotate_only:
+        update()
+        restart_services()
+    annotate_updates_available()
+
+
+def parse_args():
+    """
+    Returns the parsed arguments.
+    """
+
+    annotate_only_msg = \
+        'Do not install any update, just annotate there are available updates'
+    version_msg = '%(prog)s {0}'.format(version())
+
+    parser = argparse.ArgumentParser(description='Updates a CaaSP node')
+    parser.add_argument(
+        '--annotate-only', action='store_true', help=annotate_only_msg
+    )
+    parser.add_argument(
+        '--version', action='version', version=version_msg
+    )
+
+    return parser.parse_args()
+
+
+def version():
+    """
+    Returns the version of the current skuba-update
+    """
+
+    return pkg_resources.require('skuba-update')[0].version
 
 
 def update():
@@ -75,10 +113,95 @@ def update():
     Performs an update operation.
     """
 
-    run_zypper_command(['zypper', 'ref', '-s'])
     code = run_zypper_patch()
     if is_restart_needed(code):
         run_zypper_patch()
+
+
+def annotate_updates_available():
+    """
+    Performs a zypper list-patches and annotates the node like so:
+
+      1. If there is at least one update of any kind `has_updates` flag is set.
+      2. If there is at least one security update `has_security_updates` flag
+         is set.
+      3. If there is at least one disruptive update `has_disruptive_updates`
+         flag is set.
+    """
+
+    node_name = node_name_from_machine_id()
+    patch_xml = run_zypper_command(
+        ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+        needsOutput=True
+    ).output
+    annotate(
+        'node', node_name, KUBE_UPDATES_KEY,
+        'yes' if has_updates(patch_xml) else 'no'
+    )
+    annotate(
+        'node', node_name, KUBE_SECURITY_UPDATES_KEY,
+        'yes' if has_security_updates(patch_xml) else 'no'
+    )
+    annotate(
+        'node', node_name, KUBE_DISRUPTIVE_UPDATES_KEY,
+        'yes' if has_disruptive_updates(patch_xml) else 'no'
+    )
+
+
+def get_update_list(patch_xml):
+    """
+    Fetch the update list from the given XML output.
+    """
+
+    try:
+        tree = ElementTree.fromstring(patch_xml)
+    except ElementTree.ParseError:
+        return None
+
+    us = tree.find('update-status')
+    if us is None:
+        return None
+    return us.find('update-list')
+
+
+def has_updates(patch_xml):
+    """
+    Returns true if there are updates available.
+    """
+
+    if get_update_list(patch_xml) is None:
+        return False
+    return True
+
+
+def has_security_updates(patch_xml):
+    """
+    Returns true if there are security updates available.
+    """
+
+    update_list = get_update_list(patch_xml)
+    if update_list is None:
+        return False
+    for update in update_list:
+        attr = update.attrib.get('category', '')
+        if attr == 'security':
+            return True
+    return False
+
+
+def has_disruptive_updates(patch_xml):
+    """
+    Returns true if there are disruptive updates available.
+    """
+
+    update_list = get_update_list(patch_xml)
+    if update_list is None:
+        return False
+    for update in update_list:
+        attr = update.attrib.get('interactive', '')
+        if is_not_false_str(attr):
+            return True
+    return False
 
 
 def restart_services():
@@ -87,21 +210,9 @@ def restart_services():
     restart.
     """
 
-    result = run_command(['zypper', 'ps', '-sss'])
+    result = run_zypper_command(['zypper', 'ps', '-sss'], needsOutput=True)
     for service in result.output.splitlines():
-        run_command(['systemctl', 'restart', service])
-
-
-def annotate_resources():
-    """
-    Annotate all the needed Kubernetes resources for the current conditions.
-    """
-
-    if interruptive_updates_available():
-        annotate(
-            'nodes', node_name_from_machine_id(),
-            KUBE_DISRUPTIVE_UPDATES_KEY, 'yes'
-        )
+        run_command(['systemctl', 'restart', service], needsOutput=False)
 
 
 def is_zypper_error(code):
@@ -110,7 +221,7 @@ def is_zypper_error(code):
     to zypper.
     """
 
-    return code != 0 and code < 100
+    return code != 0 and code < ZYPPER_EXIT_INF_UPDATE_NEEDED
 
 
 def is_restart_needed(code):
@@ -130,66 +241,6 @@ def is_reboot_needed():
     return run_zypper_command(
         ['zypper', 'needs-rebooting']
     ) == ZYPPER_EXIT_INF_REBOOT_NEEDED
-
-
-def interruptive_updates_available():
-    """
-    Returns True if there are interruptive updates available. Otherwise it
-    returns False.
-    """
-
-    res = run_zypper_command(
-        ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
-        True
-    )
-
-    try:
-        tree = ElementTree.fromstring(res.output)
-    except ElementTree.ParseError:
-        return False
-
-    us = tree.find('update-status')
-    if us is None:
-        return False
-    for update in us.find('update-list'):
-        attr = update.attrib.get('interactive', '')
-        if is_not_false_str(attr) and attr != 'reboot':
-            return True
-    return False
-
-
-def is_not_false_str(string):
-    """
-    Returns true if the given string contains a non-falsey value.
-    """
-
-    return string is not None and string != '' and string != 'false'
-
-
-def interruptive_updates_available():
-    """
-    Returns True if there are interruptive updates available. Otherwise it
-    returns False.
-    """
-
-    res = run_zypper_command(
-        ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
-        True
-    )
-
-    try:
-        tree = ElementTree.fromstring(res.output)
-    except ElementTree.ParseError:
-        return False
-
-    us = tree.find('update-status')
-    if us is None:
-        return False
-    for update in us.find('update-list'):
-        attr = update.attrib.get('interactive', '')
-        if is_not_false_str(attr):
-            return True
-    return False
 
 
 def is_not_false_str(string):
@@ -218,7 +269,7 @@ def run_zypper_command(command, needsOutput=False):
     also contains the 'zypper' string. It returns the exit code from zypper.
     """
 
-    process = run_command(command)
+    process = run_command(command, needsOutput)
     if is_zypper_error(process.returncode):
         raise Exception('"{0}" failed'.format(' '.join(command)))
     if needsOutput:
@@ -242,7 +293,7 @@ def run_zypper_patch():
     return code
 
 
-def run_command(command, added_env={}):
+def run_command(command, needsOutput=True, added_env={}):
     """
     Runs the given command and it returns a named tuple containing: 'output',
     'error' and 'returncode'. It also accepts a dictionary `added_env`, which
@@ -259,16 +310,14 @@ def run_command(command, added_env={}):
     log('running \'{0}\''.format(' '.join(command)))
     process = subprocess.Popen(
         command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE if needsOutput else None,
+        stderr=subprocess.PIPE if needsOutput else None,
         env=env
     )
     output, error = process.communicate()
-    if not error:
-        error = bytes(b'(no output on stderr)')
     return command_type(
-        output=output.decode(),
-        error=error.decode(),
+        output=output.decode() if needsOutput else None,
+        error=error.decode() if needsOutput else None,
         returncode=process.returncode
     )
 
@@ -311,7 +360,7 @@ def node_name_from_machine_id():
 
     nodes_raw_json = run_command(
         ['kubectl', 'get', 'nodes', '-o', 'json'],
-        {'KUBECONFIG': KUBECONFIG_PATH}
+        added_env={'KUBECONFIG': KUBECONFIG_PATH}
     )
 
     formatted = json.loads(nodes_raw_json.output)
@@ -332,9 +381,9 @@ def annotate(resource, resource_name, key, value):
     """
 
     ret = run_command([
-        'kubectl', 'annotate', resource, resource_name,
+        'kubectl', 'annotate', '--overwrite', resource, resource_name,
         '{}={}'.format(key, value)],
-        {'KUBECONFIG': KUBECONFIG_PATH}
+        added_env={'KUBECONFIG': KUBECONFIG_PATH}
     )
 
     return ret.output

--- a/skuba-update/skuba_update/sysconfig.skuba-update
+++ b/skuba-update/skuba_update/sysconfig.skuba-update
@@ -1,0 +1,7 @@
+## Path           : System/Management
+## Description    : Extra switches for skuba-update
+## Type           : string
+## Default        : ""
+## ServiceRestart : skuba-update
+#
+SKUBA_UPDATE_OPTIONS=""

--- a/skuba-update/test/os/suse/install_skuba_update.sh
+++ b/skuba-update/test/os/suse/install_skuba_update.sh
@@ -24,7 +24,7 @@ if [ "$release" = "NAME=\"SLES\"" ]; then
     zypper ref
 fi
 
-zypper in -y python3-setuptools
+zypper in -y python3-setuptools lsof
 
 if [ "$release" = "NAME=\"SLES\"" ]; then
     zypper rr leap15.1

--- a/skuba-update/test/os/suse/tests/test-interruptive-updates-with-message.sh
+++ b/skuba-update/test/os/suse/tests/test-interruptive-updates-with-message.sh
@@ -37,4 +37,6 @@ check_reboot_needed_absent
 check_reboot_required_absent
 
 check_kubectl_calls "kubectl get nodes -o json" \
-                    "kubectl annotate nodes my-node-1 caasp.suse.com/has-disruptive-updates=yes"
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=yes"

--- a/skuba-update/test/os/suse/tests/test-interruptive-updates-with-needreboot-message.sh
+++ b/skuba-update/test/os/suse/tests/test-interruptive-updates-with-needreboot-message.sh
@@ -39,4 +39,6 @@ check_reboot_needed_absent
 check_reboot_required_absent
 
 check_kubectl_calls "kubectl get nodes -o json" \
-                    "kubectl annotate nodes my-node-1 caasp.suse.com/has-disruptive-updates=yes"
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=yes"

--- a/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-needreboot-reboot-suggested.sh
+++ b/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-needreboot-reboot-suggested.sh
@@ -18,6 +18,9 @@ source "$(dirname "$0")/../suse.sh"
 
 UPDATE_REPO="update-with-reboot-suggested"
 
+force_machine_id_file
+install_fixtures
+
 add_repository "base"
 install_package "base" "caasp-test"
 
@@ -39,4 +42,7 @@ check_test_package_version "2"
 check_reboot_needed_present
 check_reboot_required_present
 
-check_no_kubectl_calls
+check_kubectl_calls "kubectl get nodes -o json" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=no"

--- a/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-needreboot-restart-suggested.sh
+++ b/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-needreboot-restart-suggested.sh
@@ -18,6 +18,9 @@ source "$(dirname "$0")/../suse.sh"
 
 UPDATE_REPO="update-with-restart-suggested"
 
+force_machine_id_file
+install_fixtures
+
 add_repository "base"
 install_package "base" "caasp-test"
 
@@ -40,4 +43,7 @@ check_test_package_version "2"
 check_reboot_needed_present
 check_reboot_required_present
 
-check_no_kubectl_calls
+check_kubectl_calls "kubectl get nodes -o json" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=no"

--- a/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-needreboot.sh
+++ b/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-needreboot.sh
@@ -18,6 +18,9 @@ source "$(dirname "$0")/../suse.sh"
 
 UPDATE_REPO="update-plain"
 
+force_machine_id_file
+install_fixtures
+
 add_repository "base"
 install_package "base" "caasp-test"
 
@@ -35,4 +38,7 @@ check_test_package_version "2"
 check_reboot_needed_present
 check_reboot_required_present
 
-check_no_kubectl_calls
+check_kubectl_calls "kubectl get nodes -o json" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=no"

--- a/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-reboot-suggested.sh
+++ b/skuba-update/test/os/suse/tests/test-non-interruptive-updates-with-reboot-suggested.sh
@@ -18,6 +18,9 @@ source "$(dirname "$0")/../suse.sh"
 
 UPDATE_REPO="update-with-reboot-suggested"
 
+force_machine_id_file
+install_fixtures
+
 add_repository "base"
 install_package "base" "caasp-test"
 
@@ -38,4 +41,7 @@ check_test_package_version "2"
 check_reboot_needed_absent
 check_reboot_required_present
 
-check_no_kubectl_calls
+check_kubectl_calls "kubectl get nodes -o json" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=no"

--- a/skuba-update/test/os/suse/tests/test-non-interruptive-updates.sh
+++ b/skuba-update/test/os/suse/tests/test-non-interruptive-updates.sh
@@ -18,6 +18,9 @@ source "$(dirname "$0")/../suse.sh"
 
 UPDATE_REPO="update-plain"
 
+force_machine_id_file
+install_fixtures
+
 add_repository "base"
 install_package "base" "caasp-test"
 
@@ -33,4 +36,9 @@ check_test_package_version "2"
 check_reboot_needed_absent
 check_reboot_required_absent
 
-check_no_kubectl_calls
+
+check_kubectl_calls "kubectl get nodes -o json" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-updates=yes" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-security-updates=no" \
+                    "kubectl annotate --overwrite node my-node-1 caasp.suse.com/has-disruptive-updates=no"
+


### PR DESCRIPTION
## Why is this PR needed?

Addresses and fixes SUSE/avant-garde#408

## What does this PR do?

This commit introduces the --annotate-only flag to skuba-update.
This flag is used to disable automatic updates but still keep
the service running just to verify and annotate to the node if updates
are available, without installing anything.

The service can be configured with a sysconfig file
/etc/sysconfig/skuba-update. Runtime flags added in SKUBA_UPDATE_OPTIONS
are automatically used by skuba-update.service in the next run without
having to restart or reload the skuba-update.timer.

## Anything else a reviewer needs to know?

Requires SUSE/avant-garde#407 before it can be completed