### PR TITLE
[WIP] Allow passing an external registry via environment

### DIFF
--- a/pkg/skuba/release_constants.go
+++ b/pkg/skuba/release_constants.go
@@ -19,7 +19,23 @@
 
 package skuba
 
+import "fmt"
+import "os"
+
+// Temporary workaround until release.
+// No longer a const... Bad place for this.
+var ImageRepository string
+
+func init() {
+        skubaImageRepo, skir := os.LookupEnv("SKUBA_IMAGE_REPO")
+        if skir {
+                fmt.Printf("SKUBA_IMAGE_REPO: %s\n", skubaImageRepo)
+                ImageRepository=skubaImageRepo
+        } else {
+                ImageRepository = "registry.suse.com/caasp/v4"
+        }
+}
+
 const (
-	BuildType       = "release"
-	ImageRepository = "registry.suse.com/caasp/v4"
+       BuildType       = "release"
 )


### PR DESCRIPTION
## Why is this PR needed?

This allows us to pass in an alternate registry, rather than use the hardcoded one.
This resolves the challenges with air-gapped deployments.

## What does this PR do?

Allows the the user to change the ImageRepository variable from the fixed value when the environment variable SKUBA_IMAGE_REPO is set. 

## Anything else a reviewer needs to know?

This isn't the best approach for resolving the issue, but made the most sense with the least amount of effort, since it will become obsoleted when CRI-O is updated.
This was just meant to be used for internal testing, but I was told to submit a PR.
If you'd like me to rework this, or are willing to work with me on an alternate approach, I would love to help.