### PR TITLE
Fix bootstrap command

### DIFF
--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -31,7 +31,8 @@ def build_skuba(options):
     Skuba.build(options.conf)
 
 def bootstrap(options):
-    Tests(options.conf).bootstrap_environment()
+    Skuba(options.conf).cluster_init()
+    Skuba(options.conf).node_bootstrap()
 
 def cluster_status(options):
     Skuba(options.conf).cluster_status()


### PR DESCRIPTION
## Why is this PR needed?
Bootstrap command is implemented as part of the Tests class which is being moved outside testrunner.

Fixes https://github.com/SUSE/avant-garde/issues/522

## What does this PR do?   
Re-implements the bootstrap command it using directly th Skuba class.
    
## Comments to reviewers

The bootstrap command also includes the sub-step of cluster-init  for compatibility with existing ci scripts which call bootstrap command.
