### PR TITLE
Fix kured reboot sentinel (bsc#1141015)

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -848,6 +848,9 @@ spec:
                   fieldPath: spec.nodeName
           command:
             - /usr/bin/kured
+          args:
+            - "--reboot-sentinel"
+            - "/var/run/reboot-needed" # This is the file that libzypp creates
 `
 	dexManifest = `---
 apiVersion: v1


### PR DESCRIPTION
The default reboot sentinel of kured is /var/run/reboot-required . But
libzypp/zypper creates a file called /var/run/reboot-needed when a
reboot is required.
So kured needs to watch the correct file.

