### PR TITLE
Added testrunner ability to collect more logs

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -30,7 +30,7 @@ cleanup:
 
 .PHONY: gather_logs
 gather_logs:
-	${TEST_RUNNER} --platform ${PLATFORM} log
+	${TEST_RUNNER} --platform ${PLATFORM} get_logs
 
 .PHONY: git_rebase_check
 git_rebase_check:

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -93,13 +93,13 @@ usage:
     Warning: it removes docker containers, VMs, images, and network configuration.
 
        [-h] [-v YAML_PATH]
-      {info,log,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node,reset-node,test}
+      {info,get_logs,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node,reset-node,test}
        ...
 
 positional arguments:
-  {info,log,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node,reset-node,test}
+  {info,get_logs,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node,reset-node,test}
     info                ip info
-    log                 gather logs from nodes
+    get_logs            gather logs from nodes
     cleanup             cleanup created skuba environment
     provision           provision nodes for cluster in your configured
                         platform e.g: openstack, vmware.

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -3,6 +3,8 @@ import json
 import os
 import subprocess
 
+from timeout_decorator import timeout
+
 from utils import (Format, step, Utils)
 
 
@@ -44,6 +46,33 @@ class Terraform:
 
         if cleanup_failure:
             raise Exception(Format.alert("Failure(s) during cleanup"))
+
+    @timeout(600)
+    @step
+    def gather_logs(self):
+        logging_errors = False
+
+        node_ips = {"master": self.get_nodes_ipaddrs("master"),
+                    "worker": self.get_nodes_ipaddrs("worker")}
+        logs = {"files": ["/var/run/cloud-init/status.json",
+                          "/var/log/cloud-init-output.log",
+                          "/var/log/cloud-init.log"],
+                "dirs": ["/var/log/pods"],
+                "services": ["kubelet"]}
+
+        if not os.path.isdir(self.conf.log_dir):
+            os.mkdir(self.conf.log_dir)
+            print(f"Created log dir {self.conf.log_dir}")
+
+        for node_type in node_ips:
+            for ip_address in node_ips[node_type]:
+                node_log_dir = self._create_node_log_dir(ip_address, node_type, self.conf.log_dir)
+                logging_error = self.utils.collect_remote_logs(ip_address, logs, node_log_dir)
+
+                if logging_error:
+                    logging_errors = logging_error
+
+        return logging_errors
 
     @step
     def provision(self, num_master=-1, num_worker=-1):
@@ -97,6 +126,16 @@ class Terraform:
                     raise
             finally:
                 self._fetch_terraform_output()
+
+    @staticmethod
+    def _create_node_log_dir(ip_address, node_type, log_dir_path):
+        node_log_dir_path = os.path.join(log_dir_path, f"{node_type}_{ip_address.replace('.', '_')}")
+
+        if not os.path.isdir(node_log_dir_path):
+            os.mkdir(node_log_dir_path)
+            print(f"Created log dir {node_log_dir_path}")
+
+        return node_log_dir_path
 
     def _load_tfstate(self):
         if self.state is None:

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -46,8 +46,11 @@ def cluster_status(options):
     Skuba(options.conf, options.platform).cluster_status()
 
 
-def log(options):
-    Skuba(options.conf, options.platform).gather_logs()
+def get_logs(options):
+    platform_logging_errors = Platform.get_platform(options.conf, options.platform).gather_logs()
+
+    if platform_logging_errors:
+        raise Exception("Failure(s) while collecting logs")
 
 
 def join_node(options):
@@ -65,6 +68,7 @@ def reset_node(options):
 def test(options):
     TestDriver(options.conf, options.platform).run(test_suite=options.test_suite, test=options.test,
             verbose=options.verbose, collect=options.collect)
+
 
 def main():
     help_str = """
@@ -88,8 +92,8 @@ def main():
     cmd_info = commands.add_parser("info", help='ip info')
     cmd_info.set_defaults(func=info)
 
-    cmd_log = commands.add_parser("log",  help="gather logs from nodes")
-    cmd_log.set_defaults(func=log)
+    cmd_log = commands.add_parser("get_logs",  help="gather logs from nodes")
+    cmd_log.set_defaults(func=get_logs)
 
     cmd_cleanup = commands.add_parser("cleanup", help="cleanup created skuba environment")
     cmd_cleanup.set_defaults(func=cleanup)

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -21,6 +21,7 @@ class BaseConfig:
         obj.ssh_key_option = None
         obj.username = None
         obj.nodeuser = None
+        obj.log_dir = None
 
         obj.terraform = BaseConfig.Terraform()
         obj.openstack = BaseConfig.Openstack()
@@ -132,6 +133,11 @@ class BaseConfig:
     @staticmethod
     def finalize(conf):
         conf.workspace = os.path.expanduser(conf.workspace)
+
+        if not conf.log_dir:
+            conf.log_dir = os.path.join(conf.workspace, 'testrunner_logs')
+        elif not os.path.isabs(conf.log_dir):
+            conf.log_dir = os.path.join(conf.workspace, conf.log_dir)
 
         if not conf.skuba.binpath:
             conf.skuba.binpath = os.path.join(conf.workspace, 'go/bin/skuba')


### PR DESCRIPTION


## Why is this PR needed?

We are only collecting the cloud-init logs while there are other that would be useful for troubleshooting.

Fixes https://github.com/SUSE/avant-garde/issues/571

## What does this PR do?

Added rsync function to utils
Added collect remote logs to utils.
Moved log collection to terraform since current logs aren't skuba
 specific.
Testrunner log command calls gather logs from both skuba and terraform
 classes.

## Anything else a reviewer needs to know?

Any further logs that need to be collected should be added later this is mostly about getting the kubelet log.
