### PR TITLE
Don't store the nodes keys in known hosts

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -110,6 +110,6 @@ resource "null_resource" "master_reboot" {
       host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
     }
 
-    command = "ssh -o StrictHostKeyChecking=no $user@$host sudo reboot || :"
+    command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :"
   }
 }

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -122,6 +122,6 @@ resource "null_resource" "worker_reboot" {
       host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
     }
 
-    command = "ssh -o StrictHostKeyChecking=no $user@$host sudo reboot || :"
+    command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :"
   }
 }


### PR DESCRIPTION
## Why is this PR needed?

The reboot command was causing the keys to be stored on the Jenkins workers

Fixes https://github.com/SUSE/skuba/issues/426

## What does this PR do?

The keys should no longer be stored

## Anything else a reviewer needs to know?

After this is merged we need to remove the keys from the workers