### PR TITLE
Reordering import path

### DIFF
--- a/cmd/skuba/skuba.go
+++ b/cmd/skuba/skuba.go
@@ -23,10 +23,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/klog"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/app/skuba"
 )

--- a/internal/app/skuba/cluster/upgrade.go
+++ b/internal/app/skuba/cluster/upgrade.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/SUSE/skuba/pkg/skuba/actions/cluster/upgrade"
 	"github.com/spf13/cobra"
+
+	"github.com/SUSE/skuba/pkg/skuba/actions/cluster/upgrade"
 )
 
 func NewUpgradeCmd() *cobra.Command {

--- a/internal/app/skuba/node/bootstrap.go
+++ b/internal/app/skuba/node/bootstrap.go
@@ -19,7 +19,6 @@ package node
 
 import (
 	"github.com/spf13/cobra"
-
 	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"

--- a/internal/app/skuba/node/reset.go
+++ b/internal/app/skuba/node/reset.go
@@ -21,13 +21,12 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
 	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/reset"
-
-	"k8s.io/klog"
 )
 
 type resetOptions struct {

--- a/internal/pkg/skuba/cni/cilium.go
+++ b/internal/pkg/skuba/cni/cilium.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/go-yaml/yaml"
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -37,9 +39,6 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
-
-	"github.com/go-yaml/yaml"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/pkg/errors"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 )
 
 type KubernetesUploadSecretsErrorBehavior uint

--- a/internal/pkg/skuba/etcd/member.go
+++ b/internal/pkg/skuba/etcd/member.go
@@ -20,13 +20,12 @@ package etcd
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
-
 	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
-	"github.com/pkg/errors"
 )
 
 func RemoveMember(node *v1.Node) error {

--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -18,6 +18,7 @@
 package kubeadm
 
 import (
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,7 +29,6 @@ import (
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
-	"github.com/pkg/errors"
 )
 
 // GetClusterConfiguration returns the cluster configuration from the `kubeadm-config` ConfigMap

--- a/internal/pkg/skuba/kubernetes/clientset.go
+++ b/internal/pkg/skuba/kubernetes/clientset.go
@@ -18,11 +18,11 @@
 package kubernetes
 
 import (
+	"github.com/pkg/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 
 	"github.com/SUSE/skuba/pkg/skuba"
-	"github.com/pkg/errors"
 )
 
 func GetAdminClientSet() (*clientset.Clientset, error) {

--- a/internal/pkg/skuba/kubernetes/jobs.go
+++ b/internal/pkg/skuba/kubernetes/jobs.go
@@ -22,10 +22,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"k8s.io/klog"
-
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 func CreateJob(name string, spec batchv1.JobSpec) (*batchv1.Job, error) {

--- a/internal/pkg/skuba/kubernetes/nodes.go
+++ b/internal/pkg/skuba/kubernetes/nodes.go
@@ -23,15 +23,14 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
-
+	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"github.com/SUSE/skuba/pkg/skuba"
-	"github.com/pkg/errors"
 )
 
 func GetControlPlaneNodes() (*v1.NodeList, error) {

--- a/internal/pkg/skuba/node/node.go
+++ b/internal/pkg/skuba/node/node.go
@@ -18,13 +18,13 @@
 package node
 
 import (
-	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
-	"github.com/SUSE/skuba/pkg/skuba"
-
 	"k8s.io/apimachinery/pkg/util/version"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 func AddTargetInformationToInitConfigurationWithClusterVersion(target *deployments.Target, initConfiguration *kubeadmapi.InitConfiguration, clusterVersion *version.Version) error {

--- a/internal/pkg/skuba/upgrade/cluster/drift.go
+++ b/internal/pkg/skuba/upgrade/cluster/drift.go
@@ -18,9 +18,10 @@
 package cluster
 
 import (
+	"k8s.io/apimachinery/pkg/util/version"
+
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
-	"k8s.io/apimachinery/pkg/util/version"
 )
 
 func driftedNodesWithVersions(currentClusterVersion *version.Version, nodesVersionInfo kubernetes.NodeVersionInfoMap) []kubernetes.NodeVersionInfo {

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"

--- a/pkg/skuba/actions/cluster/status/status.go
+++ b/pkg/skuba/actions/cluster/status/status.go
@@ -20,10 +20,11 @@ package cluster
 import (
 	"os"
 
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectlget "k8s.io/kubernetes/pkg/kubectl/cmd/get"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 )
 
 // Status prints the status of the cluster on the standard output by reading the

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/version"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -32,7 +33,6 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
 	"github.com/SUSE/skuba/pkg/skuba"
-	"github.com/pkg/errors"
 )
 
 // Bootstrap initializes the first master node of the cluster

--- a/pkg/skuba/actions/node/bootstrap/config.go
+++ b/pkg/skuba/actions/node/bootstrap/config.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 
 	"github.com/pkg/errors"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -34,7 +35,6 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
-	"github.com/pkg/errors"
 )
 
 // Join joins a new machine to the cluster. The role of the machine will be

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -21,13 +21,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/cni"
 	"github.com/SUSE/skuba/internal/pkg/skuba/etcd"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
-	"github.com/pkg/errors"
 )
 
 // Remove removes a node from the cluster

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
@@ -29,7 +30,6 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
 	"github.com/SUSE/skuba/pkg/skuba"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func Apply(target *deployments.Target) error {

--- a/test/core-features/00_cluster_init.go
+++ b/test/core-features/00_cluster_init.go
@@ -5,13 +5,14 @@ import (
 	"os"
 	"time"
 
-	testlib "github.com/SUSE/skuba/test/lib"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testlib "github.com/SUSE/skuba/test/lib"
 )
 
 var _ = ginkgo.Describe("Create Skuba Cluster", func() {

--- a/test/lib/skuba.go
+++ b/test/lib/skuba.go
@@ -2,16 +2,17 @@ package lib
 
 import (
 	"fmt"
-	"github.com/SUSE/skuba/pkg/skuba"
+	"os"
+	"os/exec"
+	"path/filepath"
+
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
 
-	"os"
-	"os/exec"
-	"path/filepath"
+	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 func getEnvWithDefault(variable string, defaultValue string) string {


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

Generally, import path grouping as
```
// standard packages

// third-party packages

// local packages
```

## What does this PR do?

Run `goimports` command
```
goimports -w -local=github.com/SUSE `find . -name *.go | grep -v /vendor/`
```

## Anything else a reviewer needs to know?

N/A