### PR TITLE
Fix dex no permission to update signing keys to CRD

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -993,7 +993,7 @@ rules:
   verbs: ["list"]
 - apiGroups: ["dex.coreos.com"]
   resources: ["signingkeies"]
-  verbs: ["create", "get", "list"]
+  verbs: ["create", "get", "list", "update"]
 - apiGroups: ["dex.coreos.com"]
   resources: ["authcodes", "authrequests", "offlinesessionses"]
   verbs: ["create", "delete", "get", "list", "update"]


### PR DESCRIPTION
SigningKeys defines the duration of time after which the SigningKeys will be rotated

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

Dex bumps out error on no permission to update resource `signingkeies `in API group `dex.coreos.com`, this would cause the signing key cannot be rotated.

## What does this PR do?

Add `update` verbs in dex ClusterRole on api group `dex.coreos.com` and  resources `signingkeies`

## Anything else a reviewer needs to know?

N/A