### PR TITLE
Implement Reset node command

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -68,7 +68,7 @@ usage:
     Warning: it removes docker containers, VMs, images, and network configuration.
 
        [-h] [-v YAML_PATH]
-       {info,log,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node}
+      {info,log,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node,reset-node}
        ...
 
 positional arguments:
@@ -86,6 +86,7 @@ positional arguments:
     status              check K8s cluster status
     join-node           add node in k8s cluster with the given role.
     remove-node         remove node from k8s cluster.
+    reset-node          reset node reverting state previous to bootstap/join.
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -104,7 +105,7 @@ optional arguments:
   -w WORKER_COUNT, --worker-count WORKER_COUNT
                         number of workers nodes to be deployed. eg: -w 2
 
-### Node commands (join, remove)
+### Node commands (join, remove, reset)
 
   -h, --help            show this help message and exit
   -r {master,worker}, --role {master,worker}

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -106,7 +106,7 @@ class Skuba:
         try: 
             self._run_skuba(cmd)
         except Exception as ex:
-            raise Exception("Eror executing cmd {}") from ex
+            raise Exception("Error executing cmd {}") from ex
 
     @step
     def node_remove(self, role="worker", nr=0):
@@ -129,7 +129,27 @@ class Skuba:
         try: 
             self._run_skuba(cmd)
         except Exception as ex:
-            raise Exception("Eror executing cmd {}".format(cmd)) from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
+
+    @step
+    def node_reset(self, role="worker", nr=0):
+        self._verify_bootstrap_dependency()
+
+        ip_addrs = self.platform.get_nodes_ipaddrs(role)
+
+        if nr < 0:
+            raise ValueError("Node number cannot be negative")
+
+        if nr >= len(ip_addrs):
+            raise Exception(Format.alert("Node {role}-{nr} not deployed in "
+                      "infrastructure".format(role=role, nr=nr)))
+
+        cmd = "node reset --user {username} --sudo --target {ip}".format(
+                ip=ip_addrs[nr], username=self.conf.nodeuser)
+        try: 
+            self._run_skuba(cmd)
+        except Exception as ex:
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
     def cluster_status(self):
         self._verify_bootstrap_dependency()

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -45,6 +45,8 @@ def join_node(options):
 def remove_node(options):
         Skuba(options.conf).node_remove(role=options.role, nr=options.node)
 
+def reset_node(options):
+        Skuba(options.conf).node_reset(role=options.role, nr=options.node)
 
 def main():
     help = """
@@ -106,6 +108,10 @@ def main():
     cmd_rem_node = commands.add_parser("remove-node", parents=[node_args],
                         help="remove node from k8s cluster.")
     cmd_rem_node.set_defaults(func=remove_node)
+
+    cmd_reset_node = commands.add_parser("reset-node", parents=[node_args],
+                        help="reset node reverting state previous to bootstap/join.")
+    cmd_reset_node.set_defaults(func=reset_node)
 
     options = parser.parse_args()
     conf = BaseConfig(options.yaml_path)


### PR DESCRIPTION
## Why is this PR needed?

Add function for calling the skuba node reset command and expose it to the cli interface

Fixes # https://github.com/SUSE/avant-garde/issues/415

## Anything else a reviewer needs to know?

This PR depends on the command parsing implemented in #415 