### PR TITLE
Use gomod flags for `test-unit` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test: test-unit test-e2e
 
 .PHONY: test-unit
 test-unit:
-	$(GO) test -coverprofile=coverage.out $(PROJECT_PATH)/{cmd,pkg,internal}/...
+	$(GO) test $(GOMODFLAG) -coverprofile=coverage.out $(PROJECT_PATH)/{cmd,pkg,internal}/...
 
 .PHONY: test-unit-coverage
 test-unit-coverage: test-unit


### PR DESCRIPTION
## Why is this PR needed?

Using gomod flags on `test-unit` target allows to use the vendoring
gomod capability when running unit tests as well, so no need to
fetch remote requirements.