### PR TITLE
ci: infra: Generate `var.internal_subnet` and `var.internal_router` if empty

### DIFF
--- a/ci/infra/openstack/network.tf
+++ b/ci/infra/openstack/network.tf
@@ -4,7 +4,7 @@ resource "openstack_networking_network_v2" "network" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet" {
-  name       = "${var.internal_subnet}"
+  name       = "${var.internal_subnet == "" ? "${var.internal_net}-subnet" : "${var.internal_subnet}"}"
   network_id = "${openstack_networking_network_v2.network.id}"
   cidr       = "${var.subnet_cidr}"
   ip_version = 4
@@ -15,7 +15,7 @@ data "openstack_networking_network_v2" "external_network" {
 }
 
 resource "openstack_networking_router_v2" "router" {
-  name                = "${var.internal_router}"
+  name                = "${var.internal_router == "" ? "${var.internal_net}-router" : "${var.internal_router}"}"
   external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
 }
 

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -9,14 +9,20 @@ image_name = ""
 internal_net = ""
 
 # Name of the internal subnet to be created
-# EXAMPLE:
+# IMPORTANT: If this variable is not set or empty,
+# then it will be generated with schema
 # internal_subnet = "${var.internal_net}-subnet"
-internal_subnet = "${var.internal_net}-subnet"
+# EXAMPLE:
+# internal_subnet = "testing-subnet"
+internal_subnet = ""
 
 # Name of the internal router to be created
-# EXAMPLE:
+# IMPORTANT: If this variable is not set or empty,
+# then it will be generated with schema
 # internal_router = "${var.internal_net}-router"
-internal_router = "${var.internal_net}-router"
+# EXAMPLE:
+# internal_router = "testing-router"
+internal_router = ""
 
 # Name of the external network to be used, the one used to allocate floating IPs
 # EXAMPLE:


### PR DESCRIPTION
## Why is this PR needed?


Currently `var.internal_subnet` and `var.internal_router` variables
are created in wrong way which is causing also problem with
their names in OpenStack e.g. ${var.internal_net}-subnet and
${var.internal_net}-router

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1138859

## What does this PR do?

This change is auto-generating `var.internal_subnet` and
`var.internal_router` if they are empty, they can be still
set explicitly in terraform.tfvars

## Documentation PR

https://github.com/SUSE/doc-caasp/pull/301