### PR TITLE
gangway APIServerURL should be https://<LB IP/LB FQDN>:6443

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -1035,7 +1035,7 @@ data:
     clientID: "gangway"
     clientSecret: "{{.GangwayClientSecret}}"
     usernameClaim: "sub"
-    apiServerURL: "https://kubernetes.default.svc.cluster.local:6443"
+    apiServerURL: "https://{{.ControlPlane}}:6443"
     cluster_ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     trustedCAPath: /etc/gangway/pki/ca.crt
 ---


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

The API server URL should be load balancer <IP/FQDN>:6443 which let the user configures kubectl RBAC, original FQDN `https://kubernetes.default.svc.cluster.local:6443` may not be accessible to the user.

## What does this PR do?

Change API server URL from load balancer <IP/FQDN>

## Anything else a reviewer needs to know?

An example on gangway of how the user configures kubectl
![Screenshot from 2019-07-08 16-55-04](https://user-images.githubusercontent.com/49380831/60799770-63a65900-a1a6-11e9-90cc-7ccfeb1d32f8.png)
