### PR TITLE
cilium: Add permission to patch k8s node

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -670,7 +670,7 @@ metadata:
   name: cilium
 rules:
 - apiGroups:
-  - "networking.k8s.io"
+  - networking.k8s.io
   resources:
   - networkpolicies
   verbs:
@@ -700,10 +700,15 @@ rules:
   - watch
   - update
 - apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
   - extensions
   resources:
-  - networkpolicies #FIXME remove this when we drop support for k8s NP-beta GH-1202
-  - thirdpartyresources
   - ingresses
   verbs:
   - create
@@ -711,7 +716,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "apiextensions.k8s.io"
+  - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
@@ -728,7 +733,7 @@ rules:
   - ciliumendpoints
   - ciliumendpoints/status
   verbs:
-  - "*"
+  - '*'
 `
 	kuredManifest = `---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION

## Why is this PR needed?

cilium annotates nodes and that permission was missing from ClusterRole

```
nirmoy@chapman:~/go/src/github.com/SUSE/skuba/ci/infra/openstack/ndas> kubectl --kubeconfig=./admin.conf -n kube-system exec cilium-bkt5z --  cilium status                                                                                   
KVStore:                Ok   etcd: 1/1 connected, has-quorum=true: https://172.28.0.31:2379 - 3.3.11 (Leader)                                                                                                                                 
ContainerRuntime:       Ok   cri-o client: Ok - cri daemon: Ok                                                                                                                                                                                
Kubernetes:             Ok   1.14 (v1.14.1) [linux/amd64]                                                                                                                                                                                     
Kubernetes APIs:        ["CustomResourceDefinition", "cilium/v2::CiliumNetworkPolicy", "core/v1::Endpoint", "core/v1::Namespace", "core/v1::Node", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]                
Cilium:                 Ok   OK                                                                                                                                                                                                               
NodeMonitor:            Disabled                                                                                                                                                                                                              
Cilium health daemon:   Ok                                                                                                                                                                                                                    
IPv4 address pool:      6/255 allocated from 10.244.0.0/24                                                                                                                                                                                    
IPv6 address pool:      6/65535 allocated from f00d::af4:0:0:0/112                                                                                                                                                                            
Controller Status:      26/27 healthy                                                                                                                                                                                                         
  Name                          Last success   Last error   Count   Message                                            
  update-k8s-node-annotations   never          3s ago       16      nodes "master-1" is forbidden: User "system:serviceaccount:kube-system:cilium" cannot patch resource "nodes" in API group "" at the cluster scope                         
Proxy Status:   OK, ip 10.244.0.1, port-range 10000-20000                                                                                                                                                                                     
Cluster health:          0/2 reachable   (2019-06-19T10:09:26Z)                                                                                                                                                                               
  Name                   IP              Reachable   Endpoints reachable                                               
  master-1 (localhost)   172.28.0.31     false       false                                                                                                                                                                                    
  delta2                 172.28.0.6      false       false 
```

