### PR TITLE
cilium: Update to 1.5.3

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -72,7 +72,7 @@ var (
 				KubeletVersion: "1.14.1",
 			},
 			AddonsVersion: AddonsVersion{
-				CiliumVersion:  "1.5.1",
+				CiliumVersion:  "1.5.3",
 				ToolingVersion: "0.1.0",
 				KuredVersion:   "1.2.0",
 			},


### PR DESCRIPTION
Update Cilium from 1.5.1 to 1.5.3. This update contains several
bugfixes.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>

## Why is this PR needed?

It updates Cilium from 1.5.1 to 1.5.3.

## What does this PR do?

The update contains several bugfixes. For details please look on release notes:

- https://github.com/cilium/cilium/releases/tag/v1.5.3

## Anything else a reviewer needs to know?

No

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->