### PR TITLE
Disallow remove last master in cluster (bsc#1138467)

### DIFF
--- a/internal/app/skuba/node/remove.go
+++ b/internal/app/skuba/node/remove.go
@@ -23,8 +23,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
-	node "github.com/SUSE/skuba/pkg/skuba/actions/node/remove"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	node "github.com/SUSE/skuba/pkg/skuba/actions/node/remove"
 )
 
 type removeOptions struct {

--- a/internal/app/skuba/node/remove.go
+++ b/internal/app/skuba/node/remove.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/klog"
 
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/remove"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 )
 
 type removeOptions struct {
@@ -36,11 +38,17 @@ func NewRemoveCmd() *cobra.Command {
 		Use:   "remove <node-name>",
 		Short: "Removes a node from the cluster",
 		Run: func(cmd *cobra.Command, nodenames []string) {
+			client, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Fatalf("unable to get admin client set: %s", err)
+			}
+
 			if removeOptions.drainTimeout < 0 {
 				klog.Infof("the passed duration was negative and will be ignored")
 				removeOptions.drainTimeout = 0
 			}
-			if err := node.Remove(nodenames[0], removeOptions.drainTimeout); err != nil {
+
+			if err := node.Remove(client, nodenames[0], removeOptions.drainTimeout); err != nil {
 				klog.Fatalf("error removing node %s: %s", nodenames[0], err)
 			}
 		},

--- a/internal/app/skuba/node/remove.go
+++ b/internal/app/skuba/node/remove.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/klog"
 
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/remove"
-
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 )
 

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -39,8 +39,7 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 		return errors.Wrapf(err, "[remove-node] could not get node %s", target)
 	}
 
-	_, isMaster := node.ObjectMeta.Labels[kubeadmconstants.LabelNodeRoleMaster]
-	if isMaster {
+	if kubernetes.IsControlPlane(node) {
 		nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=", kubeadmconstants.LabelNodeRoleMaster),
 		})
@@ -49,7 +48,7 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 			return errors.Wrapf(err, "could not retrieve master node list")
 		}
 
-		if len(nodes.Items) < 2 {
+		if len(nodes.Items) == 1 {
 			return errors.New(fmt.Sprintf("could not remove last master of the cluster"))
 		}
 	}

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -40,7 +40,6 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 	}
 
 	_, isMaster := node.ObjectMeta.Labels[kubeadmconstants.LabelNodeRoleMaster]
