### PR TITLE
Implement kubectl wrapper for testrunner

### DIFF
--- a/ci/infra/testrunner/kubectl/__init__.py
+++ b/ci/infra/testrunner/kubectl/__init__.py
@@ -1,0 +1,1 @@
+from kubectl.kubectl import Kubectl

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -1,5 +1,7 @@
 import os
 
+from timeout_decorator import timeout
+
 from platforms.platform import Platform
 from utils.format import Format
 from utils.utils import (step, Utils)
@@ -10,24 +12,15 @@ class Kubectl:
         self.conf = conf
         self.utils = Utils(self.conf)
         self.platform = Platform.get_platform(conf, platform)
-        self.cwd = "{}/test-cluster".format(self.conf.workspace)
-
-
-    def get_pods(self):
-        print("gets pods using kubectl")
-        try:
-            self._run_kubectl("get po -o wide")
-        except Exception as ex:
-            print("Received the following error {}".format(ex))
 
 
     def create_deployment(self, name, image):
         print("create a new deployment {}".format(name))
         try:
             self._run_kubectl("create deployment {name}  --image={image}"
-                             .format(name=name, image=image))
+                                .format(name=name, image=image))
         except Exception as ex:
-            print("Received the following error {}".format(ex))
+            raise Exception("Error executing cmd {}") from ex
 
 
     def scale_deployment(self, name, replicas):
@@ -36,7 +29,7 @@ class Kubectl:
             self._run_kubectl("scale deployment {name} --replicas={replicas}"
                              .format(name=name, replicas=replicas))
         except Exception as ex:
-            print("Received the following error {}".format(ex))
+            raise Exception("Error executing cmd {}") from ex
 
 
     def expose_deployment(self, name, port, nodeType="NodePort"):
@@ -45,7 +38,7 @@ class Kubectl:
             self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
                              .format(name=name, port=port, nodeType=nodeType))
         except Exception as ex:
-            print("Received the following error {}".format(ex))
+            raise Exception("Error executing cmd {}") from ex
 
 
     def wait_deployment(self, name, timeout):
@@ -54,7 +47,7 @@ class Kubectl:
             self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
                              .format(name=name, timeout=timeout))
         except Exception as ex:
-            print("Received the following error {}".format(ex))
+            raise Exception("Error executing cmd {}") from ex
 
 
     def count_available_replicas(self, name):
@@ -64,8 +57,7 @@ class Kubectl:
                                        .format(name=name))
             return int(result)
         except Exception as ex:
-            print("Received the following error {}".format(ex))
-            return 0
+            raise Exception("Error executing cmd {}") from ex
 
 
     def get_service_port(self, name):
@@ -75,25 +67,24 @@ class Kubectl:
                                        .format(name=name))
             return int(result)
         except Exception as ex:
-            print("Received the following error {}".format(ex))
-            return 0
+            raise Exception("Error executing cmd {}") from ex
 
-    def test_service(self, name, path="/"):
+
+    def test_service(self, name, path="/", worker=0):
         print("curl deployment {}".format(name))
         ip_address = self.platform.get_nodes_ipaddrs("worker")
         port = self.get_service_port(name)
         try:
             return self.utils.runshellcommand_withoutput("curl {ip}:{port}{path}"
-                                                    .format(ip=ip_address[0],port=port,path=path), False)
+                                                        .format(ip=ip_address[worker],port=port,path=path), False)
         except Exception as ex:
-            print("Received the following error {}".format(ex))
-            return ""
+            raise Exception("Error executing cmd {}") from ex
 
 
     def _run_kubectl(self, command):
         try:
             return self.utils.runshellcommand_withoutput("kubectl --kubeconfig={cwd}/test-cluster/admin.conf -o json {command}"
-                                                  .format(command=command,cwd=self.conf.workspace), False)
+                                                        .format(command=command,cwd=self.conf.workspace), False)
         except Exception as ex:
