### PR TITLE
[WIP] manifests: Fixes for PSP and Cilium manifests

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -91,7 +91,31 @@ spec:
     - azureDisk
     - azureFile
     - vsphereVolume
-  #allowedHostPaths: []
+  allowedHostPaths:
+    - pathPrefix: /etc/ca-certificates
+    - pathPrefix: /etc/cni/net.d
+    - pathPrefix: /etc/kubernetes
+    - pathPrefix: /etc/openssl
+    - pathPrefix: /etc/pki
+    - pathPrefix: /etc/srv/kubernetes
+    - pathPrefix: /etc/srv/sshproxy
+    - pathPrefix: /etc/ssl
+    - pathPrefix: /run/xtables.lock
+    - pathPrefix: /sys/fs/bpf
+    - pathPrefix: /srv/kubernetes
+    - pathPrefix: /usr/lib/cni
+    - pathPrefix: /usr/lib/ssl
+    - pathPrefix: /usr/share/ca-certificates
+    - pathPrefix: /usr/ssl
+    - pathPrefix: /var/etcd
+    - pathPrefix: /var/lib/etcd
+    - pathPrefix: /var/lib/kube-proxy
+    - pathPrefix: /var/lib/kubelet
+    - pathPrefix: /var/log
+    - pathPrefix: /var/run/cilium
+    - pathPrefix: /var/run/crio
+    - pathPrefix: /var/run/kubernetes
+    - pathPrefix: /var/ssl
   readOnlyRootFilesystem: false
   # Users and groups
   runAsUser:
@@ -413,10 +437,14 @@ spec:
             readOnly: true
           - name: cilium-etcd-secret-mount
             mountPath: /tmp/cilium-etcd
+          - name: lib-modules
+            mountPath: /lib/modules
+            readOnly: true
         securityContext:
           capabilities:
             add:
               - "NET_ADMIN"
+              - "SYS_MODULE"
           privileged: true
       hostNetwork: true
       volumes:
@@ -436,7 +464,11 @@ spec:
           # To install cilium cni configuration in the host
         - name: host-cni-conf
           hostPath:
-              path: /etc/cni/net.d
+            path: /etc/cni/net.d
+          # To be able to load kernel modules
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
           # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:


### PR DESCRIPTION
## Why is this PR needed?

If fixes:

- the bug https://bugzilla.suse.com/show_bug.cgi?id=1136406
- the issue with automatic checks and load of kernel modules

## What does this PR do?

This PR:

- fixes the privileged PSP by allowing the following hostPaths used by Cilium and Kubernetes core components
- adds SYS_MODULE capability for Cilium

## Anything else a reviewer needs to know?

The issue itself is quite hard to reproduce if you don't check the state of deployment very fast.