### PR TITLE
Use "zypper needs-rebooting"

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -58,7 +58,7 @@ BuildRequires:  python3-setuptools
 BuildRequires:  pkgconfig(systemd)
 %{?systemd_requires}
 Requires:       python3-setuptools
-Requires:       zypper >= 1.14
+Requires:       zypper >= 1.14.15
 Requires:       lsof
 BuildArch:      noarch
 Supplements:    skuba

--- a/skuba-update/test/os/suse/suse.sh
+++ b/skuba-update/test/os/suse/suse.sh
@@ -67,7 +67,8 @@ check_test_package_version() {
 }
 
 check_reboot_needed_present() {
-    [ -f /var/run/reboot-needed ]
+    zypper needs-rebooting
+    [ $? -eq 102 ] && [ -f /var/run/reboot-needed ]
 }
 
 check_reboot_required_present() {
@@ -77,7 +78,8 @@ check_reboot_required_present() {
 }
 
 check_reboot_needed_absent() {
-    [ ! -f /var/run/reboot-needed ]
+    zypper needs-rebooting
+    [ $? -ne 102 ] && [ ! -f /var/run/reboot-needed ]
 }
 
 check_reboot_required_absent() {

--- a/skuba-update/test/unit/skuba_update_test.py
+++ b/skuba-update/test/unit/skuba_update_test.py
@@ -125,6 +125,7 @@ def test_main(mock_subprocess, mock_geteuid):
     assert mock_subprocess.call_args_list == [
         call(['zypper', '--version'], stdout=ANY, stderr=ANY, env=ANY),
         call(['zypper', 'ref', '-s'], stdout=-1, stderr=-1, env=ANY),
+        call(['zypper', 'needs-rebooting'], stdout=-1, stderr=-1, env=ANY),
         call([
             'zypper', '--non-interactive',
             '--non-interactive-include-reboot-patches', 'patch'
@@ -173,6 +174,9 @@ def test_main_zypper_returns_100(mock_subprocess, mock_geteuid):
             'zypper', '--non-interactive',
             '--non-interactive-include-reboot-patches', 'patch'
         ], stdout=-1, stderr=-1, env=ANY),
+        call([
+            'zypper', 'needs-rebooting'
+        ], env=ANY),
         call([
             'zypper', '--non-interactive',
             '--non-interactive-include-reboot-patches', 'patch'


### PR DESCRIPTION
instead of checking /var/lib/reboot-needed existence

it is safer to use the built in subcommand in case something
changes in zypper in the future

Signed-off-by: Maximilian Meister <mmeister@suse.de>