-            print("Received the following error {}".format(ex))
-            return ""
+            raise Exception("Error executing cmd {}") from ex
+

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -1,0 +1,99 @@
+import os
+
+from platforms.platform import Platform
+from utils.format import Format
+from utils.utils import (step, Utils)
+
+class Kubectl:
+
+    def __init__(self, conf, platform):
+        self.conf = conf
+        self.utils = Utils(self.conf)
+        self.platform = Platform.get_platform(conf, platform)
+        self.cwd = "{}/test-cluster".format(self.conf.workspace)
+
+
+    def get_pods(self):
+        print("gets pods using kubectl")
+        try:
+            self._run_kubectl("get po -o wide")
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+
+
+    def create_deployment(self, name, image):
+        print("create a new deployment {}".format(name))
+        try:
+            self._run_kubectl("create deployment {name}  --image={image}"
+                             .format(name=name, image=image))
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+
+
+    def scale_deployment(self, name, replicas):
+        print("scale deployment {}".format(name))
+        try:
+            self._run_kubectl("scale deployment {name} --replicas={replicas}"
+                             .format(name=name, replicas=replicas))
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+
+
+    def expose_deployment(self, name, port, nodeType="NodePort"):
+        print("expose deployment {}".format(name))
+        try:
+            self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
+                             .format(name=name, port=port, nodeType=nodeType))
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+
+
+    def wait_deployment(self, name, timeout):
+        print("wait deployment {}".format(name))
+        try:
+            self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
+                             .format(name=name, timeout=timeout))
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+
+
+    def count_available_replicas(self, name):
+        print("count available replicas of deployment {}".format(name))
+        try:
+            result = self._run_kubectl("get deployment/{name} | jq '.status.availableReplicas'"
+                                       .format(name=name))
+            return int(result)
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+            return 0
+
+
+    def get_service_port(self, name):
+        print("get port for deployment {}".format(name))
+        try:
+            result = self._run_kubectl("get service/{name} | jq '.spec.ports[0].nodePort'"
+                                       .format(name=name))
+            return int(result)
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+            return 0
+
+    def test_service(self, name, path="/"):
+        print("curl deployment {}".format(name))
+        ip_address = self.platform.get_nodes_ipaddrs("worker")
+        port = self.get_service_port(name)
+        try:
+            return self.utils.runshellcommand_withoutput("curl {ip}:{port}{path}"
+                                                    .format(ip=ip_address[0],port=port,path=path), False)
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+            return ""
+
+
+    def _run_kubectl(self, command):
+        try:
+            return self.utils.runshellcommand_withoutput("kubectl --kubeconfig={cwd}/test-cluster/admin.conf -o json {command}"
+                                                  .format(command=command,cwd=self.conf.workspace), False)
+        except Exception as ex:
+            print("Received the following error {}".format(ex))
+            return ""

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -9,6 +9,7 @@ import sys
 from argparse import ArgumentParser
 
 from skuba import Skuba
+from kubectl import Kubectl
 from platforms import Platform
 from tests import TestDriver
 from utils import (BaseConfig, Utils)

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -9,7 +9,6 @@ import sys
 from argparse import ArgumentParser
 
 from skuba import Skuba
-from kubectl import Kubectl
 from platforms import Platform
 from tests import TestDriver
 from utils import (BaseConfig, Utils)

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from skuba import Skuba
+from kubectl import Kubectl
 from platforms import Platform
 from utils import BaseConfig
 
@@ -26,6 +27,10 @@ def target(request):
 @pytest.fixture
 def skuba(conf, target):
     return Skuba(conf, target)
+
+@pytest.fixture
+def kubectl(conf, target):
+    return Kubectl(conf, target)
 
 @pytest.fixture
 def platform(conf, target):

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -13,6 +13,16 @@ def pytest_addoption(parser):
     parser.addoption("--platform", action="store",help="target platform" )
 
 @pytest.fixture
+def setup(request, platform, skuba):
+    platform.provision()
+    def cleanup():
+        platform.cleanup()
+    request.addfinalizer(cleanup)
+
+    skuba.cluster_init()
+    skuba.node_bootstrap()
+
+@pytest.fixture
 def conf(request):
     """Builds a conf object from a yaml file"""
     path = request.config.getoption("vars")

--- a/ci/infra/testrunner/tests/test_deployments.py
+++ b/ci/infra/testrunner/tests/test_deployments.py
@@ -1,0 +1,22 @@
+from platforms import Platform
+from skuba import Skuba
+from kubectl import Kubectl
+import pytest
+import time
+from timeout_decorator import timeout
+
+def test_nginx_deployment(setup, skuba, kubectl):
+    skuba.node_join(role="worker", nr=0)
+    skuba.node_join(role="worker", nr=1)
+    masters = skuba.num_of_nodes("master")
+    workers = skuba.num_of_nodes("worker")
+    assert masters == 1
+    assert workers == 2
+    kubectl.create_deployment("nginx", "nginx:stable-alpine")
+    kubectl.scale_deployment("nginx", workers)
+    kubectl.expose_deployment("nginx", 80)
+    kubectl.wait_deployment("nginx", 3)
+    assert kubectl.count_available_replicas("nginx") == workers
+    result = kubectl.test_service("nginx")
+    assert "Welcome to nginx" in result
+

