### PR TITLE
Added dex CaaS theme

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -871,6 +871,7 @@ data:
       tlsClientCA: /etc/dex/pki/ca.crt
 
     frontend:
+      theme: "caasp"
       dir: /usr/share/caasp-dex/web
 
     # This is a sample with LDAP as connector.


### PR DESCRIPTION
This is required to replace default Dex CoreOS theme with CaaS branding.

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>
