### PR TITLE
Update spec to require go1.12 for build

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -31,7 +31,7 @@ Source0:        %{name}.tar.gz
 Patch0:         0001-Patch-out-load-balancer.patch
 BuildRequires:  go-go-md2man
 BuildRequires:  golang-packaging
-BuildRequires:  golang(API) >= 1.11
+BuildRequires:  golang(API) >= 1.12
 BuildRequires:  python3-setuptools
 # Standard systemd requirements
 BuildRequires:  pkgconfig(systemd)


### PR DESCRIPTION
## Why is this PR needed?

This PR is needed to update the RPM spec, otherwise the package does not build in OBS.

## What does this PR do?

increase GO API requirement from 1.11 to 1.12