--- a/ci/infra/testrunner/tests/test_workers.py
+++ b/ci/infra/testrunner/tests/test_workers.py
@@ -1,40 +1,11 @@
 from platforms import Platform
 from skuba import Skuba
-from kubectl import Kubectl
 import pytest
 import time
 
-@pytest.fixture
-def setup(request, platform, skuba):
-    platform.provision()
-    def cleanup():
-        platform.cleanup()
-    request.addfinalizer(cleanup)
-
-    skuba.cluster_init()
-    skuba.node_bootstrap()
-
-#def test_add_worker(setup, skuba):
-#    skuba.node_join(role="worker", nr=0)
-#    masters = skuba.num_of_nodes("master")
-#    workers = skuba.num_of_nodes("worker")
-#    assert masters == 1
-#    assert workers == 1
-
-def test_nginx_deployment(setup, skuba, kubectl):
-    skuba.node_join(role="worker", nr=0)
-    skuba.node_join(role="worker", nr=1)
-    masters = skuba.num_of_nodes("master")
-    workers = skuba.num_of_nodes("worker")
-    assert masters == 1
-    assert workers == 2
-    kubectl.get_pods()
-    kubectl.create_deployment("nginx", "nginx:stable-alpine")
-    kubectl.scale_deployment("nginx", workers)
-    kubectl.expose_deployment("nginx", 80)
-    kubectl.wait_deployment("nginx", 3)
-    kubectl.get_pods()
-    assert kubectl.count_available_replicas("nginx") == workers
-    result = kubectl.test_service("nginx")
-    assert "Welcome to nginx" in result
-
+def test_add_worker(setup, skuba):
+   skuba.node_join(role="worker", nr=0)
+   masters = skuba.num_of_nodes("master")
+   workers = skuba.num_of_nodes("worker")
+   assert masters == 1
+   assert workers == 1

--- a/ci/infra/testrunner/tests/test_workers.py
+++ b/ci/infra/testrunner/tests/test_workers.py
@@ -1,3 +1,6 @@
+from platforms import Platform
+from skuba import Skuba
+from kubectl import Kubectl
 import pytest
 import time
 
@@ -17,3 +20,21 @@ def test_add_worker(setup, skuba):
     workers = skuba.num_of_nodes("worker")
     assert masters == 1
     assert workers == 1
+
+def test_nginx_deployment(setup, conf):
+    skuba.node_join(role="worker", nr=0)
+    skuba.node_join(role="worker", nr=1)
+    masters = skuba.num_of_nodes("master")
+    workers = skuba.num_of_nodes("worker")
+    assert masters == 1
+    assert workers == 2
+    kubectl.get_pods()
+    kubectl.create_deployment("nginx", "nginx:stable-alpine")
+    kubectl.scale_deployment("nginx", workers)
+    kubectl.expose_deployment("nginx", 80)
+    kubectl.wait_deployment("nginx", 3)
+    kubectl.get_pods()
+    assert kubectl.count_available_replicas("nginx") == workers
+    result = kubectl.test_service("nginx")
+    assert "Welcome to nginx" in result
+

--- a/ci/infra/testrunner/tests/test_workers.py
+++ b/ci/infra/testrunner/tests/test_workers.py
@@ -14,14 +14,14 @@ def setup(request, platform, skuba):
     skuba.cluster_init()
     skuba.node_bootstrap()
 
-def test_add_worker(setup, skuba):
-    skuba.node_join(role="worker", nr=0)
-    masters = skuba.num_of_nodes("master")
-    workers = skuba.num_of_nodes("worker")
-    assert masters == 1
-    assert workers == 1
+#def test_add_worker(setup, skuba):
+#    skuba.node_join(role="worker", nr=0)
+#    masters = skuba.num_of_nodes("master")
+#    workers = skuba.num_of_nodes("worker")
+#    assert masters == 1
+#    assert workers == 1
 
-def test_nginx_deployment(setup, conf):
+def test_nginx_deployment(setup, skuba, kubectl):
     skuba.node_join(role="worker", nr=0)
     skuba.node_join(role="worker", nr=1)
     masters = skuba.num_of_nodes("master")


### PR DESCRIPTION
## Why is this PR needed?

adds an kubectl wrapper to help with the execution of e2e testing in testrunner.

Fixes SUSE/avant-garde#550

## What does this PR do?

adds an kubectl wrapper to help with the execution of e2e testing in testrunner.
also contains a sample test that will deploy a nginx and test it.

