### PR TITLE
Modify integration pipeline for running `skuba` tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,10 @@ VERSION      := $(shell cat VERSION)
 COMMIT       := $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_DATE   := $(shell date +%Y%m%d)
 TAGS         := development
-SKUBA_LDFLAGS = -ldflags "-X=github.com/SUSE/skuba/internal/app/skuba.Version=$(VERSION) \
-                          -X=github.com/SUSE/skuba/internal/app/skuba.Commit=$(COMMIT) \
-                          -X=github.com/SUSE/skuba/internal/app/skuba.BuildDate=$(BUILD_DATE)"
+PROJECT_PATH := github.com/SUSE/skuba
+SKUBA_LDFLAGS = -ldflags "-X=$(PROJECT_PATH)/internal/app/skuba.Version=$(VERSION) \
+                          -X=$(PROJECT_PATH)/internal/app/skuba.Commit=$(COMMIT) \
+                          -X=$(PROJECT_PATH)/internal/app/skuba.BuildDate=$(BUILD_DATE)"
 
 SKUBA_DIRS    = cmd pkg internal test
 
@@ -84,6 +85,13 @@ suse-changelog:
 	ci/packaging/suse/changelog_maker.sh "$(CHANGES)"
 
 # tests
+.PHONY: test
+test: test-unit test-e2e
+
+.PHONY: test-unit
+test-unit:
+	$(GO) test $(PROJECT_PATH)/{cmd,pkg,internal}/...
+
 .PHONY: test-e2e
 test-e2e:
 	./ci/tasks/e2e-tests.py

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -5,7 +5,7 @@
     repo-credentials: github-token
     platform: openstack
     jobs:
-        - '{name}-integration'
+        - '{name}-test'
         - '{name}-update-unit'
         - '{name}-update-integration'
         - '{name}-code-lint'

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -38,6 +38,10 @@ pipeline {
             }
         }}
 
+        stage('Running skuba unit tests') { steps {
+            sh(script: 'make test-unit', label: 'make test-unit')
+        } }
+
         stage('Getting Ready For Cluster Deployment') { steps {
             sh(script: 'make -f skuba/ci/Makefile pre_deployment', label: 'Pre Deployment')
             sh(script: 'make -f skuba/ci/Makefile pr_checks', label: 'PR Checks')

--- a/ci/jenkins/templates/test-template.yaml
+++ b/ci/jenkins/templates/test-template.yaml
@@ -1,10 +1,10 @@
 - job-template:
-    name: '{name}-integration'
+    name: '{name}-test'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30
     days-to-keep: 30
-    script-path: ci/jenkins/pipelines/prs/skuba-integration.Jenkinsfile
+    script-path: ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
     wrappers:
       - timeout:
           timeout: 120


### PR DESCRIPTION
## Why is this PR needed?

* Add unit tests for `skuba` on the integration pipeline

* Add a `Makefile` `make test-unit` target that will execute unit
  tests automatically.

* Add a `Makefile` `make test` target that will execute all tests
  automatically (`unit` and `e2e`).

Fixes https://github.com/SUSE/avant-garde/issues/458