### PR TITLE
Generate a configuration file for `kubeadm upgrade apply`

### DIFF
--- a/internal/pkg/skuba/deployments/upgrade.go
+++ b/internal/pkg/skuba/deployments/upgrade.go
@@ -19,5 +19,5 @@ package deployments
 
 // UpgradeConfiguration holds information passed to kubeadm during upgrade
 type UpgradeConfiguration struct {
-	KubernetesVersion string
+	KubeadmConfigContents string
 }

--- a/internal/pkg/skuba/kubeadm/images.go
+++ b/internal/pkg/skuba/kubeadm/images.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package kubeadm
+
+import (
+	"k8s.io/apimachinery/pkg/util/version"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/pkg/skuba"
+)
+
+func SetContainerImagesWithClusterVersion(initConfiguration *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
+	initConfiguration.UseHyperKubeImage = true
+	initConfiguration.ImageRepository = skuba.ImageRepository
+	initConfiguration.KubernetesVersion = kubernetes.ComponentVersionForClusterVersion(kubernetes.Hyperkube, clusterVersion)
+	initConfiguration.Etcd.Local = &kubeadmapi.LocalEtcd{
+		ImageMeta: kubeadmapi.ImageMeta{
+			ImageRepository: skuba.ImageRepository,
+			ImageTag:        kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, clusterVersion),
+		},
+	}
+	initConfiguration.DNS.ImageMeta = kubeadmapi.ImageMeta{
+		ImageRepository: skuba.ImageRepository,
+		ImageTag:        kubernetes.ComponentVersionForClusterVersion(kubernetes.CoreDNS, clusterVersion),
+	}
+}

--- a/internal/pkg/skuba/node/node.go
+++ b/internal/pkg/skuba/node/node.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package node
+
+import (
+	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/pkg/skuba"
+
+	"k8s.io/apimachinery/pkg/util/version"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+)
+
+func AddTargetInformationToInitConfigurationWithClusterVersion(target *deployments.Target, initConfiguration *kubeadmapi.InitConfiguration, clusterVersion *version.Version) error {
+	if initConfiguration.NodeRegistration.KubeletExtraArgs == nil {
+		initConfiguration.NodeRegistration.KubeletExtraArgs = map[string]string{}
+	}
+	initConfiguration.NodeRegistration.Name = target.Nodename
+	initConfiguration.NodeRegistration.CRISocket = skuba.CRISocket
+	initConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename
+	initConfiguration.NodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = images.GetGenericImage(skuba.ImageRepository, "pause", kubernetes.ComponentVersionForClusterVersion(kubernetes.Pause, clusterVersion))
+	isSUSE, err := target.IsSUSEOS()
+	if err != nil {
+		return err
+	}
+	if isSUSE {
+		initConfiguration.NodeRegistration.KubeletExtraArgs["cni-bin-dir"] = skuba.SUSECNIDir
+	}
+	return nil
+}

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -33,6 +33,10 @@ func KubeadmInitConfFile() string {
 	return "kubeadm-init.conf"
 }
 
+func KubeadmUpgradeConfFile() string {
+	return "kubeadm-upgrade.conf"
+}
+
 func JoinConfDir() string {
 	return "kubeadm-join.conf.d"
 }


### PR DESCRIPTION
## Why is this PR needed?

When running `kubeadm upgrade apply`, instead of using an argument
to pass the new Kubernetes version, use a complete configuration file,
so versions of `etcd`, or `coredns` can be updated as well.

Fixes https://github.com/SUSE/avant-garde/issues/548