-
 	if isMaster {
 		nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=", kubeadmconstants.LabelNodeRoleMaster),

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/cni"
@@ -32,15 +33,10 @@ import (
 )
 
 // Remove removes a node from the cluster
-func Remove(target string, drainTimeout time.Duration) error {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return errors.Wrap(err, "unable to get admin client set")
-	}
-
+func Remove(client clientset.Interface, target string, drainTimeout time.Duration) error {
 	node, err := client.CoreV1().Nodes().Get(target, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrapf(err, "could not get node %s", target)
+		return errors.Wrapf(err, "[remove-node] could not get node %s", target)
 	}
 
 	_, isMaster := node.ObjectMeta.Labels[kubeadmconstants.LabelNodeRoleMaster]
@@ -49,6 +45,7 @@ func Remove(target string, drainTimeout time.Duration) error {
 		nodes, err := client.CoreV1().Nodes().List(metav1.ListOptions{
 			LabelSelector: fmt.Sprintf("%s=", kubeadmconstants.LabelNodeRoleMaster),
 		})
+
 		if err != nil {
 			return errors.Wrapf(err, "could not retrieve master node list")
 		}

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -49,7 +49,7 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 		}
 
 		if len(nodes.Items) == 1 {
-			return errors.New(fmt.Sprintf("could not remove last master of the cluster"))
+			return errors.New("could not remove last master of the cluster")
 		}
 	}
 

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -42,19 +42,27 @@ func Test_RemoveMasterNode(t *testing.T) {
 			errorExpected: 	true,
 			errorMessage: 	"could not remove last master of the cluster",
 		},
+		{
+			name:			"cannot get node",
+			target: 		"master-2",
+			clientset:		fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
+			errorExpected: 	true,
+			errorMessage: 	"[remove-node] could not get node master-2: nodes \"master-2\" not found",
+		},
 	}
 
 	for _, tt := range test {
+		tt := tt // Parallel testing
 		t.Run(tt.name, func(t *testing.T) {
-			actual := Remove(tt.clientset, tt.target, 0)
-			if tt.errorExpected && actual.Error() == "" {
+			err := Remove(tt.clientset, tt.target, 0)
+			if tt.errorExpected && err == nil {
 				t.Errorf("error expected on %s, but no error reported", tt.name)
 				return
-			} else if !tt.errorExpected && actual.Error() != "" {
-				t.Errorf("error not expected on %s, but an error was reported (%s)", tt.name, actual.Error())
+			} else if !tt.errorExpected && err != nil {
+				t.Errorf("error not expected on %s, but an error was reported (%s)", tt.name, err.Error())
 				return
-			} else if tt.errorExpected && actual.Error() != tt.errorMessage {
-				t.Errorf("(%v) expected on %s, but different error message reported (%v)", tt.errorMessage, tt.name, actual.Error())
+			} else if tt.errorExpected && err.Error() != tt.errorMessage {
+				t.Errorf("(%v) expected on %s, but different error message reported (%v)", tt.errorMessage, tt.name, err.Error())
 				return
 			}
 		})

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package remove
+
+import (
+	"testing"
+ 
+	"k8s.io/client-go/kubernetes/fake"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_RemoveMasterNode(t *testing.T) {
+	node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "master-1", Labels: map[string]string{"node-role.kubernetes.io/master": "" }}}
+
+	test := []struct {
+		name			string
+		target			string
+		clientset		*fake.Clientset
+		errorExpected	bool
+		errorMessage	string
+	}{
+		{
+			name:			"remove last master from cluster",
+			target: 		"master-1",
+			clientset:		fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
+			errorExpected: 	true,
+			errorMessage: 	"could not remove last master of the cluster",
+		},
+	}
+
+	for _, tt := range test {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := Remove(tt.clientset, tt.target, 0)
+			if tt.errorExpected && actual.Error() == "" {
+				t.Errorf("error expected on %s, but no error reported", tt.name)
+				return
+			} else if !tt.errorExpected && actual.Error() != "" {
+				t.Errorf("error not expected on %s, but an error was reported (%s)", tt.name, actual.Error())
+				return
+			} else if tt.errorExpected && actual.Error() != tt.errorMessage {
+				t.Errorf("(%v) expected on %s, but different error message reported (%v)", tt.errorMessage, tt.name, actual.Error())
+				return
+			}
+		})
+	}
+}
+

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -19,35 +19,35 @@ package remove
 
 import (
 	"testing"
- 
-	"k8s.io/client-go/kubernetes/fake"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_RemoveMasterNode(t *testing.T) {
-	node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "master-1", Labels: map[string]string{"node-role.kubernetes.io/master": "" }}}
+	node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "master-1", Labels: map[string]string{"node-role.kubernetes.io/master": ""}}}
 
 	test := []struct {
-		name			string
-		target			string
-		clientset		*fake.Clientset
-		errorExpected	bool
-		errorMessage	string
+		name          string
+		target        string
+		clientset     *fake.Clientset
+		errorExpected bool
+		errorMessage  string
 	}{
 		{
-			name:			"remove last master from cluster",
-			target: 		"master-1",
-			clientset:		fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
-			errorExpected: 	true,
-			errorMessage: 	"could not remove last master of the cluster",
+			name:          "remove last master from cluster",
+			target:        "master-1",
+			clientset:     fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
+			errorExpected: true,
+			errorMessage:  "could not remove last master of the cluster",
 		},
 		{
-			name:			"cannot get node",
-			target: 		"master-2",
-			clientset:		fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
-			errorExpected: 	true,
-			errorMessage: 	"[remove-node] could not get node master-2: nodes \"master-2\" not found",
+			name:          "cannot get node",
+			target:        "master-2",
+			clientset:     fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
+			errorExpected: true,
+			errorMessage:  "[remove-node] could not get node master-2: nodes \"master-2\" not found",
 		},
 	}
 
@@ -68,4 +68,3 @@ func Test_RemoveMasterNode(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>
Fixes #1138467

## What does this PR do?

Added checks so `skuba` does not let user remove the last master of the cluster.