### PR TITLE
Enable second stage installer in AutoYaST

### DIFF
--- a/ci/infra/bare-metal/autoyast.xml
+++ b/ci/infra/bare-metal/autoyast.xml
@@ -17,20 +17,6 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
 ]]>
           </source>
       </script>
-      <!-- Workaround for bsc#1136861 -->
-      <script>
-        <chrooted config:type="boolean">true</chrooted>
-        <filename>add_ntp_server.sh</filename>
-        <interpreter>shell</interpreter>
-        <source>
-<![CDATA[
-#!/bin/sh
-# INFO: You may replace NTPPOOL value bellow with NTP server pool from your infrastructure
-NTPPOOL="0.novell.pool.ntp.org"
-sed -i "s/^! pool [^ ]*/pool ${NTPPOOL}/" /etc/chrony.conf
-]]>
-        </source>
-      </script>
     </chroot-scripts>
   </scripts>
   
@@ -49,8 +35,6 @@ sed -i "s/^! pool [^ ]*/pool ${NTPPOOL}/" /etc/chrony.conf
     <ask-list config:type="list"/>
     <mode>
       <confirm config:type="boolean">false</confirm>
-      <second_stage config:type="boolean">false</second_stage>
-      <self_update config:type="boolean">false</self_update>
     </mode>
     <proposals config:type="list"/>
     <storage>


### PR DESCRIPTION
Addressed issues:
- enable 2nd stage AutoYaST installer to solve bsc#1136861 (default)
- enable self_update of the YaST installer (default)
- remove workaround script for setting up chronyd

## Why is this PR needed?

* For using proper AutoYaST method for setting up ntp-client/chronyd by enabling default 2nd stage.
* I also enabled YaST `self_updates` to solve bugs in the installer that were discovered after the release.

After the installation of the basic system and initial reboot, the system configuration is performed in the second stage of the installation - In my case 2nd stage of YaST installation appears as ncurses textmode application where some additional steps (like setting up ntp) are performed, once it finish a login prompt appear without a need to perform additional reboot.

Fixes #
http://bugzilla.suse.com/show_bug.cgi?id=1136861

## What does this PR do?

see commit message

## Anything else a reviewer needs to know?

The commit was tested on real b-m machines by using this autoyast profile (well, patched for Staging repo and with provided authorized_keys) and I was able deploy, bootstrap and test 1+2 bare-metal cluster.