### PR TITLE
Update kubernetes version to 1.15.0

### DIFF
--- a/internal/pkg/skuba/kubernetes/nodes_test.go
+++ b/internal/pkg/skuba/kubernetes/nodes_test.go
@@ -18,6 +18,7 @@
 package kubernetes
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -28,8 +29,8 @@ import (
 )
 
 func TestNodeVersioningInfoWithClientset(t *testing.T) {
-	testK8sVersion := version.MustParseSemantic("v1.14.1")
-	testEtcdVersion := version.MustParseSemantic("3.3.11")
+	testK8sVersion := version.MustParseSemantic(fmt.Sprintf("v%s", CurrentVersion))
+	testEtcdVersion := version.MustParseSemantic(currentETCDVersion)
 	namespace := "kube-system"
 	var nodes = []struct {
 		name                     string
@@ -47,14 +48,14 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 			name:                     "node version info schedulable",
 			nodeName:                 "my-master-0",
 			unschedulable:            false,
-			containerRuntimeVersion:  "cri-o://1.14.1",
+			containerRuntimeVersion:  fmt.Sprintf("cri-o://%s", CurrentVersion),
 			kubeletVersion:           testK8sVersion,
 			apiServerVersion:         testK8sVersion,
 			controllerManagerVersion: testK8sVersion,
 			schedulerVersion:         testK8sVersion,
 			etcdVersion:              testEtcdVersion,
 			expectedNodeVersionInfo: NodeVersionInfo{
-				ContainerRuntimeVersion:  "cri-o://1.14.1",
+				ContainerRuntimeVersion:  fmt.Sprintf("cri-o://%s", CurrentVersion),
 				KubeletVersion:           testK8sVersion,
 				APIServerVersion:         testK8sVersion,
 				ControllerManagerVersion: testK8sVersion,
@@ -67,14 +68,14 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 			name:                     "node version info unschedulable",
 			nodeName:                 "my-master-0",
 			unschedulable:            true,
-			containerRuntimeVersion:  "cri-o://1.14.1",
+			containerRuntimeVersion:  fmt.Sprintf("cri-o://%s", CurrentVersion),
 			kubeletVersion:           testK8sVersion,
 			apiServerVersion:         testK8sVersion,
 			controllerManagerVersion: testK8sVersion,
 			schedulerVersion:         testK8sVersion,
 			etcdVersion:              testEtcdVersion,
 			expectedNodeVersionInfo: NodeVersionInfo{
-				ContainerRuntimeVersion:  "cri-o://1.14.1",
+				ContainerRuntimeVersion:  fmt.Sprintf("cri-o://%s", CurrentVersion),
 				KubeletVersion:           testK8sVersion,
 				APIServerVersion:         testK8sVersion,
 				ControllerManagerVersion: testK8sVersion,
@@ -108,7 +109,7 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "kube-apiserver",
-							Image: "registry.suse.com/caasp/v4/hyperkube:1.14.1",
+							Image: fmt.Sprintf("%s/%s/%s/hyperkube:%s", registry, productName, caaspVersion, CurrentVersion),
 						},
 					},
 					NodeName: "my-master-0",
@@ -122,7 +123,7 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "kube-controller-manager",
-							Image: "registry.suse.com/caasp/v4/hyperkube:1.14.1",
+							Image: fmt.Sprintf("%s/%s/%s/hyperkube:%s", registry, productName, caaspVersion, CurrentVersion),
 						},
 					},
 					NodeName: "my-master-0",
@@ -136,7 +137,7 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "kube-scheduler",
-							Image: "registry.suse.com/caasp/v4/hyperkube:1.14.1",
+							Image: fmt.Sprintf("%s/%s/%s/hyperkube:%s", registry, productName, caaspVersion, CurrentVersion),
 						},
 					},
 					NodeName: "my-master-0",
@@ -150,7 +151,7 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 					Containers: []v1.Container{
 						{
 							Name:  "etcd",
-							Image: "registry.suse.com/caasp/v4/etcd:3.3.11",
+							Image: fmt.Sprintf("%s/%s/%s/etcd:%s", registry, productName, caaspVersion, currentETCDVersion),
 						},
 					},
 					NodeName: "my-master-0",
