### PR TITLE
Support EFI on VMWare

### DIFF
--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -1,74 +1,68 @@
 ## Introduction
 
-These terraform definitions are going to create the whole cluster including load-balancer node/vm on top of VMWare vSphere cluster.
+These terraform definitions are going to create the CaaSP v4 cluster on top of VMWare vSphere cluster.
 
 This code was developed and tested on VMware vSphere cluster based on VMware ESXi 6.7.20000.
 
 ## Deployment
 
-Prepare a template machine in vSphere by following [vmware-deployment guide](https://susedoc.github.io/doc-caasp/adoc/caasp-deployment/single-html/#_vm_preparation_for_creating_a_template).
+Prepare a VM template machine in vSphere by following [vmware-deployment guide](https://susedoc.github.io/doc-caasp/master/caasp-deployment/single-html/#_vm_preparation_for_creating_a_template).
 
-It doesn't matter if you deploy the vm template for SLES_SP1 manually by using ISO or you use pregenerated vmdk image SLES15_SP1 JeOS but in both cases you'll need `cloud-init` package installed and the respective services must be enabled:
+It doesn't matter if you deploy the VM template for SLES15-SP1 manually by using ISO or you use pregenerated vmdk SLES15-SP1 JeOS image but in both cases you'll need `cloud-init-vmware-guestinfo` package (from SUSE CaaS Platform module), `cloud-init` package (from Public Cloud Module) and its dependent packages installed. The respective services must be enabled:
 
 ```sh
 systemctl enable cloud-init cloud-init-local cloud-config cloud-final
 ```
 
-```sh
-sed -i -e '/mount_default_fields/{adatasource_list: [ NoCloud, OpenStack, None ]
-}' /etc/cloud/cloud.cfg
-```
-
 Next you need to define following environment variables in your current shell with proper value:
 
 ```sh
-# HINT, please enter just a hostname without specifing a protocol in VSPHERE_SERVER variable (using https by default)
+# HINT: Please enter just a hostname without specifing a protocol in VSPHERE_SERVER variable (using https by default).
 export VSPHERE_SERVER="vsphere.cluster.endpoint.hostname"
-export VSPHERE_USER="an_user"
-export VSPHERE_PASSWORD="passwd"
+export VSPHERE_USER="username"
+export VSPHERE_PASSWORD="password"
 export VSPHERE_ALLOW_UNVERIFIED_SSL="true"
 ```
 
-Then you can use `terraform` to deploy the cluster
+Once you perform a [Customization](#Customization) you can use `terraform` to deploy the cluster:
 
 ```sh
 terraform init
+terraform validate
 terraform apply
 ```
 
 ## Machine access
 
-It is important to have your public ssh key within the `authorized_keys`,
-this is done by `cloud-init` through a terraform variable called `authorized_keys`.
+It is important to have your public ssh key within the `authorized_keys`, this is done by `cloud-init` through a terraform variable called `authorized_keys`.
 
 All the instances have a `sles` user, password is not set. User can login only as `sles` user over SSH by using his private ssh key. The `sles` user can perform `sudo` without specifying a password.
 
 ## Load balancer
 
-vSPhere doesn't offer a load-balancer solution by itself but this terraform code will deploy a basic load-balancer vm based on haproxy which will be configured to expose ports 6443 of api-severs on all master nodes by doing round-robin 1:1 portforwarding.
+VMWare vSPhere doesn't offer a load-balancer solution. Please expose port 6443 for the Kubernetes api-servers on the master nodes on a local load-balancer using round-robin 1:1 port forwarding.
+
+NOTE: Development version of these VMWare Terraform definitions will deploy preconfigured load-balancer VM node which is using haproxy software. Use its IP address in `skuba cluster init --control-plane <ip-load-balancer> <cluster-name>` command. For accessing haproxy statistics open http://ip-load-balancer:9000/stats in your browser.
 
 ## Customization
 
-IMPORTANT, please define unique `stack_name` value in `terrafrom.tfvars` file to not interfere with other deployments.
+IMPORTANT: Please define unique `stack_name` value in `terrafrom.tfvars` file to not interfere with other deployments.
 
 Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable values.
 
 ## Variables
 
-`vsphere_datastore` - Provide the datastore to use on the vSphere server
-`vsphere_datacenter` - Provide the datacenter to use on the vSphere server
-`vsphere_network` - Provide the network to use on the vSphere server - this network must be able to access the ntp servers and the nodes must be able to reach each other
-`vsphere_resource_ppol` - Provide the resource pool the machines will be running in
-`template_name` - The template name the machines will be copied from
-`stack_name` - A prefix that all of the booted machines will use
-`authorized_keys` - A list of ssh public keys that will be installed on all nodes
-`repositories` - Additional repositories that will be added on all nodes
+`vsphere_datastore` - Provide the datastore to use on the vSphere server  
+`vsphere_datacenter` - Provide the datacenter to use on the vSphere server  
+`vsphere_network` - Provide the network to use on the vSphere server - this network must be able to access the ntp servers and the nodes must be able to reach each other  
+`vsphere_resource_ppol` - Provide the resource pool the machines will be running in  
+`template_name` - The template name the machines will be copied from  
+`firmware` - Replace the default "bios" value with "efi" in case your template was created by using EFI firmware  
+`stack_name` - A prefix that all of the booted machines will use  
+`authorized_keys` - A list of ssh public keys that will be installed on all nodes  
+`repositories` - Additional repositories that will be added on all nodes  
 `packages` - Additional packages that will be installed on all nodes
 
-Please use one from the following options:
-
-`caasp_registry_code` - Provide SUSE CaaSP Product Registration Code in
-`registration.auto.tfvars` file to register product against official repositories
-
-`rmt_server_name` - Provide SUSE Repository Mirroring Tool Server Name in
-￼ `registration.auto.tfvars` file to register product against official repositories
+### Please use one of the following options:
+`caasp_registry_code` - Provide SUSE CaaSP Product Registration Code in `registration.auto.tfvars` file to register product against official SCC server  
+`rmt_server_name` - Provide SUSE Repository Mirroring Tool Server Name in `registration.auto.tfvars` file to use repositories stored on RMT server  

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -78,6 +78,7 @@ resource "vsphere_virtual_machine" "lb" {
   num_cpus         = "${var.lb_cpus}"
   memory           = "${var.lb_memory}"
   guest_id         = "${var.guest_id}"
+  firmware         = "${var.firmware}"
   scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
@@ -121,7 +122,7 @@ resource "null_resource" "lb_wait_cloudinit" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait",
+      "cloud-init status --wait > /dev/null",
     ]
   }
 }

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -62,6 +62,7 @@ resource "vsphere_virtual_machine" "master" {
   num_cpus         = "${var.master_cpus}"
   memory           = "${var.master_memory}"
   guest_id         = "${var.guest_id}"
+  firmware         = "${var.firmware}"
   scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
@@ -101,7 +102,7 @@ resource "null_resource" "master_wait_cloudinit" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait",
+      "cloud-init status --wait > /dev/null",
     ]
   }
 }

