### PR TITLE
tools: Drop unused package

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,6 +1,0 @@
-# Skuba Tools pkg
-
-Why is this needed?
-
-We need this pkg tools for making working cmd-line vendored pkgs, such `ginkgo`.
-In order to make the vendoring work for the cmd, we import those pkgs here, since they are not used in the code anyhow.

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,7 +1,0 @@
-// +build tools
-
-package tools
-
-import (
-	_ "github.com/onsi/ginkgo/ginkgo"
-)


### PR DESCRIPTION
Its sole purpose was to bring ginkgo as dependency but it does not
seem useful right now so we can drop it. We can add the necessary
dependencies into the go.mod file directly.