### PR TITLE
Improvements around security groups in OpenStack

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -65,8 +65,10 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   security_groups = [
-    "${openstack_compute_secgroup_v2.secgroup_base.name}",
-    "${openstack_compute_secgroup_v2.secgroup_master.name}",
+    "${openstack_compute_secgroup_v2.secgroup_base_external.name}",
+    "${openstack_compute_secgroup_v2.secgroup_base_internal.name}",
+    "${openstack_compute_secgroup_v2.secgroup_master_external.name}",
+    "${openstack_compute_secgroup_v2.secgroup_master_internal.name}",
   ]
 
   user_data = "${data.template_file.master-cloud-init.rendered}"

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -68,7 +68,6 @@ resource "openstack_compute_instance_v2" "master" {
     "${openstack_compute_secgroup_v2.secgroup_base_external.name}",
     "${openstack_compute_secgroup_v2.secgroup_base_internal.name}",
     "${openstack_compute_secgroup_v2.secgroup_master_external.name}",
-    "${openstack_compute_secgroup_v2.secgroup_master_internal.name}",
   ]
 
   user_data = "${data.template_file.master-cloud-init.rendered}"

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -55,14 +55,6 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
     cidr        = "0.0.0.0/0"
   }
 
-  # Kubernetes API server
-  rule {
-    from_port   = 6443
-    to_port     = 6444
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
   # Kubelet API
   rule {
     from_port   = 10250

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -2,6 +2,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
   name        = "caasp-base-${var.stack_name}"
   description = "Basic security group"
 
+  # ping
   rule {
     from_port   = -1
     to_port     = -1
@@ -9,6 +10,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     cidr        = "0.0.0.0/0"
   }
 
+  # ssh
   rule {
     from_port   = 22
     to_port     = 22
@@ -16,6 +18,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     cidr        = "0.0.0.0/0"
   }
 
+  # etcd client requests
   rule {
     from_port   = 2379
     to_port     = 2379
@@ -31,6 +34,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Cilium VXLAN overlay
   rule {
     from_port   = 8472
     to_port     = 8472
@@ -43,6 +47,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
   name        = "caasp-master-${var.stack_name}"
   description = "security group for masters"
 
+  # etcd peer
   rule {
     from_port   = 2380
     to_port     = 2380
@@ -50,6 +55,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Kubernetes API server
   rule {
     from_port   = 6443
     to_port     = 6444
@@ -57,6 +63,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Kubelet API
   rule {
     from_port   = 10250
     to_port     = 10250
@@ -64,6 +71,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Node ports (TCP)
   rule {
     from_port   = 30000
     to_port     = 32768
@@ -71,6 +79,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Node ports (UDP)
   rule {
     from_port   = 30000
     to_port     = 32768
@@ -83,6 +92,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
   name        = "caasp-worker-${var.stack_name}"
   description = "security group for workers"
 
+  # etcd peer
   rule {
     from_port   = 2380
     to_port     = 2380
@@ -90,6 +100,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Kubelet API
   rule {
     from_port   = 10250
     to_port     = 10250
@@ -97,6 +108,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Node ports (TCP)
   rule {
     from_port   = 30000
     to_port     = 32768
@@ -104,6 +116,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Node ports (UDP)
   rule {
     from_port   = 30000
     to_port     = 32768
@@ -116,6 +129,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master_lb" {
   name        = "caasp-master-lb-${var.stack_name}"
   description = "security group for master load balancers"
 
+  # Kubernetes API server
   rule {
     from_port   = 6443
     to_port     = 6443

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -23,6 +23,14 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     cidr        = "0.0.0.0/0"
   }
 
+  # Cilium health checks
+  rule {
+    from_port   = 4240
+    to_port     = 4240
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
   rule {
     from_port   = 8472
     to_port     = 8472

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -58,13 +58,6 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
   }
 
   rule {
-    from_port   = 8285
-    to_port     = 8285
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
     from_port   = 30000
     to_port     = 32768
     ip_protocol = "tcp"
@@ -84,34 +77,6 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
   description = "security group for workers"
 
   rule {
-    from_port   = 80
-    to_port     = 80
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 443
-    to_port     = 443
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 8080
-    to_port     = 8080
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 8081
-    to_port     = 8081
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
     from_port   = 2380
     to_port     = 2380
     ip_protocol = "tcp"
@@ -122,13 +87,6 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
     from_port   = 10250
     to_port     = 10250
     ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  rule {
-    from_port   = 8285
-    to_port     = 8285
-    ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
   }
 

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -23,10 +23,10 @@ resource "openstack_compute_secgroup_v2" "secgroup_base_internal" {
   name        = "caasp-base-internal-${var.stack_name}"
   description = "Basic internal security group"
 
-  # etcd client requests
+  # etcd client and peer
   rule {
     from_port   = 2379
-    to_port     = 2379
+    to_port     = 2380
     ip_protocol = "tcp"
     self        = true
   }
@@ -44,40 +44,6 @@ resource "openstack_compute_secgroup_v2" "secgroup_base_internal" {
     from_port   = 8472
     to_port     = 8472
     ip_protocol = "udp"
-    self        = true
-  }
-}
-
-resource "openstack_compute_secgroup_v2" "secgroup_master_external" {
-  name        = "caasp-master-external-${var.stack_name}"
-  description = "External security group for masters"
-
-  # Node ports (TCP)
-  rule {
-    from_port   = 30000
-    to_port     = 32768
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  # Node ports (UDP)
-  rule {
-    from_port   = 30000
-    to_port     = 32768
-    ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
-  }
-}
-
-resource "openstack_compute_secgroup_v2" "secgroup_master_internal" {
-  name        = "caasp-master-internal-${var.stack_name}"
-  description = "Internal security group for masters"
-
-  # etcd peer
-  rule {
-    from_port   = 2380
-    to_port     = 2380
-    ip_protocol = "tcp"
     self        = true
   }
 
@@ -114,9 +80,9 @@ resource "openstack_compute_secgroup_v2" "secgroup_master_internal" {
   }
 }
 
-resource "openstack_compute_secgroup_v2" "secgroup_worker_external" {
-  name        = "caasp-worker-external-${var.stack_name}"
-  description = "External security group for workers"
+resource "openstack_compute_secgroup_v2" "secgroup_master_external" {
+  name        = "caasp-master-external-${var.stack_name}"
+  description = "External security group for masters"
 
   # Node ports (TCP)
   rule {
@@ -135,32 +101,16 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker_external" {
   }
 }
 
-resource "openstack_compute_secgroup_v2" "secgroup_worker_internal" {
-  name        = "caasp-worker-internal-${var.stack_name}"
-  description = "Internal security group for workers"
-
-  # etcd peer
-  rule {
-    from_port   = 2380
-    to_port     = 2380
-    ip_protocol = "tcp"
-    self        = true
-  }
-
-  # Kubelet API
-  rule {
-    from_port   = 10250
-    to_port     = 10250
-    ip_protocol = "tcp"
-    self        = true
-  }
+resource "openstack_compute_secgroup_v2" "secgroup_worker_external" {
+  name        = "caasp-worker-external-${var.stack_name}"
+  description = "External security group for workers"
 
   # Node ports (TCP)
   rule {
     from_port   = 30000
     to_port     = 32768
     ip_protocol = "tcp"
-    self        = true
+    cidr        = "0.0.0.0/0"
   }
 
   # Node ports (UDP)
@@ -168,7 +118,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker_internal" {
     from_port   = 30000
     to_port     = 32768
     ip_protocol = "udp"
-    self        = true
+    cidr        = "0.0.0.0/0"
   }
 }
 

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -58,6 +58,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
   }
 
   rule {
+    from_port   = 10250
+    to_port     = 10250
+    ip_protocol = "tcp"
+    cidr        = "0.0.0.0/0"
+  }
+
+  rule {
     from_port   = 30000
     to_port     = 32768
     ip_protocol = "tcp"

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -1,6 +1,6 @@
-resource "openstack_compute_secgroup_v2" "secgroup_base" {
-  name        = "caasp-base-${var.stack_name}"
-  description = "Basic security group"
+resource "openstack_compute_secgroup_v2" "secgroup_base_external" {
+  name        = "caasp-base-external-${var.stack_name}"
+  description = "Basic external security group"
 
   # ping
   rule {
@@ -17,13 +17,18 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }
+}
+
+resource "openstack_compute_secgroup_v2" "secgroup_base_internal" {
+  name        = "caasp-base-internal-${var.stack_name}"
+  description = "Basic internal security group"
 
   # etcd client requests
   rule {
     from_port   = 2379
     to_port     = 2379
     ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
+    self        = true
   }
 
   # Cilium health checks
@@ -31,7 +36,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     from_port   = 4240
     to_port     = 4240
     ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
+    self        = true
   }
 
   # Cilium VXLAN overlay
@@ -39,29 +44,13 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
     from_port   = 8472
     to_port     = 8472
     ip_protocol = "udp"
-    cidr        = "0.0.0.0/0"
+    self        = true
   }
 }
 
-resource "openstack_compute_secgroup_v2" "secgroup_master" {
-  name        = "caasp-master-${var.stack_name}"
-  description = "security group for masters"
-
-  # etcd peer
-  rule {
-    from_port   = 2380
-    to_port     = 2380
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
-
-  # Kubelet API
-  rule {
-    from_port   = 10250
-    to_port     = 10250
-    ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
-  }
+resource "openstack_compute_secgroup_v2" "secgroup_master_external" {
+  name        = "caasp-master-external-${var.stack_name}"
+  description = "External security group for masters"
 
   # Node ports (TCP)
   rule {
@@ -80,16 +69,24 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
   }
 }
 
-resource "openstack_compute_secgroup_v2" "secgroup_worker" {
-  name        = "caasp-worker-${var.stack_name}"
-  description = "security group for workers"
+resource "openstack_compute_secgroup_v2" "secgroup_master_internal" {
+  name        = "caasp-master-internal-${var.stack_name}"
+  description = "Internal security group for masters"
 
   # etcd peer
   rule {
     from_port   = 2380
     to_port     = 2380
     ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
+    self        = true
+  }
+
+  # Kubernetes API server
+  rule {
+    from_port   = 6443
+    to_port     = 6443
+    ip_protocol = "tcp"
+    self        = true
   }
 
   # Kubelet API
@@ -97,8 +94,29 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
     from_port   = 10250
     to_port     = 10250
     ip_protocol = "tcp"
-    cidr        = "0.0.0.0/0"
+    self        = true
   }
+
+  # Node ports (TCP)
+  rule {
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "tcp"
+    self        = true
+  }
+
+  # Node ports (UDP)
+  rule {
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "udp"
+    self        = true
+  }
+}
+
+resource "openstack_compute_secgroup_v2" "secgroup_worker_external" {
+  name        = "caasp-worker-external-${var.stack_name}"
+  description = "External security group for workers"
 
   # Node ports (TCP)
   rule {
@@ -114,6 +132,43 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
     to_port     = 32768
     ip_protocol = "udp"
     cidr        = "0.0.0.0/0"
+  }
+}
+
+resource "openstack_compute_secgroup_v2" "secgroup_worker_internal" {
+  name        = "caasp-worker-internal-${var.stack_name}"
+  description = "Internal security group for workers"
+
+  # etcd peer
+  rule {
+    from_port   = 2380
+    to_port     = 2380
+    ip_protocol = "tcp"
+    self        = true
+  }
+
+  # Kubelet API
+  rule {
+    from_port   = 10250
+    to_port     = 10250
+    ip_protocol = "tcp"
+    self        = true
+  }
+
+  # Node ports (TCP)
+  rule {
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "tcp"
+    self        = true
+  }
+
+  # Node ports (UDP)
+  rule {
+    from_port   = 30000
+    to_port     = 32768
+    ip_protocol = "udp"
+    self        = true
   }
 }
 

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -77,8 +77,10 @@ resource "openstack_compute_instance_v2" "worker" {
   }
 
   security_groups = [
-    "${openstack_compute_secgroup_v2.secgroup_base.name}",
-    "${openstack_compute_secgroup_v2.secgroup_worker.name}",
+    "${openstack_compute_secgroup_v2.secgroup_base_external.name}",
+    "${openstack_compute_secgroup_v2.secgroup_base_internal.name}",
+    "${openstack_compute_secgroup_v2.secgroup_worker_external.name}",
+    "${openstack_compute_secgroup_v2.secgroup_worker_internal.name}",
   ]
 
   user_data = "${data.template_file.worker-cloud-init.rendered}"

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -80,7 +80,6 @@ resource "openstack_compute_instance_v2" "worker" {
     "${openstack_compute_secgroup_v2.secgroup_base_external.name}",
     "${openstack_compute_secgroup_v2.secgroup_base_internal.name}",
     "${openstack_compute_secgroup_v2.secgroup_worker_external.name}",
-    "${openstack_compute_secgroup_v2.secgroup_worker_internal.name}",
   ]
 
   user_data = "${data.template_file.worker-cloud-init.rendered}"


### PR DESCRIPTION
## Allow Cilium healthchecks on the OpenStack security groups

By opening 4240/tcp, we allow cilium to perform health checks among
other members.

## Remove unneeded ports from OpenStack security groups

* 8285/udp was specific for Flannel UDP backend
* 80/tcp and 443/tcp
  * In the past, for Velum: remove, old
  * Aiming for ingress in the future?: remove, can be added later
    when we have ingress
* 8080/tcp unsure, remove
* 8081/tcp unsure, remove

## Allow Kubelet port also on control plane nodes on OpenStack

If we are opening the Kubelet API port on worker nodes, do the same
on master nodes so we are consistent.

If they both need to be removed, remove them altogether.

## Document all open ports in security groups for Openstack

Add a comment to every open port, so we keep track of what's the
reason for them to be open.