### PR TITLE
Replace password with key-based auth (bsc#1136366)(bsc#1138476)

### DIFF
--- a/ci/infra/openstack/README.md
+++ b/ci/infra/openstack/README.md
@@ -30,8 +30,12 @@ terraform apply
 It is important to have your public ssh key within the `authorized_keys`,
 this is done by `cloud-init` through a terraform variable called `authorized_keys`.
 
-All the instances have a `root` and a `opensuse` user. The `opensuse` user can
+All the instances have a `root` and `sles` user. The normal 'sles' user user can
 perform `sudo` without specifying a password.
+
+Neither root nor the normal `sles` user will have password. Both `terraform` and `skuba`
+are using SSH key-based authentication. You can always set a password after the
+creation of the machines using `sudo passwd sles` (for normal user) or `sudo passwd` (for root).
 
 ## Load balancer
 
@@ -52,7 +56,7 @@ provide reasonable values.
 `repositories` - Additional repositories that will be added on all nodes
 `packages` - Additional packages that will be installed on all nodes
 
-Please use one from the following options:
+Please use **one** from the following options:
 `caasp_registry_code` - Provide SUSE CaaSP Product Registration Code in 
 `registration.auto.tfvars` file to register product against official repositories
 

--- a/ci/infra/openstack/cloud-init/common.tpl
+++ b/ci/infra/openstack/cloud-init/common.tpl
@@ -6,13 +6,7 @@ locale: en_US.UTF-8
 # set timezone
 timezone: Etc/UTC
 
-# set root password
-chpasswd:
-  list: |
-    root:linux
-    ${username}:${password}
-  expire: False
-
+# Inject the public keys
 ssh_authorized_keys:
 ${authorized_keys}
 
@@ -47,6 +41,11 @@ bootcmd:
 runcmd:
   # workaround for bsc#1119397 . If this is not called, /etc/resolv.conf is empty
   - netconfig -f update
+  # Workaround for bsc#1138557 . Disable root and password SSH login
+  - sed -i -e '/^PermitRootLogin/s/^.*$/PermitRootLogin no/' /etc/ssh/sshd_config
+  - sed -i -e '/^#ChallengeResponseAuthentication/s/^.*$/ChallengeResponseAuthentication no/' /etc/ssh/sshd_config
+  - sed -i -e '/^#PasswordAuthentication/s/^.*$/PasswordAuthentication no/' /etc/ssh/sshd_config
+  - systemctl restart sshd
 ${register_scc}
 ${register_rmt}
 ${commands}

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -44,7 +44,6 @@ data "template_file" "master-cloud-init" {
     register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
     commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
     username        = "${var.username}"
-    password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
@@ -88,10 +87,9 @@ resource "null_resource" "master_wait_cloudinit" {
   count = "${var.masters}"
 
   connection {
-    host     = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
-    type     = "ssh"
+    host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
+    user = "${var.username}"
+    type = "ssh"
   }
 
   depends_on = ["openstack_compute_instance_v2.master"]

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -60,16 +60,6 @@ dnsdomain = ""
 # Set DNS Entry (0 is false, 1 is true)
 dnsentry = 0
 
-# Username for the cluster nodes
-# EXAMPLE:
-# username = "sles"
-username = ""
-
-# Password for the cluster nodes
-# EXAMPLE:
-# password = "linux"
-password = ""
-
 # define the repositories to use
 # EXAMPLE:
 # repositories = {

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -14,8 +14,6 @@
     "worker_size": "m1.medium",
     "workers_vol_enabled": 0,
     "workers_vol_size": 5,
-    "username": "sles",
-    "password": "linux",
     "repositories": {
         "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/",
         "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/",

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -105,12 +105,7 @@ variable "packages" {
 
 variable "username" {
   default     = "sles"
-  description = "Username for the cluster nodes"
-}
-
-variable "password" {
-  default     = "linux"
-  description = "Password for the cluster nodes"
+  description = "Default user for the cluster nodes created by cloud-init default configuration for all SUSE SLES systems"
 }
 
 variable "caasp_registry_code" {

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -44,7 +44,6 @@ data "template_file" "worker-cloud-init" {
     register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
     commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
     username        = "${var.username}"
-    password        = "${var.password}"
     ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
@@ -100,10 +99,9 @@ resource "null_resource" "worker_wait_cloudinit" {
   count = "${var.workers}"
 
   connection {
-    host     = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
-    type     = "ssh"
+    host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
+    user = "${var.username}"
+    type = "ssh"
   }
 
   depends_on = ["openstack_compute_instance_v2.worker"]


### PR DESCRIPTION
This PR is addressing the security aspect of creating machines
using Terraform and also connecting into them later on using
skuba. The preferred method is to avoid using any pre-configured
password no matter if they can be hashed or not. It is listed in
the cloud-init documentation:

"While the use of a hashed password is better than plain text,
the use of this feature is not ideal. Also, using a high number
of salting rounds will help, but it should not be relied upon."

## Why is this PR needed?

Using passwords (hashed or not) is a potential security risk and
it is was provided for Beta2 for your convenience only. If you
do not fully trust the medium over which your cloud-config will
be transmitted, then you should use SSH authentication only.



Fixes two bugs:
P4 - https://bugzilla.suse.com/show_bug.cgi?id=1136366
P2 - https://bugzilla.suse.com/show_bug.cgi?id=1138476

## What does this PR do?

This PR makes sure that Terraform is using only SSH-key based
authentication for openstack deployment.
please include a brief "management" technical overview (details are in the code)