### PR TITLE
Update e2e tests instructions

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -12,8 +12,13 @@ The test can be run locally or in CI.
 
 # Requirements:
 
-- the infrastructure is already deployed. ( Terraform is not necessary a requirement, only the ips)
-  See mandatory variable for the number of instances required.
+- The infrastructure should be already deployed (using Terraform is not mandatory; only the IP addresses are needed). For more information see mandatory variables for the number of instances required.
+
+- Running _ssh-agent_ socket at `/tmp/ssh-agent-sock`. You can do that by running: `./ci/tasks/setup-ssh.py`. Otherwise, you can try manually, by typing: `eval $(ssh-agent -a /tmp/ssh-agent-sock); ssh-add ci/infra/id_shared`. 
+
+- You can verify whether the key has been loaded correctly into the _ssh-agent_ by issuing the command: `ssh-add -L`.
+
+- Last but not least, you should be able to connect non-interactively to (either master or worker) node as a _sles_ user : `ssh sles@<node-ip>`.
 
 # Howto 
 


### PR DESCRIPTION
Adds missing information about configuring the ssh-agent.
Otherwise it fails to run the tests, but because of the tests,
but because of the ssh connection.

## Why is this PR needed?

It improves the documentation for running e2e tests.

## What does this PR do?

Make's sure the user doesn't see this error:

```
F0702 15:56:13.551152   12614 bootstrap.go:49] error bootstraping node: unable to add target information to init configuration: could not retrieve OS release information: failed to initialize client: dial unix /tmp/ssh-agent-sock: connect: no such file or directory
```

## Anything else a reviewer needs to know?

No tests or further work is needed. This should be a simple `approve` situation.