### PR TITLE
Return available platform versions known to skuba

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+func TestAvailableVersionsForMap(t *testing.T) {
+	var versions = []struct {
+		name                      string
+		kubernetesVersions        KubernetesVersions
+		expectedAvailableVersions []*version.Version
+	}{
+		{
+			name: "v1.14.0-v1.15.0",
+			kubernetesVersions: KubernetesVersions{
+				"v1.14.0": KubernetesVersion{},
+				"v1.15.0": KubernetesVersion{},
+			},
+			expectedAvailableVersions: []*version.Version{
+				version.MustParseSemantic("v1.14.0"),
+				version.MustParseSemantic("v1.15.0"),
+			},
+		},
+		{
+			name: "v1.14.0-v1.14.1-v1.15.0",
+			kubernetesVersions: KubernetesVersions{
+				"v1.14.0": KubernetesVersion{},
+				"v1.15.0": KubernetesVersion{},
+				"v1.14.1": KubernetesVersion{},
+			},
+			expectedAvailableVersions: []*version.Version{
+				version.MustParseSemantic("v1.14.0"),
+				version.MustParseSemantic("v1.14.1"),
+				version.MustParseSemantic("v1.15.0"),
+			},
+		},
+	}
+	for _, tt := range versions {
+		t.Run(tt.name, func(t *testing.T) {
+			availableVersions := availableVersionsForMap(tt.kubernetesVersions)
+			if !reflect.DeepEqual(availableVersions, tt.expectedAvailableVersions) {
+				t.Errorf("got %q, want %q", availableVersions, tt.expectedAvailableVersions)
+			}
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -259,6 +259,7 @@ k8s.io/apiextensions-apiserver/pkg/features
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/types
 k8s.io/apimachinery/pkg/runtime
+k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/util/intstr
@@ -268,7 +269,6 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/watch
-k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/strategicpatch


### PR DESCRIPTION
## Why is this PR needed?

Add function to return the list of available platform versions known to skuba.
The resulting list of versions is sorted semver aware.

Fixes https://github.com/SUSE/avant-garde/issues/449