### PR TITLE
skuba: Improve cleaning nodes from cluster, bsc#1138908

### DIFF
--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -53,6 +53,8 @@ func disarmKubeletJobSpec(node *v1.Node) batchv1.JobSpec {
 							strings.Join(
 								[]string{
 									"rm -rf /etc/kubernetes/*",
+									"rm -rf /var/lib/kubelet/pki/*",
+									"rm -f /var/lib/kubelet/{config.yaml,kubeadm-flags.env}",
 									"rm -rf /var/lib/etcd/*",
 									"dbus-send --system --print-reply --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.DisableUnitFiles array:string:'kubelet.service' boolean:false",
 									"dbus-send --system --print-reply --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.MaskUnitFiles array:string:'kubelet.service' boolean:false boolean:true",
@@ -62,6 +64,7 @@ func disarmKubeletJobSpec(node *v1.Node) batchv1.JobSpec {
 						},
 						VolumeMounts: []v1.VolumeMount{
 							VolumeMount("etc-kubernetes", "/etc/kubernetes", VolumeMountReadWrite),
+							VolumeMount("var-lib-kubelet", "/var/lib/kubelet", VolumeMountReadWrite),
 							VolumeMount("var-lib-etcd", "/var/lib/etcd", VolumeMountReadWrite),
 							VolumeMount("var-run-dbus", "/var/run/dbus", VolumeMountReadWrite),
 						},
@@ -73,6 +76,7 @@ func disarmKubeletJobSpec(node *v1.Node) batchv1.JobSpec {
 				RestartPolicy: v1.RestartPolicyNever,
 				Volumes: []v1.Volume{
 					HostMount("etc-kubernetes", "/etc/kubernetes"),
+					HostMount("var-lib-kubelet", "/var/lib/kubelet"),
 					HostMount("var-lib-etcd", "/var/lib/etcd"),
 					HostMount("var-run-dbus", "/var/run/dbus"),
 				},


### PR DESCRIPTION
## Why is this PR needed?

To disarm kubelet nodes, we have to remove config.yaml,
kubeadm-flags.env and kubelet certificates.

It will prevent from rejoining worker nodes to the cluster after rebooting.

Fixes #

https://bugzilla.suse.com/show_bug.cgi?id=1138908

## What does this PR do?

Removes `config.yaml`, `kubeadm-flags.env` and kubelet certificates
