### PR TITLE
Expose dex/gangway port on VMware/libvirt load balancer

### DIFF
--- a/ci/infra/libvirt/cloud-init/lb.tpl
+++ b/ci/infra/libvirt/cloud-init/lb.tpl
@@ -57,9 +57,25 @@ write_files:
       bind :6443
       default_backend apiserver-backend
 
+    frontend gangway
+      bind :32001
+      default_backend gangway-backend
+
+    frontend dex
+      bind :32002
+      default_backend dex-backend
+
     backend apiserver-backend
       option httpchk GET /healthz
-      ${backends}
+      ${apiserver_backends}
+
+    backend gangway-backend
+      option httpchk GET /
+      ${gangway_backends}
+
+    backend dex-backend
+      option httpchk GET /healthz
+      ${dex_backends}
 
 runcmd:
   # Since we are currently inside of the cloud-init systemd unit, trying to

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -8,9 +8,29 @@ data "template_file" "lb_repositories" {
   }
 }
 
-data "template_file" "haproxy_backends_master" {
+data "template_file" "haproxy_apiserver_backends_master" {
   count    = "${var.masters}"
   template = "server $${fqdn} $${ip}:6443 check check-ssl verify none\n"
+
+  vars = {
+    fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
+    ip   = "${cidrhost(var.network_cidr, 512 + count.index)}"
+  }
+}
+
+data "template_file" "haproxy_gangway_backends_master" {
+  count    = "${var.masters}"
+  template = "server $${fqdn} $${ip}:32001 check check-ssl verify none\n"
+
+  vars = {
+    fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
+    ip   = "${cidrhost(var.network_cidr, 512 + count.index)}"
+  }
+}
+
+data "template_file" "haproxy_dex_backends_master" {
+  count    = "${var.masters}"
+  template = "server $${fqdn} $${ip}:32002 check check-ssl verify none\n"
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
@@ -23,13 +43,15 @@ data "template_file" "lb_cloud_init_userdata" {
   template = "${file("cloud-init/lb.tpl")}"
 
   vars {
-    backends        = "${join("      ", data.template_file.haproxy_backends_master.*.rendered)}"
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.lb_repositories.*.rendered)}"
-    packages        = "${join("\n", formatlist("  - %s", var.packages))}"
-    username        = "${var.username}"
-    password        = "${var.password}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+    apiserver_backends = "${join("      ", data.template_file.haproxy_apiserver_backends_master.*.rendered)}"
+    gangway_backends   = "${join("      ", data.template_file.haproxy_gangway_backends_master.*.rendered)}"
+    dex_backends       = "${join("      ", data.template_file.haproxy_dex_backends_master.*.rendered)}"
+    authorized_keys    = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
+    repositories       = "${join("\n", data.template_file.lb_repositories.*.rendered)}"
+    packages           = "${join("\n", formatlist("  - %s", var.packages))}"
+    username           = "${var.username}"
+    password           = "${var.password}"
+    ntp_servers        = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
   }
 }
 

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -50,10 +50,28 @@ write_files:
       bind :6443
       default_backend apiserver-backend
 
+    frontend gangway
+      bind :32001
+      default_backend gangway-backend
+
+    frontend dex
+      bind :32002
+      default_backend dex-backend
+
     backend apiserver-backend
       option httpchk GET /healthz
-      http-check expect string ok
-      ${backends}
+      http-check expect status 200
+      ${apiserver_backends}
+
+    backend gangway-backend
+      option httpchk GET /
+      http-check expect status 200
+      ${gangway_backends}
+
+    backend dex-backend
+      option httpchk GET /healthz
+      http-check expect status 200
+      ${dex_backends}
 
 runcmd:
   # Since we are currently inside of the cloud-init systemd unit, trying to


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

Previous [PR](https://github.com/SUSE/skuba/pull/446) supports dex/gangway on OpenStack only, add platform VMware and libvirt also.

## What does this PR do?

Add gangway port `32001` and dex port `32002` on the load balancer and add a health check endpoint to gangway `/` and dex `/healthz`

## Anything else a reviewer needs to know?

dex and gangway log bump out error message `http: TLS handshake error from 10.244.0.1:34080: tls: client offered only unsupported versions: [300]`, this is due to the Kubernetes root CA is not a trusted certificate in the load balancer. But API server log also bumps this error message out.

The way to fix this issue is to add Kubernetes root CA to load balancer node trusted certificate chain but we are not going to do since the customer might change the root CA.