### PR TITLE
Moved vmware load balancer variables

### DIFF
--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -1,35 +1,3 @@
-variable "lbs" {
-  default     = 1
-  description = "Number of load-balancer nodes"
-}
-
-variable "lb_cpus" {
-  default     = 1
-  description = "Number of CPUs used on load-balancer node"
-}
-
-variable "lb_memory" {
-  default     = 2048
-  description = "Amount of memory used on load-balancer node"
-}
-
-variable "lb_disk_size" {
-  default     = 40
-  description = "Size of the root disk in GB on load-balancer node"
-}
-
-variable "lb_repositories" {
-  type = "map"
-
-  default = {
-    sle_server_pool    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
-    basesystem_pool    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
-    ha_pool            = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-HA/15/x86_64/product/"
-    sle_server_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
-    basesystem_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
-  }
-}
-
 data "template_file" "lb_repositories_template" {
   count    = "${length(var.lb_repositories)}"
   template = "${file("cloud-init/repository.tpl")}"

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -59,6 +59,21 @@ variable "masters" {
   description = "Number of master nodes"
 }
 
+variable "master_cpus" {
+  default     = 4
+  description = "Number of CPUs used on master node"
+}
+
+variable "master_memory" {
+  default     = 8192
+  description = "Amount of memory used on master node"
+}
+
+variable "master_disk_size" {
+  default     = 50
+  description = "Size of the root disk in GB on master node"
+}
+
 variable "workers" {
   default     = 1
   description = "Number of worker nodes"
@@ -79,19 +94,30 @@ variable "worker_disk_size" {
   description = "Size of the root disk in GB on worker node"
 }
 
-variable "master_cpus" {
-  default     = 4
-  description = "Number of CPUs used on master node"
+variable "lbs" {
+  default     = 1
+  description = "Number of load-balancer nodes"
 }
 
-variable "master_memory" {
-  default     = 8192
-  description = "Amount of memory used on master node"
+variable "lb_cpus" {
+  default     = 1
+  description = "Number of CPUs used on load-balancer node"
 }
 
-variable "master_disk_size" {
-  default     = 50
-  description = "Size of the root disk in GB on master node"
+variable "lb_memory" {
+  default     = 2048
+  description = "Amount of memory used on load-balancer node"
+}
+
+variable "lb_disk_size" {
+  default     = 40
+  description = "Size of the root disk in GB on load-balancer node"
+}
+
+variable "lb_repositories" {
+  type = "map"
+
+  default = {}
 }
 
 #### To be moved to separate vsphere.tf? ####


### PR DESCRIPTION


## Why is this PR needed?

We should probably consolidate all the variables like the other nodes

Fixes #

## What does this PR do?

Move the variables to variables.tf since that's where the others are.
Also removed the default repos since they are declared in the tfvars.ci
 file and probably shouldn't be hardcoded in terraform.

## Anything else a reviewer needs to know?
