### PR TITLE
ci: pr_manager: Add check for max commit title and body message

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ This list is not comprehensive, meaning if you want to include more detail than 
   * Always start with an upper-case letter
   * Do not put a dot (period) at the end
   * Use imperative verbs
-  * Maximum characters: 50
+  * Maximum characters: 50 (excluding the (bsc#123456) part)
   * Tracking issues from Bugzilla
     * Add `(bsc#123456)` as part of the title
 

--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
@@ -43,8 +43,8 @@ def check_pr(args):
 
         if args.is_fork:
             pr_checks.check_pr_from_fork(CHANGE_ID)
-        if args.employee_email:
-            pr_checks.check_employee_emails(CHANGE_ID)
+        if args.check_pr_details:
+            pr_checks.check_pr_details(CHANGE_ID)
     else:
         print(f'No CHANGE_ID was set assuming this is not a PR. Skipping checks...')
 
@@ -102,7 +102,7 @@ def parse_args():
     # Parse check-pr command
     checks_parser = subparsers.add_parser('check-pr', help='Check to make sure the PR meets certain standards')
     checks_parser.add_argument('--is-fork', action='store_true')
-    checks_parser.add_argument('--employee-email', action='store_true')
+    checks_parser.add_argument('--check-pr-details', action='store_true')
     checks_parser.set_defaults(func=check_pr)
 
     # Parse merge-prs command

--- a/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
         } }
 
         stage('Validating PR author') { steps {
-            sh(script: "${PR_MANAGER} check-pr --is-fork --employee-email", label: 'checking valid PR author')
+            sh(script: "${PR_MANAGER} check-pr --is-fork --check-pr-details", label: 'checking valid PR author')
         } }
 
     }


### PR DESCRIPTION
The CONTRIBUTING.md guidelines suggest that the maximum number of
characters in the commit title should be 50 and in the commit body
72 (per line) so we can add this check to the job to free reviewers
from checking these limits themselves.

## Why is this PR needed?

Enforces the current CONTRIBUTING.md guidelines so reviewers have less work to do :)

## What does this PR do?

Checks that git commit messages are following the guidelines