### PR TITLE
Unify OpenStack terraform README.md with VMWare

### DIFF
--- a/ci/infra/openstack/README.md
+++ b/ci/infra/openstack/README.md
@@ -43,7 +43,7 @@ Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable
 
 `image_name` - Name of the image to use 
 `internal_net` - Name of the internal network to be created  
-`stack_name` - A prefix that all of the booted machines will use  
+`stack_name` - Identifier to make all your resources unique and avoid clashes with other users of this terraform project  
 `authorized_keys` - A list of ssh public keys that will be installed on all nodes  
 `repositories` - Additional repositories that will be added on all nodes  
 `packages` - Additional packages that will be installed on all nodes  

--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -58,7 +58,7 @@ Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable
 `vsphere_resource_ppol` - Provide the resource pool the machines will be running in  
 `template_name` - The template name the machines will be copied from  
 `firmware` - Replace the default "bios" value with "efi" in case your template was created by using EFI firmware  
-`stack_name` - A prefix that all of the booted machines will use  
+`stack_name` - Identifier to make all your resources unique and avoid clashes with other users of this terraform project  
 `authorized_keys` - A list of ssh public keys that will be installed on all nodes  
 `repositories` - Additional repositories that will be added on all nodes  
 `packages` - Additional packages that will be installed on all nodes


### PR DESCRIPTION
## Why is this PR needed?

To unify our README.md files for both supported terraform definitions.

## What does this PR do?

it's a documentation so nothing

## Anything else a reviewer needs to know?
