### PR TITLE
ci: infra: Wait for ssh in libvirt terraform after reboot

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -102,6 +102,10 @@ resource "null_resource" "lb_reboot" {
       host = "${element(libvirt_domain.lb.*.network_interface.0.addresses.0, count.index)}"
     }
 
-    command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :"
+    command = <<EOT
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
+# wait for ssh ready after reboot
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
+EOT
   }
 }

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -122,6 +122,10 @@ resource "null_resource" "master_reboot" {
       host = "${element(libvirt_domain.master.*.network_interface.0.addresses.0, count.index)}"
     }
 
-    command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :"
+    command = <<EOT
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
+# wait for ssh ready after reboot
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
+EOT
   }
 }

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -122,6 +122,10 @@ resource "null_resource" "worker_reboot" {
       host = "${element(libvirt_domain.worker.*.network_interface.0.addresses.0, count.index)}"
     }
 
-    command = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :"
+    command = <<EOT
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
+# wait for ssh ready after reboot
+ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
+EOT
   }
 }


### PR DESCRIPTION
Commit c9ac03aa366 fixed the reboot for the nodes when deployed with
libvirt. But now terraform finishes but the nodes are not ready
because they are currently rebooted. So wait until the reboot is done.
