### PR TITLE
Fix Jenkins cluster naming

### DIFF
--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -145,7 +145,8 @@ resource "vsphere_virtual_machine" "lb" {
 }
 
 resource "null_resource" "lb_wait_cloudinit" {
-  count = "${var.lbs}"
+  depends_on = ["vsphere_virtual_machine.lb"]
+  count      = "${var.lbs}"
 
   connection {
     host  = "${element(vsphere_virtual_machine.lb.*.guest_ip_addresses.0, count.index)}"

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         VMWARE_ENV_FILE = credentials('vmware-env')
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'vmware'
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
         PR_CONTEXT = 'jenkins/skuba-test-vmware'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'openstack'
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
         PR_CONTEXT = 'jenkins/skuba-test'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     environment {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
     }

--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
 
    environment {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
    }


### PR DESCRIPTION
## Why is this PR needed?

The VMware load balancer was failing to setup because of how the clusters were being named by Jenkins. Also the cloud init wait wasn't waiting for the lb to be done.

Fixes #

## What does this PR do?

Updates how we name the clusters with jenkins replacing `/` with `-`.
Makes it so the LB should be ready before the cloud init wait is started.

## Anything else a reviewer needs to know?
