### PR TITLE
Remove CaaSP pattern installation from autoyast

### DIFF
--- a/ci/infra/bare-metal/autoyast.xml
+++ b/ci/infra/bare-metal/autoyast.xml
@@ -19,7 +19,7 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
       </script>
     </chroot-scripts>
   </scripts>
-  
+
   <bootloader>
     <global>
       <generic_mbr>true</generic_mbr>
@@ -149,11 +149,10 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
     </products>
     <instsource/>
     <patterns config:type="list">
-      <pattern>base</pattern>    
+      <pattern>base</pattern>
       <pattern>enhanced_base</pattern>
       <pattern>minimal_base</pattern>
       <pattern>basesystem</pattern>
-      <pattern>SUSE-CaaSP-Node</pattern>
     </patterns>
   </software>
 


### PR DESCRIPTION
## Why is this PR needed?

Remove remaining CaaSP pattern installation from the autoyast
profile.