### PR TITLE
ci: infra: Fix terraform outputs for libvirt

### DIFF
--- a/ci/infra/libvirt/output.tf
+++ b/ci/infra/libvirt/output.tf
@@ -1,11 +1,11 @@
-output "ip_lb" {
+output "ip_load_balancer" {
   value = "${libvirt_domain.lb.network_interface.0.addresses.0}"
 }
 
-output "masters" {
+output "ip_masters" {
   value = ["${libvirt_domain.master.*.network_interface.0.addresses.0}"]
 }
 
-output "workers" {
+output "ip_workers" {
   value = ["${libvirt_domain.worker.*.network_interface.0.addresses.0}"]
 }


### PR DESCRIPTION
Use the same output names in the libvirt and openstack provider
specific code.
This makes it easier to use the nodes later no matter with which
provider the nodes were deployed.