### PR TITLE
Add a drain-timeout parameter to node removal.

### DIFF
--- a/internal/pkg/skuba/kubernetes/nodes.go
+++ b/internal/pkg/skuba/kubernetes/nodes.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -65,11 +66,11 @@ func IsControlPlane(node *v1.Node) bool {
 	return isControlPlane
 }
 
-func DrainNode(node *v1.Node) error {
+func DrainNode(node *v1.Node, drainTimeout time.Duration) error {
 	// Drain node (shelling out, FIXME after https://github.com/kubernetes/kubernetes/pull/72827 can be used [1.14])
 	cmd := exec.Command("kubectl",
 		fmt.Sprintf("--kubeconfig=%s", skuba.KubeConfigAdminFile()),
-		"drain", "--delete-local-data=true", "--force=true", "--ignore-daemonsets=true", node.ObjectMeta.Name)
+		"drain", "--delete-local-data=true", "--force=true", "--ignore-daemonsets=true", fmt.Sprintf("--timeout=%s", drainTimeout.String()), node.ObjectMeta.Name)
 
 	if err := cmd.Run(); err != nil {
 		klog.V(1).Infof("could not drain node %s, aborting (use --force if you want to ignore this error)", node.ObjectMeta.Name)

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -19,6 +19,7 @@ package remove
 
 import (
 	"fmt"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -30,7 +31,7 @@ import (
 )
 
 // Remove removes a node from the cluster
-func Remove(target string) error {
+func Remove(target string, drainTimeout time.Duration) error {
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return errors.Wrap(err, "unable to get admin client set")
@@ -45,12 +46,12 @@ func Remove(target string) error {
 
 	var isControlPlane bool
 	if isControlPlane = kubernetes.IsControlPlane(node); isControlPlane {
-		fmt.Printf("[remove-node] removing control plane node %s\n", targetName)
+		fmt.Printf("[remove-node] removing control plane node %s (drain timeout: %s)\n", targetName, drainTimeout.String())
 	} else {
-		fmt.Printf("[remove-node] removing worker node %s\n", targetName)
+		fmt.Printf("[remove-node] removing worker node %s (drain timeout: %s)\n", targetName, drainTimeout.String())
 	}
 
-	kubernetes.DrainNode(node)
+	kubernetes.DrainNode(node, drainTimeout)
 
 	if isControlPlane {
 		fmt.Printf("[remove-node] removing etcd from node %s\n", targetName)


### PR DESCRIPTION
When draining a node kubernetes usually waits indefinitely, but if
the node is powered off this will lead to it not being removed.

With this parameters the user can specify a custom timeout in a case
like this, to force the removal after a certain amount of time.

## Why is this PR needed?

Fixes bsc#1138139

## Anything else a reviewer needs to know?

When attempting to remove the node without specifying a timeout it will still hang forever, so the user still *must* pass a timeout to prevent the bug from happening.

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->