### PR TITLE
Fix gangway not request group information

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -1026,6 +1026,7 @@ data:
     clusterName: "skuba"
 
     redirectURL: "https://{{.ControlPlane}}:32001/callback"
+    scopes: ["openid", "email", "groups", "profile", "offline_access"]
 
     serveTLS: true
     authorizeURL: "https://{{.ControlPlane}}:32000/auth"
@@ -1035,7 +1036,7 @@ data:
 
     clientID: "oidc"
     clientSecret: "{{.GangwayClientSecret}}"
-    usernameClaim: "sub"
+    usernameClaim: "email"
     apiServerURL: "https://{{.ControlPlane}}:6443"
     cluster_ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     trustedCAPath: /etc/gangway/pki/ca.crt


### PR DESCRIPTION
Change default username to email address

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

Gangway cannot get group information in `id-token`, so RBAC cannot grant Role/CustomRole by group.

## What does this PR do?

By default, gangway use configs `["openid", "email", "profile", "offline_access"]` which does not request `groups` information. Add groups to scopes also.

Also, change default displaying username from sub to email for a much better user experience

**WAS**
![image](https://user-images.githubusercontent.com/49380831/60947592-80b46680-a323-11e9-8fe6-a9fd4e0468da.png)

**IS**
![image](https://user-images.githubusercontent.com/49380831/60947454-25827400-a323-11e9-9b0d-01dd6c18c8a5.png)


## Anything else a reviewer needs to know?

N/A