### PR TITLE
manifests: cilium: Allow to manage kernel modules

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -413,10 +413,14 @@ spec:
             readOnly: true
           - name: cilium-etcd-secret-mount
             mountPath: /tmp/cilium-etcd
+          - name: lib-modules
+            mountPath: /lib/modules
+            readOnly: true
         securityContext:
           capabilities:
             add:
               - "NET_ADMIN"
+              - "SYS_MODULE"
           privileged: true
       hostNetwork: true
       volumes:
@@ -436,7 +440,11 @@ spec:
           # To install cilium cni configuration in the host
         - name: host-cni-conf
           hostPath:
-              path: /etc/cni/net.d
+            path: /etc/cni/net.d
+          # To be able to load kernel modules
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
           # To read the etcd config stored in config maps
         - name: etcd-config-path
           configMap:


### PR DESCRIPTION
## Why is this PR needed?

If fixes:

- The bug https://bugzilla.suse.com/show_bug.cgi?id=1136406
  - Which on the first glance seems to be not related, but in fact the issue disappears! So the actual cause of failure was lack of access to kernel modules, no changes in PSP were needed.
- The issue with automatic checks and load of kernel modules.

## What does this PR do?

This PR adds two things in Cilium DaemonSet which allow Cilium to manage kernel modules:

- SYS_MODULE capability
- /lib/modules mount

## Anything else a reviewer needs to know?

The issue itself is quite hard to reproduce if you don't check the state of deployment very fast. You need to ensure that all Cilium pods are initially up without any restarts.