### PR TITLE
Fix `go get` path for executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The terraform based deployments are taking care of fulfilling these requirements
 ## Installation
 
 ```sh
-go get -d github.com/SUSE/skuba
+go get github.com/SUSE/skuba/cmd/skuba
 ```
 
 ### Development


### PR DESCRIPTION
## Why is this PR needed?

The mentioned path for go get seems not correct, which should be fixed now.

## What does this PR do?

Update the documentation part of the README.md