### PR TITLE
cmd/skuba: set the proper long name for the -v flag

### DIFF
--- a/cmd/skuba/skuba.go
+++ b/cmd/skuba/skuba.go
@@ -61,6 +61,7 @@ func main() {
 func register(local *pflag.FlagSet, globalName string) {
 	if f := flag.CommandLine.Lookup(globalName); f != nil {
 		pflagFlag := pflag.PFlagFromGoFlag(f)
+		pflagFlag.Name = "verbosity"
 		local.AddFlag(pflagFlag)
 	} else {
 		klog.Fatalf("failed to find flag in global flagset (flag): %s", globalName)


### PR DESCRIPTION
## Why is this PR needed?

The help action show a weird output for the `-v` flag:

```
  -v, --v Level   number for the log level verbosity
```

## What does this PR do?

Gives a proper long name to this flag. Now the output shows:

```
  -v, --verbosity Level   number for the log level verbosity
```