### PR TITLE
Move common flags to own function

### DIFF
--- a/internal/app/skuba/node/bootstrap.go
+++ b/internal/app/skuba/node/bootstrap.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
+	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/bootstrap"
 )
 
@@ -52,7 +53,6 @@ func NewBootstrapCmd() *cobra.Command {
 	}
 
 	cmd.Flags().AddFlagSet(target.GetFlags())
-	cmd.Flags().StringVar(&bootstrapOptions.ignorePreflightErrors, "ignore-preflight-errors", "", "Comma separated list of preflight errors to ignore")
-
+	actions.AddCommonFlags(&cmd, &bootstrapOptions.ignorePreflightErrors)
 	return &cmd
 }

--- a/internal/app/skuba/node/join.go
+++ b/internal/app/skuba/node/join.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
+	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/join"
 )
 
@@ -54,7 +55,8 @@ func NewJoinCmd() *cobra.Command {
 
 	cmd.Flags().AddFlagSet(target.GetFlags())
 	cmd.Flags().StringVarP(&joinOptions.role, "role", "r", "", "Role that this node will have in the cluster (master|worker) (required)")
-	cmd.Flags().StringVar(&joinOptions.ignorePreflightErrors, "ignore-preflight-errors", "", "Comma separated list of preflight errors to ignore")
+
+	actions.AddCommonFlags(cmd, &joinOptions.ignorePreflightErrors)
 
 	cmd.MarkFlagRequired("role")
 

--- a/internal/app/skuba/node/reset.go
+++ b/internal/app/skuba/node/reset.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
+	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/reset"
 
 	"k8s.io/klog"
@@ -57,7 +58,7 @@ func NewResetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().AddFlagSet(target.GetFlags())
-	cmd.Flags().StringVar(&resetOptions.ignorePreflightErrors, "ignore-preflight-errors", "", "Comma separated list of preflight errors to ignore")
+	actions.AddCommonFlags(&cmd, &resetOptions.ignorePreflightErrors)
 
 	return &cmd
 }

--- a/pkg/skuba/actions/utils.go
+++ b/pkg/skuba/actions/utils.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package actions
+
+import "github.com/spf13/cobra"
+
+// AddCommonFlags adds some common flags to a cobra command
+func AddCommonFlags(cmd *cobra.Command, ignorePreflightErrors *string) {
+	cmd.Flags().StringVar(ignorePreflightErrors, "ignore-preflight-errors", "", "Comma separated list of preflight errors to ignore")
+}


### PR DESCRIPTION
## Why is this PR needed?
Just clean up to ensure common flags have the same wording and done in a central place.
Fixes #https://github.com/SUSE/avant-garde/issues/189

## What does this PR do?
Just cleans up and adds a place for common flags

## Anything else a reviewer needs to know?
I don't think this is 100% needed now that ssh flags are separated, but it could be helpful if in the future we want to add another common flag. Let me know what you think!

