### PR TITLE
Use 3 digits in name instances and uniformize name between platforms

### DIFF
--- a/ci/infra/aws/cluster.tf
+++ b/ci/infra/aws/cluster.tf
@@ -500,7 +500,7 @@ resource "aws_instance" "control_plane" {
   user_data                   = "${data.template_cloudinit_config.cfg.rendered}"
 
   tags = "${merge(local.tags, map(
-    "Name", "${var.stack_name}-master-${count.index}",
+    "Name", "${format("${var.stack_name}-master-%03d", count.index)}",
     "Class", "Instance"))}"
 
   vpc_security_group_ids = [
@@ -567,7 +567,7 @@ resource "aws_instance" "nodes" {
   user_data = "${data.template_cloudinit_config.cfg.rendered}"
 
   tags = "${merge(local.tags, map(
-    "Name", "${var.stack_name}-node-${count.index}",
+    "Name", "${format("${var.stack_name}-worker-%03d", count.index)}",
     "Class", "Instance"))}"
 
   security_groups = [

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -70,7 +70,7 @@ resource "libvirt_cloudinit_disk" "lb" {
 }
 
 resource "libvirt_domain" "lb" {
-  name      = "${var.stack_name}-lb-domain"
+  name      = "${var.stack_name}-lb"
   memory    = "${var.lb_memory}"
   vcpu      = "${var.lb_vcpu}"
   cloudinit = "${libvirt_cloudinit_disk.lb.id}"

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -67,7 +67,7 @@ resource "libvirt_cloudinit_disk" "master" {
 
 resource "libvirt_domain" "master" {
   count      = "${var.masters}"
-  name       = "${var.stack_name}-master-domain-${count.index}"
+  name       = "${format("${var.stack_name}-master-%03d", count.index)}"
   memory     = "${var.master_memory}"
   vcpu       = "${var.master_vcpu}"
   cloudinit  = "${element(libvirt_cloudinit_disk.master.*.id, count.index)}"

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -67,7 +67,7 @@ resource "libvirt_cloudinit_disk" "worker" {
 
 resource "libvirt_domain" "worker" {
   count      = "${var.workers}"
-  name       = "${var.stack_name}-worker-domain-${count.index}"
+  name       = "${format("${var.stack_name}-worker-%03d", count.index)}"
   memory     = "${var.worker_memory}"
   vcpu       = "${var.worker_vcpu}"
   cloudinit  = "${element(libvirt_cloudinit_disk.worker.*.id, count.index)}"

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -50,7 +50,7 @@ data "template_file" "master-cloud-init" {
 
 resource "openstack_compute_instance_v2" "master" {
   count      = "${var.masters}"
-  name       = "caasp-master-${var.stack_name}-${count.index}"
+  name       = "${format("${var.stack_name}-master-%03d", count.index)}"
   image_name = "${var.image_name}"
 
   depends_on = [

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -1,5 +1,5 @@
 resource "openstack_compute_secgroup_v2" "secgroup_base" {
-  name        = "caasp-base-${var.stack_name}"
+  name        = "${var.stack_name}-base"
   description = "Basic security group"
 
   rule {
@@ -39,7 +39,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_base" {
 }
 
 resource "openstack_compute_secgroup_v2" "secgroup_master" {
-  name        = "caasp-master-${var.stack_name}"
+  name        = "${var.stack_name}-master"
   description = "security group for masters"
 
   rule {
@@ -79,7 +79,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_master" {
 }
 
 resource "openstack_compute_secgroup_v2" "secgroup_worker" {
-  name        = "caasp-worker-${var.stack_name}"
+  name        = "${var.stack_name}-worker"
   description = "security group for workers"
 
   rule {
@@ -147,7 +147,7 @@ resource "openstack_compute_secgroup_v2" "secgroup_worker" {
 }
 
 resource "openstack_compute_secgroup_v2" "secgroup_master_lb" {
-  name        = "caasp-master-lb-${var.stack_name}"
+  name        = "${var.stack_name}-master-lb"
   description = "security group for master load balancers"
 
   rule {

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -62,7 +62,7 @@ resource "openstack_compute_volume_attach_v2" "worker_vol_attach" {
 
 resource "openstack_compute_instance_v2" "worker" {
   count      = "${var.workers}"
-  name       = "caasp-worker-${var.stack_name}-${count.index}"
+  name       = "${format("${var.stack_name}-worker-%03d", count.index)}"
   image_name = "${var.image_name}"
 
   depends_on = [

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -109,7 +109,7 @@ data "template_file" "lb_cloud_init_userdata" {
 
 resource "vsphere_virtual_machine" "lb" {
   count            = "${var.lbs}"
-  name             = "${var.stack_name}-lb-${count.index}"
+  name             = "${format("${var.stack_name}-lb-%03d", count.index)}"
   num_cpus         = "${var.lb_cpus}"
   memory           = "${var.lb_memory}"
   guest_id         = "${var.guest_id}"

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -58,7 +58,7 @@ data "template_file" "master_cloud_init_userdata" {
 
 resource "vsphere_virtual_machine" "master" {
   count            = "${var.masters}"
-  name             = "${var.stack_name}-master-${count.index}"
+  name             = "${format("${var.stack_name}-master-%03d", count.index)}"
   num_cpus         = "${var.master_cpus}"
   memory           = "${var.master_memory}"
   guest_id         = "${var.guest_id}"

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -58,7 +58,7 @@ data "template_file" "worker_cloud_init_userdata" {
 
 resource "vsphere_virtual_machine" "worker" {
   count            = "${var.workers}"
-  name             = "${var.stack_name}-worker-${count.index}"
+  name             = "${format("${var.stack_name}-worker-%03d", count.index)}"
   num_cpus         = "${var.worker_cpus}"
   memory           = "${var.worker_memory}"
   guest_id         = "${var.guest_id}"


### PR DESCRIPTION
## Why is this PR needed?

This commits sets the index for the name
of instances on 3 digits so the outputs from
terraform, skuba and in platform dashboard are 
way proper in alphabetical order.

It also uniformize the name of instances to
releasename-role-index.


Signed-off-by: lcavajani <lcavajani@suse.com>

