### PR TITLE
Rename `pkg/skuba/actions/node/*` packages

### DIFF
--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -15,7 +15,7 @@
  *
  */
 
-package node
+package bootstrap
 
 import (
 	"fmt"

--- a/pkg/skuba/actions/node/bootstrap/config.go
+++ b/pkg/skuba/actions/node/bootstrap/config.go
@@ -15,7 +15,7 @@
  *
  */
 
-package node
+package bootstrap
 
 import (
 	"fmt"

--- a/pkg/skuba/actions/node/join/config.go
+++ b/pkg/skuba/actions/node/join/config.go
@@ -15,7 +15,7 @@
  *
  */
 
-package node
+package join
 
 import (
 	"io/ioutil"

--- a/pkg/skuba/actions/node/join/config_test.go
+++ b/pkg/skuba/actions/node/join/config_test.go
@@ -15,7 +15,7 @@
  *
  */
 
-package node
+package join
 
 import (
 	"reflect"

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -15,7 +15,7 @@
  *
  */
 
-package node
+package join
 
 import (
 	"fmt"

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -15,7 +15,7 @@
  *
  */
 
-package node
+package remove
 
 import (
 	"fmt"


### PR DESCRIPTION
## Why is this PR needed?

This renames the packages under `pkg/skuba/actions/node/*` to fit the location they are found under.

It also adds very basic unit tests for configuration loading.

Fixes https://github.com/SUSE/avant-garde/issues/178

## What does this PR do?

Refactor the package names of the packages and add some basic unit tests.