### PR TITLE
Fixes reset command by unmasking the kubelet service

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -47,6 +47,10 @@ func kubeadmReset(t *Target, data interface{}) error {
 		ignorePreflightErrors = "--ignore-preflight-errors=" + ignorePreflightErrorsVal
 	}
 	_, _, err := t.ssh("kubeadm", "reset", "--cri-socket", "/var/run/crio/crio.sock", "--force", ignorePreflightErrors)
+	if err != nil {
+		return err
+	}
+	_, _, err = t.ssh("systemctl", "unmask", "kubelet")
 	return err
 }
 


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

## Why is this PR needed?

When removing a node and then reset it, it cannot be rejoined due to an error in the `kubelet` service. So the `kubelet` service needs to be unmasked to be able to rejoin the node.

Does it fix an issue? addresses a business case?

The feature to solve this issue:
- https://bugzilla.suse.com/show_bug.cgi?id=1136371

## What does this PR do?

This PR includes the execution of the command to unmask `kubelet` service.

## Anything else a reviewer needs to know?

- Build Skuba
- Start a cluster
- remove a node
- reset a node
- rejoin the node
