### PR TITLE
Change seccomp profile to runtime/default, docker/default is deprecated

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -67,7 +67,7 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.privileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
   # Privileged
@@ -176,8 +176,8 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.unprivileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged
   privileged: false


### PR DESCRIPTION
Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

The seccomp profiles `docker/default` is deprecated as of Kubernetes 1.11.

## What does this PR do?

The seccomp profiles change to `runtime/default` instead.

## Anything else a reviewer needs to know?

N/A