### PR TITLE
Add dex version to 1.15 map as well

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -88,6 +88,7 @@ var (
 				CiliumVersion:  "1.5.3",
 				ToolingVersion: "0.1.0",
 				KuredVersion:   "1.2.0",
+				DexVersion:     "2.16.0",
 				GangwayVersion: "3.1.0",
 			},
 		},

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -86,7 +86,7 @@ func TestCurrentComponentVersion(t *testing.T) {
 }
 
 func TestCurrentAddonVersion(t *testing.T) {
-	addons := []Addon{Tooling, Cilium, Kured, Gangway}
+	addons := []Addon{Tooling, Cilium, Kured, Dex, Gangway}
 	for _, addon := range addons {
 		t.Run(fmt.Sprintf("addon %q has a version assigned", addon), func(t *testing.T) {
 			addonVersion := CurrentAddonVersion(addon)


### PR DESCRIPTION
## Why is this PR needed?

This fixes the build for 1.15, since dex version is not mappable
without being present on the version map.

After https://github.com/SUSE/skuba/pull/446 merged, dex version is also necessary on the version map.