### PR TITLE
Add `test-unit-coverage` target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 # RPM files folder
 ci/packaging/suse/obs_files
 
+# ignore coverage result
+/coverage.out
+
 # ignore ginkgo and skuba
 /ginkgo
 /skuba

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,11 @@ test: test-unit test-e2e
 
 .PHONY: test-unit
 test-unit:
-	$(GO) test $(PROJECT_PATH)/{cmd,pkg,internal}/...
+	$(GO) test -coverprofile=coverage.out $(PROJECT_PATH)/{cmd,pkg,internal}/...
+
+.PHONY: test-unit-coverage
+test-unit-coverage: test-unit
+	$(GO) tool cover -html=coverage.out
 
 .PHONY: test-e2e
 test-e2e:


### PR DESCRIPTION
## Why is this PR needed?

Add a new `test-unit-coverage` that will call to `go tool coverage`
showing the coverage result of the unit tests.

When running unit tests, automatically generate the coverage report.