### PR TITLE
Improve VMware LB haproxy health-check

### DIFF
--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -52,6 +52,7 @@ write_files:
 
     backend apiserver-backend
       option httpchk GET /healthz
+      http-check expect string ok
       ${backends}
 
 runcmd:


### PR DESCRIPTION
## Why is this PR needed?

Using this http-check improve the reliability
of the health check as it checks the body of
the response on /healthz

Signed-off-by: lcavajani <lcavajani@suse.com>