### PR TITLE
Added ability to collect logs from VMware LB

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -21,7 +21,11 @@ class Terraform:
         return ""
 
     def _cleanup_platform(self):
-        """Platform specific cleanup. Expected to be overriden by platforms"""
+        """Platform specific cleanup. Expected to be overridden by platforms"""
+
+    def _get_platform_logs(self):
+        """Platform specific logs to collect. Expected to be overridden by platforms"""
+        return False
 
     def cleanup(self):
         """ Clean up """
@@ -71,6 +75,11 @@ class Terraform:
 
                 if logging_error:
                     logging_errors = logging_error
+
+        platform_log_error = self._get_platform_logs()
+
+        if platform_log_error:
+            logging_errors = platform_log_error
 
         return logging_errors
 

--- a/ci/infra/testrunner/platforms/vmware.py
+++ b/ci/infra/testrunner/platforms/vmware.py
@@ -28,3 +28,17 @@ class VMware(Terraform):
                f"terraform destroy -auto-approve -var stack_name={self.conf.terraform.stack_name}")
 
         self._runshellcommandterraform(cmd)
+
+    def _get_platform_logs(self):
+        # Get logs from the VMware LB
+        node_ip = self.get_lb_ipaddr()
+        logs = {"files": ["/var/run/cloud-init/status.json",
+                          "/var/log/cloud-init-output.log",
+                          "/var/log/cloud-init.log"],
+                "dirs": [],
+                "services": ["haproxy"]}
+
+        node_log_dir = self._create_node_log_dir(node_ip, "load_balancer", self.conf.log_dir)
+        logging_error = self.utils.collect_remote_logs(node_ip, logs, node_log_dir)
+
+        return logging_error


### PR DESCRIPTION
## Why is this PR needed?

We aren't currently collecting logs from the VMware LB

Fixes #

## What does this PR do?

Makes it so platform specific logs can be collected.
Also collects the cloud-init and haproxy logs from the LB

## Anything else a reviewer needs to know?

Opening this to try and diagnose the VMware nightly failures and unblock https://github.com/SUSE/avant-garde/issues/443