### PR TITLE
Enable apparmor service

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/apparmor.go
+++ b/internal/pkg/skuba/deployments/ssh/apparmor.go
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ssh
+
+func init() {
+	stateMap["apparmor.start"] = apparmorStart
+}
+
+func apparmorStart(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "enable", "--now", "apparmor")
+	return err
+}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -79,6 +79,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		"kubernetes.bootstrap.upload-secrets",
 		"kernel.load-modules",
 		"kernel.configure-parameters",
+		"apparmor.start",
 		"cri.start",
 		"kubelet.configure",
 		"kubelet.enable",

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -45,6 +45,7 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 	statesToApply := []string{
 		"kernel.load-modules",
 		"kernel.configure-parameters",
+		"apparmor.start",
 		"cri.start",
 		"kubelet.configure",
 		"kubelet.enable",


### PR DESCRIPTION
## Why is this PR needed?

Since crio 1.15, the apparmor pattern is installed
by default on the hosts and the correct apparmor
profile is defined by default in /etc/crio/crio.conf

This commit will allow skuba to start apparmor during
bootstrap or join phase of a node.

Fixes https://github.com/SUSE/avant-garde/issues/570

Signed-off-by: lcavajani <lcavajani@suse.com>