### PR TITLE
ci: infra: Generate cloud provider config file on nodes

### DIFF
--- a/ci/infra/openstack/cloud-provider.tf
+++ b/ci/infra/openstack/cloud-provider.tf
@@ -1,0 +1,19 @@
+resource "null_resource" "generate_cloud_provider_conf" {
+  depends_on = ["null_resource.master_reboot", "null_resource.worker_reboot"]
+  count      = "${var.cpi_enable ? 1 : 0}"
+
+  provisioner "local-exec" {
+    environment = {
+      CA_FILE              = "${var.ca_file}"
+      TR_STACK             = "${var.stack_name}"
+      TR_USERNAME          = "${var.username}"
+      TR_LB_IP             = "${openstack_networking_floatingip_v2.lb_ext.address}"
+      TR_MASTER_IPS        = "${join(" ", openstack_networking_floatingip_v2.master_ext.*.address)}"
+      TR_WORKER_IPS        = "${join(" ", openstack_networking_floatingip_v2.worker_ext.*.address)}"
+      OS_PRIVATE_SUBNET_ID = "${openstack_networking_subnet_v2.subnet.id}"
+      OS_PUBLIC_NET_ID     = "${data.openstack_networking_network_v2.external_network.id}"
+    }
+
+    command = "bash generate-cloud-provider-conf"
+  }
+}

--- a/ci/infra/openstack/generate-cloud-provider-conf
+++ b/ci/infra/openstack/generate-cloud-provider-conf
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+log()   { (>&1 echo -e "$@") ; }
+cmd()   { log "[ CMD ] $@" ; }
+info()  { log "[ INFO ] $@" ; }
+error() { (>&2 echo -e "[ ERROR ] $@") ;}
+
+if [ -z "${OS_AUTH_URL}" ] || [ -z "${OS_USERNAME}" ] || \
+   [ -z "${OS_PASSWORD}" ] || [ -z "${OS_PROJECT_ID}" ] || \
+   [ -z "${OS_PRIVATE_SUBNET_ID}" ] || [ -z "${OS_PUBLIC_NET_ID}" ]; then
+  error '$OS_AUTH_URL $OS_USERNAME $OS_PASSWORD $OS_PROJECT_ID'
+  error '$OS_PRIVATE_SUBNET_ID $OS_PUBLIC_NET_ID must be specified'
+  error 'Please download and source your OpenStack RC file'
+  exit 1
+fi
+
+OPENSTACK_CONF="openstack.conf"
+
+umask 077
+
+cat << EOF > "${OPENSTACK_CONF}"
+[Global]
+auth-url="${OS_AUTH_URL}"
+username="${OS_USERNAME}"
+password="${OS_PASSWORD}"
+tenant-id="${OS_PROJECT_ID}"
+tenant-name="${OS_PROJECT_NAME}"
+domain-id="${OS_USER_DOMAIN_ID}"
+domain-name="${OS_USER_DOMAIN_NAME}"
+region="${OS_REGION_NAME}"
+ca-file="${CA_FILE}"
+[LoadBalancer]
+lb-version=v2
+subnet-id="${OS_PRIVATE_SUBNET_ID}"
+floating-network-id="${OS_PUBLIC_NET_ID}"
+create-monitor=yes
+monitor-delay=1m
+monitor-timeout=30s
+monitor-max-retries=3
+[BlockStorage]
+trust-device-path=false
+bs-version=v2
+ignore-volume-az=true
+EOF
+
+umask 022
+
+[ -z "$OS_PROJECT_NAME" ] && sed -i '/^tenant-name=/d' "${OPENSTACK_CONF}"
+[ -z "$OS_USER_DOMAIN_ID" ] &&  sed -i '/^domain-id=/d' "${OPENSTACK_CONF}"
+[ -z "$OS_USER_DOMAIN_NAME" ] && sed -i '/^domain-name=/d' "${OPENSTACK_CONF}"
+[ -z "$CA_FILE" ] && sed -i '/^ca-file=/d' "${OPENSTACK_CONF}"
+
+if [ -z "${TR_STACK}" ] || [ -z "${TR_LB_IP}" ] || \
+   [ -z "$TR_MASTER_IPS" ] || [ -z "$TR_WORKER_IPS" ] || \
+   [ -z "${TR_USERNAME}" ]; then
+  error '$TR_STACK $TR_LB_IP $TR_MASTER_IPS $TR_WORKER_IPS must be specified'
+  exit 1
+fi
+
+info "### Run following commands to bootstrap skuba cluster:\n"
+cmd " skuba cluster init --control-plane ${TR_LB_IP} --cloud-provider openstack ${TR_STACK}-cluster"
+cmd " mv openstack.conf ${TR_STACK}-cluster/cloud/openstack/openstack.conf"
+cmd " cd ${TR_STACK}-cluster"
+
+i=0
+for MASTER in $TR_MASTER_IPS; do
+  if [ $i -eq "0" ]; then
+    cmd " skuba node bootstrap --target ${MASTER} --sudo --user ${TR_USERNAME} caasp-master-${TR_STACK}-0"
+  else
+    cmd " skuba node join --role master --target ${MASTER} --sudo --user ${TR_USERNAME} caasp-master-${TR_STACK}-${i}"
+  fi
+  ((++i))
+done
+
+i=0
+for WORKER in $TR_WORKER_IPS; do
+  cmd " skuba node join --role worker --target ${WORKER} --sudo --user ${TR_USERNAME} caasp-worker-${TR_STACK}-${i}"
+  ((++i))
+done

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -116,3 +116,13 @@ variable "rmt_server_name" {
   default     = ""
   description = "SUSE Repository Mirroring Server Name"
 }
+
+variable "cpi_enable" {
+  default     = false
+  description = "Enable CPI integration with OpenStack"
+}
+
+variable "ca_file" {
+  default     = ""
+  description = "Used to specify the path to your custom CA file"
+}


### PR DESCRIPTION
## Why is this PR needed?

It will generate cloud provider integration config file for OpenStack

Issue # https://github.com/SUSE/avant-garde/issues/568

## What does this PR do?

1. Use OpenStack and Terraform variables to generate `openstack.conf` file needed by skuba for enabling cloud provider integration
2. Will suggest about next steps how to bootstrap `skuba` cluster, example output below
```
null_resource.generate_cloud_provider_conf (local-exec): Executing: ["/bin/sh" "-c" "bash generate-cloud-provider-conf"]

null_resource.generate_cloud_provider_conf (local-exec): [ INFO ] ### Run following commands to bootstrap skuba cluster:

null_resource.generate_cloud_provider_conf (local-exec):  skuba cluster init --control-plane 10.86.2.28 --cloud-provider openstack mjura-cluster
null_resource.generate_cloud_provider_conf (local-exec):  mv openstack.conf mjura-cluster/cloud/openstack.conf
null_resource.generate_cloud_provider_conf (local-exec):  cd mjura-cluster
null_resource.generate_cloud_provider_conf (local-exec):  skuba node bootstrap --target 10.86.1.214 --sudo --user sles caasp-master-mjura-0
null_resource.generate_cloud_provider_conf (local-exec):  skuba node join --role worker --target 10.86.0.195 --sudo --user sles caasp-worker-mjura-0
null_resource.generate_cloud_provider_conf (local-exec):  skuba node join --role worker --target 10.86.2.19 --sudo --user sles caasp-worker-mjura-1
```