### PR TITLE
Added firmware property to VMware CI tvfars

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -4,6 +4,7 @@
     "vsphere_network": "VM Network",
     "vsphere_resource_pool": "CaaSP_RP",
     "template_name": "SLES15-SP1-GM-guestinfo",
+    "firmware": "bios",
     "stack_name": "caasp-jenkins-v4",
     "masters": 1,
     "workers": 2,


### PR DESCRIPTION

## Why is this PR needed?

It was added to the HCL example but not to the one that Jenkins uses.

Fixes #

## What does this PR do?

Adds the property to the CI tfvars

## Anything else a reviewer needs to know?
