### PR TITLE
Switch to kernel-default-base on openstack

### DIFF
--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -77,8 +77,7 @@ repositories = {}
 # Minimum required packages. Do not remove them.
 # Feel free to add more packages
 packages = [
-  "kernel-default",
-  "-kernel-default-base",
+  "kernel-default-base",
   "patterns-caasp-Node"
 ]
 

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -27,8 +27,7 @@
         "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
     },
     "packages": [
-        "kernel-default",
-        "-kernel-default-base",
+        "kernel-default-base",
         "ca-certificates-suse",
         "patterns-caasp-Node"
     ],

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -95,8 +95,7 @@ variable "packages" {
   type = "list"
 
   default = [
-    "kernel-default",
-    "-kernel-default-base",
+    "kernel-default-base",
     "patterns-caasp-Node",
   ]
 


### PR DESCRIPTION
Kernel-default-base has required modules now. It's not in JeOS-15-SP1-GM, so we still need to update
kernel until we rebase on JeOS-15-SP2.

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1134743
Related issue: https://github.com/SUSE/avant-garde/issues/490
Doc PR: https://github.com/SUSE/doc-caasp/pull/342

Verified with cloud-init-output.log:
```
The following 33 NEW packages are going to be installed:
  apparmor-parser bash-completion ca-certificates-suse caasp-config cni cni-plugins conntrack-tools cri-o cri-o-kubeadm-criconfig cri-tools ebtables ethtool iptables kernel-default-base-4.12.14-197.7.1 kubernetes-client kubernetes-common kubernetes-kubeadm kubernetes-kubelet libcontainers-common libiptc0 libnetfilter_conntrack3 libnetfilter_cthelper0 libnetfilter_cttimeout1 libnetfilter_queue1 libnfnetlink0 libwrap0 lsof patterns-base-basesystem patterns-caasp-Node runc skuba-update socat xtables-plugins

The following 2 NEW patterns are going to be installed:
  SUSE-CaaSP-Node basesystem

The following 11 packages have no support information from their vendor:
  ca-certificates-suse caasp-config cri-o cri-o-kubeadm-criconfig cri-tools kubernetes-client kubernetes-common kubernetes-kubeadm kubernetes-kubelet patterns-caasp-Node skuba-update

The following package requires a system reboot:
  kernel-default-base-4.12.14-197.7.1
```