--- a/ci/infra/vmware/output.tf
+++ b/ci/infra/vmware/output.tf
@@ -1,9 +1,3 @@
-# TODO show also real fqdn hostnames - maybe later over guestinfo or if variable can be filled by remote-exec
-
-output "hostname_hint" {
-  value = ["vm[last_two_ip_octets].qa.prv.suse.net"]
-}
-
 output "ip_masters" {
   value = ["${vsphere_virtual_machine.master.*.default_ip_address}"]
 }

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -23,6 +23,9 @@ vsphere_resource_pool = ""
 # template_name = "SLES15-SP1-cloud-init"
 template_name = ""
 
+# IMPORTANT: Replace by "efi" string in case your template was created by using EFI firmware
+firmware = "bios"
+
 # prefix that all of the booted machines will use
 # IMPORTANT: please enter unique identifier below as value of
 # stack_name variable to not interfere with other deployments

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -1,4 +1,5 @@
 variable "template_name" {}
+variable "firmware" {}
 variable "stack_name" {}
 variable "vsphere_datastore" {}
 variable "vsphere_datacenter" {}

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -62,6 +62,7 @@ resource "vsphere_virtual_machine" "worker" {
   num_cpus         = "${var.worker_cpus}"
   memory           = "${var.worker_memory}"
   guest_id         = "${var.guest_id}"
+  firmware         = "${var.firmware}"
   scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
   resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
   datastore_id     = "${data.vsphere_datastore.datastore.id}"
@@ -101,7 +102,7 @@ resource "null_resource" "worker_wait_cloudinit" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait",
+      "cloud-init status --wait > /dev/null",
     ]
   }
 }


### PR DESCRIPTION
Addressed issues:
- EFI firmware enabled on VMWare tf states
- prevent cloud-init to output on wait
- README.md changes mainly regarding to EFI and load-balancer

## Why is this PR needed?

It happened several times to me that I've created VM template in VMWare with its default EFI firmware because I forgot switch to required BIOS firmware in VM definition. This VM template is not working then (and doesn't even boot) with our terraform scripts because terraform is still using BIOS fw by default. This commit brings support for both kind of FWs.

## Anything else a reviewer needs to know?

I've tested this commit on VMWare with JeOS image with preinstalled `cloud-init-vmware-guestinfo` package on BIOS (it stays default in our states) and with EFI firmware as well - JeOS is compatible with both firmwares.