### PR TITLE
Revert "ci: Makefile: Delete obsolete jobs on update"

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -53,7 +53,7 @@ test_jenkins_jobs:
 
 .PHONY: update_jenkins_jobs
 update_jenkins_jobs:
-	jenkins-jobs  --ignore-cache --conf ${JENKINS_JOB_CONFIG} update --delete-old ${JENKINS_JOBS_DIR}/:${JENKINS_JOBS_DIR}/templates/
+	jenkins-jobs  --ignore-cache --conf ${JENKINS_JOB_CONFIG} update ${JENKINS_JOBS_DIR}/:${JENKINS_JOBS_DIR}/templates/
 
 # Stages
 .PHONY: pre_deployment


### PR DESCRIPTION
This reverts commit e662121e40a3af26a42faa8bff8c11ebd37d7689.

This has the unintended consequence that no-caasp jobs are also removed.