### PR TITLE
Fix dex static client id must equals to apiserver oidc client id

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -31,7 +31,7 @@ apiServer:
     - {{.ControlPlane}}
   extraArgs:
     oidc-issuer-url: https://{{.ControlPlane}}:32002
-    oidc-client-id: oidc-dex
+    oidc-client-id: oidc
     oidc-ca-file: /etc/kubernetes/pki/ca.crt
     oidc-username-claim: email
     oidc-groups-claim: groups
@@ -901,10 +901,10 @@ data:
           nameAttr: cn
 
     staticClients:
-    - id: gangway
+    - id: oidc
       redirectURIs:
       - 'https://{{.ControlPlane}}:32001/callback'
-      name: 'gangway'
+      name: 'OIDC'
       secret: {{.GangwayClientSecret}}
 ---
 apiVersion: apps/v1
@@ -1032,7 +1032,7 @@ data:
     keyFile: /etc/gangway/pki/tls.key
     certFile: /etc/gangway/pki/tls.crt
 
-    clientID: "gangway"
+    clientID: "oidc"
     clientSecret: "{{.GangwayClientSecret}}"
     usernameClaim: "sub"
     apiServerURL: "https://{{.ControlPlane}}:6443"


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

User cannot use downloaded kubeconfig to access k8s cluster, bump error `error: You must be logged in to the server (Unauthorized)`.

## What does this PR do?

This is due to the client id of dex and apiserver mismatch, so align it.

## Anything else a reviewer needs to know?

N/A