### PR TITLE
Moved results extracting to the sonobuoy script

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -28,11 +28,8 @@ pipeline {
         stage('Conformance Tests') { steps {
             sh(script: "skuba/ci/tasks/sonobuoy_e2e.py run --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Run Conformance')
             sh(script: "skuba/ci/tasks/sonobuoy_e2e.py collect --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Collect Results')
-            dir('results') {
-                archiveArtifacts("*sonobuoy*.tar.gz")
-                sh(script: 'tar -xzf *sonobuoy*.tar.gz')
-                junit('plugins/e2e/results/*.xml')
-            }
+            archiveArtifacts('results')
+            junit('results/plugins/e2e/results/*.xml')
             sh(script: "skuba/ci/tasks/sonobuoy_e2e.py cleanup --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Cleanup Cluster')
         } }
 


### PR DESCRIPTION
## Why is this PR needed?

Jenkins was having issues with the permissions of the results tar. This makes it so the python script extracts the results and deletes the tar file.

Fixes #

## What does this PR do?

Moved results extracting to the sonobuoy script
Also fixed how often the status is checked

## Anything else a reviewer needs to know?