@@ -168,7 +169,7 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 func TestGetPodContainerImageTagWithClientset(t *testing.T) {
 	podName := "etcd-my-master-0"
 	namespace := "kube-system"
-	expectedEtcdContainerImageTag := "3.3.11"
+	expectedEtcdContainerImageTag := currentETCDVersion
 	t.Run("get pod container image tag with clientset", func(t *testing.T) {
 		clientset := fake.NewSimpleClientset(&v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -179,7 +180,7 @@ func TestGetPodContainerImageTagWithClientset(t *testing.T) {
 				Containers: []v1.Container{
 					{
 						Name:  "etcd",
-						Image: "registry.suse.com/caasp/v4/etcd:3.3.11",
+						Image: fmt.Sprintf("%s/%s/%s/etcd:%s", registry, productName, caaspVersion, currentETCDVersion),
 					},
 				},
 			},

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -18,10 +18,25 @@
 package kubernetes
 
 import (
+	"fmt"
 	"log"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/util/version"
+)
+
+// Update the latest currently supported versions
+const (
+	CurrentVersion        = "1.15.0"
+	currentETCDVersion    = "3.3.11"
+	currentCoreDNSVersion = "1.3.1"
+	currentPauseVersion   = "3.1"
+	currentCiliumVersion  = "1.5.3"
+	currentToolingVersion = "0.1.0"
+	currentKuredVersion   = "1.2.0"
+	registry              = "registry.suse.com"
+	productName           = "caasp"
+	caaspVersion          = "v4"
 )
 
 type Addon string
@@ -61,12 +76,10 @@ type KubernetesVersion struct {
 
 type KubernetesVersions map[string]KubernetesVersion
 
-const (
-	CurrentVersion = "v1.14.1"
-)
-
 var (
 	Versions = KubernetesVersions{
+		// Old supported k8s versions
+		// When you update the KubernetesVersion to a new one, add the current to the old supported versions
 		"v1.14.1": KubernetesVersion{
 			ControlPlaneComponentsVersion: ControlPlaneComponentsVersion{
 				EtcdVersion:    "3.3.11",
@@ -82,11 +95,27 @@ var (
 				KuredVersion:   "1.2.0",
 			},
 		},
+		// New (current) supported supported version
+		fmt.Sprintf("v%s", CurrentVersion): KubernetesVersion{
+			ControlPlaneComponentsVersion: ControlPlaneComponentsVersion{
+				EtcdVersion:    currentETCDVersion,
+				CoreDNSVersion: currentCoreDNSVersion,
+				PauseVersion:   currentPauseVersion,
+			},
+			ComponentsVersion: ComponentsVersion{
+				KubeletVersion: fmt.Sprintf("v%s", CurrentVersion),
+			},
+			AddonsVersion: AddonsVersion{
+				CiliumVersion:  currentCiliumVersion,
+				ToolingVersion: currentToolingVersion,
+				KuredVersion:   currentKuredVersion,
+			},
+		},
 	}
 )
 
 func CurrentComponentVersion(component Component) string {
-	currentKubernetesVersion := Versions[CurrentVersion]
+	currentKubernetesVersion := Versions[fmt.Sprintf("v%s", CurrentVersion)]
 	switch component {
 	case Etcd:
 		return currentKubernetesVersion.ControlPlaneComponentsVersion.EtcdVersion
@@ -100,7 +129,7 @@ func CurrentComponentVersion(component Component) string {
 }
 
 func CurrentAddonVersion(addon Addon) string {
-	currentKubernetesVersion := Versions[CurrentVersion]
+	currentKubernetesVersion := Versions[fmt.Sprintf("v%s", CurrentVersion)]
 	switch addon {
 	case Tooling:
 		return currentKubernetesVersion.AddonsVersion.ToolingVersion


### PR DESCRIPTION
This PR updates the current supported version of k8s up to 1.15.0
while maintains the previous entries (1.14.1) for upgrade
functionality.

## Why is this PR needed?

There's a new version of k8s available we need to support.

Fixes https://github.com/SUSE/avant-garde/issues/518

## What does this PR do?

Update the currently supported versions for the k8s ecosystem to work by adding a new entry, instead of overriding the current one. The reasoning behind this is since beta3 will be updatable to beta4, we need to test the upgrade functionality.

## Anything else a reviewer needs to know?

unit tests seems to be passing:

```
tux@ultron:~/go/src/github.com/SUSE/skuba/internal/pkg/skuba/kubernetes(bump_k8s_1.15.0)$ go test -v
=== RUN   TestNodeVersioningInfoWithClientset
=== RUN   TestNodeVersioningInfoWithClientset/node_version_info_schedulable
=== RUN   TestNodeVersioningInfoWithClientset/node_version_info_unschedulable
--- PASS: TestNodeVersioningInfoWithClientset (0.00s)
    --- PASS: TestNodeVersioningInfoWithClientset/node_version_info_schedulable (0.00s)
    --- PASS: TestNodeVersioningInfoWithClientset/node_version_info_unschedulable (0.00s)
=== RUN   TestGetPodContainerImageTagWithClientset
=== RUN   TestGetPodContainerImageTagWithClientset/get_pod_container_image_tag_with_clientset
--- PASS: TestGetPodContainerImageTagWithClientset (0.00s)
    --- PASS: TestGetPodContainerImageTagWithClientset/get_pod_container_image_tag_with_clientset (0.00s)
=== RUN   TestAvailableVersionsForMap
=== RUN   TestAvailableVersionsForMap/v1.14.0-v1.15.0
=== RUN   TestAvailableVersionsForMap/v1.14.0-v1.14.1-v1.15.0
--- PASS: TestAvailableVersionsForMap (0.00s)
    --- PASS: TestAvailableVersionsForMap/v1.14.0-v1.15.0 (0.00s)
    --- PASS: TestAvailableVersionsForMap/v1.14.0-v1.14.1-v1.15.0 (0.00s)
PASS
ok  	github.com/SUSE/skuba/internal/pkg/skuba/kubernetes	0.008s
```

I am not aware what documentation is needed for the new versions.
Please do not merge this until everything is published into build.suse.de and registry.suse.de (see: https://github.com/SUSE/avant-garde/issues/466)