### PR TITLE
Update name of the patterns-caasp-Node package.

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -42,7 +42,7 @@ repositories = {}
 packages = [
   "kernel-default",
   "-kernel-default-base",
-  "patterns-caasp-Node"
+  "patterns-caasp-Node-1.15"
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -25,7 +25,7 @@
         "kernel-default",
         "-kernel-default-base",
         "ca-certificates-suse",
-        "patterns-caasp-Node"
+        "patterns-caasp-Node-1.15"
     ],
     "authorized_keys": [],
     "ntp_servers": [

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -79,7 +79,7 @@ repositories = {}
 packages = [
   "kernel-default",
   "-kernel-default-base",
-  "patterns-caasp-Node"
+  "patterns-caasp-Node-1.15"
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -30,7 +30,7 @@
         "kernel-default",
         "-kernel-default-base",
         "ca-certificates-suse",
-        "patterns-caasp-Node"
+        "patterns-caasp-Node-1.15"
     ],
     "authorized_keys": [],
     "ntp_servers": [

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -54,7 +54,7 @@ repositories = {}
 # Minimum required packages. Do not remove them.
 # Feel free to add more packages
 packages = [
-  "patterns-caasp-Node"
+  "patterns-caasp-Node-1.15"
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -29,7 +29,7 @@
         "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
     },
     "packages": [
-        "patterns-caasp-Node",
+        "patterns-caasp-Node-1.15",
         "ca-certificates-suse"
     ],
     "authorized_keys": [],


### PR DESCRIPTION
It now references the concrete k8s version.

## Why is this PR needed?

The current example files still reference the `patterns-caasp-Node` package, but it is now called `patterns-caasp-Node-1.15`.

Using terraform fails right now when not fixing this.