### PR TITLE
Change dex port to 32000 (align with v3)

### DIFF
--- a/ci/infra/libvirt/cloud-init/lb.tpl
+++ b/ci/infra/libvirt/cloud-init/lb.tpl
@@ -62,7 +62,7 @@ write_files:
       default_backend gangway-backend
 
     frontend dex
-      bind :32002
+      bind :32000
       default_backend dex-backend
 
     backend apiserver-backend

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -30,7 +30,7 @@ data "template_file" "haproxy_gangway_backends_master" {
 
 data "template_file" "haproxy_dex_backends_master" {
   count    = "${var.masters}"
-  template = "server $${fqdn} $${ip}:32002 check check-ssl verify none\n"
+  template = "server $${fqdn} $${ip}:32000 check check-ssl verify none\n"
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"

--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -23,7 +23,7 @@ resource "openstack_lb_listener_v2" "gangway_listener" {
 
 resource "openstack_lb_listener_v2" "dex_listener" {
   protocol        = "TCP"
-  protocol_port   = "32002"
+  protocol_port   = "32000"
   loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
   name            = "${var.stack_name}-dex-listener"
 }
@@ -70,7 +70,7 @@ resource "openstack_lb_member_v2" "dex_member" {
   pool_id       = "${openstack_lb_pool_v2.dex_pool.id}"
   address       = "${element(openstack_compute_instance_v2.master.*.access_ip_v4, count.index)}"
   subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
-  protocol_port = 32002
+  protocol_port = 32000
 }
 
 resource "openstack_networking_floatingip_v2" "lb_ext" {

--- a/ci/infra/openstack/security-groups.tf
+++ b/ci/infra/openstack/security-groups.tf
@@ -165,8 +165,8 @@ resource "openstack_compute_secgroup_v2" "secgroup_master_lb" {
   }
 
   rule {
-    from_port   = 32002
-    to_port     = 32002
+    from_port   = 32000
+    to_port     = 32000
     ip_protocol = "tcp"
     cidr        = "0.0.0.0/0"
   }

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -55,7 +55,7 @@ write_files:
       default_backend gangway-backend
 
     frontend dex
-      bind :32002
+      bind :32000
       default_backend dex-backend
 
     backend apiserver-backend

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -70,7 +70,7 @@ data "template_file" "haproxy_gangway_backends_master" {
 
 data "template_file" "haproxy_dex_backends_master" {
   count    = "${var.masters}"
-  template = "server $${fqdn} $${ip}:32002 check check-ssl verify none\n"
+  template = "server $${fqdn} $${ip}:32000 check check-ssl verify none\n"
 
   vars = {
     fqdn = "${element(vsphere_virtual_machine.master.*.name, count.index)}"

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -30,7 +30,7 @@ apiServer:
   certSANs:
     - {{.ControlPlane}}
   extraArgs:
-    oidc-issuer-url: https://{{.ControlPlane}}:32002
+    oidc-issuer-url: https://{{.ControlPlane}}:32000
     oidc-client-id: oidc
     oidc-ca-file: /etc/kubernetes/pki/ca.crt
     oidc-username-claim: email
@@ -857,7 +857,7 @@ metadata:
   namespace: kube-system
 data:
   config.yaml: |
-    issuer: https://{{.ControlPlane}}:32002
+    issuer: https://{{.ControlPlane}}:32000
 
     storage:
       type: kubernetes
@@ -865,7 +865,7 @@ data:
         inCluster: true
 
     web:
-      https: 0.0.0.0:32002
+      https: 0.0.0.0:32000
       tlsCert: /etc/dex/pki/tls.crt
       tlsKey: /etc/dex/pki/tls.key
       tlsClientCA: /etc/dex/pki/ca.crt
@@ -940,7 +940,7 @@ spec:
           - /etc/dex/cfg/config.yaml
         ports:
           - name: https
-            containerPort: 32002
+            containerPort: 32000
         volumeMounts:
           - name: dex-config-path
             mountPath: /etc/dex/cfg
@@ -968,9 +968,9 @@ spec:
   type: NodePort
   ports:
   - name: https
-    port: 32002
-    targetPort: 32002
-    nodePort: 32002
+    port: 32000
+    targetPort: 32000
+    nodePort: 32000
     protocol: TCP
 ---
 apiVersion: v1
@@ -1028,8 +1028,8 @@ data:
     redirectURL: "https://{{.ControlPlane}}:32001/callback"
 
     serveTLS: true
-    authorizeURL: "https://{{.ControlPlane}}:32002/auth"
-    tokenURL: "https://{{.ControlPlane}}:32002/token"
+    authorizeURL: "https://{{.ControlPlane}}:32000/auth"
+    tokenURL: "https://{{.ControlPlane}}:32000/token"
     keyFile: /etc/gangway/pki/tls.key
     certFile: /etc/gangway/pki/tls.crt
 


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

Align with CaaS platform v3, dex port is on `32000`.

## What does this PR do?

Change all expose port from `32002` to `32000`

## Anything else a reviewer needs to know?

N/A