### PR TITLE
ci: Makefile: Delete obsolete jobs on update

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -53,7 +53,7 @@ test_jenkins_jobs:
 
 .PHONY: update_jenkins_jobs
 update_jenkins_jobs:
-	jenkins-jobs  --ignore-cache --conf ${JENKINS_JOB_CONFIG} update ${JENKINS_JOBS_DIR}/:${JENKINS_JOBS_DIR}/templates/
+	jenkins-jobs  --ignore-cache --conf ${JENKINS_JOB_CONFIG} update --delete-old ${JENKINS_JOBS_DIR}/:${JENKINS_JOBS_DIR}/templates/
 
 # Stages
 .PHONY: pre_deployment


### PR DESCRIPTION
Add the --delete-old option to the 'update' subcommand so old
jobs are automatically deleted if they are no longer referenced
in the yaml files