### PR TITLE
ci: infra: Enable DNS in libvirt terraform

### DIFF
--- a/ci/infra/libvirt/network.tf
+++ b/ci/infra/libvirt/network.tf
@@ -1,6 +1,11 @@
 resource "libvirt_network" "network" {
-  name      = "${var.stack_name}-network"
-  mode      = "${var.network_mode}"
-  domain    = "${var.dns_domain}"
+  name   = "${var.stack_name}-network"
+  mode   = "${var.network_mode}"
+  domain = "${var.dns_domain}"
+
+  dns = {
+    enabled = true
+  }
+
   addresses = ["${var.network_cidr}"]
 }


### PR DESCRIPTION
Without dns=enabled set, /etc/resolv.conf does not contain any
nameservers so eg. package installation does not work.