### PR TITLE
openstack: cilium: Open cilium-health port

### DIFF
--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -24,6 +24,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
   }
 
   rule {
+    from_port   = 4240
+    to_port     = 4240
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
     from_port   = 8472
     to_port     = 8472
     ip_protocol = "udp"


### PR DESCRIPTION
cilium-health runs on 4240 which should be open so that
cilium-health agents can reach each other to verify cluster
status.


Fixes: #403
