### PR TITLE
bootstrap: Prevent accidental bootstraps

### DIFF
--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -39,6 +39,13 @@ import (
 // FIXME: being this a part of the go API accept the toplevel directory instead
 //        of using the PWD
 func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target *deployments.Target) error {
+	if clientSet, err := kubernetes.GetAdminClientSet(); err == nil {
+		_, err := clientSet.ServerVersion()
+		if err == nil {
+			return errors.New("cluster is already bootstrapped")
+		}
+	}
+
 	initConfiguration, err := LoadInitConfigurationFromFile(skuba.KubeadmInitConfFile())
 	if err != nil {
 		return errors.Wrapf(err, "could not parse %s file", skuba.KubeadmInitConfFile())


### PR DESCRIPTION
check cluster status before bootstrap. Error out if
cluster is already. This also prevent creating multiple
k8s cluster using same init files.
