### PR TITLE
Enable upgrade via intermediate pattern

### DIFF
--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -55,7 +55,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	versionToDeploy := version.MustParseSemantic(initConfiguration.KubernetesVersion)
 
 	_, err = target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
-		KubernetesVersion: kubernetes.MajorMinorVersion(versionToDeploy),
+		KubernetesVersion: versionToDeploy.String(),
 	})
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -52,14 +52,14 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		return errors.Wrapf(err, "could not parse %s file", skuba.KubeadmInitConfFile())
 	}
 
+	versionToDeploy := version.MustParseSemantic(initConfiguration.KubernetesVersion)
+
 	_, err = target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
-		KubernetesVersion: kubernetes.MajorMinorVersion(version.MustParseSemantic(initConfiguration.KubernetesVersion)),
+		KubernetesVersion: kubernetes.MajorMinorVersion(versionToDeploy),
 	})
 	if err != nil {
 		return err
 	}
-
-	versionToDeploy := kubernetes.LatestVersion()
 
 	fmt.Println("[bootstrap] updating init configuration with target information")
 	if err := node.AddTargetInformationToInitConfigurationWithClusterVersion(target, initConfiguration, versionToDeploy); err != nil {

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -45,7 +45,7 @@ import (
 func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.Target) error {
 	currentClusterVersion, _ := kubeadm.GetCurrentClusterVersion()
 	_, err := target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
-		KubernetesVersion: kubernetes.MajorMinorVersion(currentClusterVersion),
+		KubernetesVersion: currentClusterVersion.String(),
 	})
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -87,7 +87,7 @@ func Apply(target *deployments.Target) error {
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
-			}, "kubernetes.install-base-packages")
+			}, "kubernetes.install-intermediate-node-pattern")
 			if err != nil {
 				return err
 			}
@@ -123,7 +123,7 @@ func Apply(target *deployments.Target) error {
 			err := target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
-			}, "kubernetes.install-base-packages")
+			}, "kubernetes.install-intermediate-node-pattern")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
To achieve kubeadm being upgraded without upgrading kubelet
and the container runtime, we decided to go with an inter-
mediate pattern "patterns-caasp-Node-[OldVersion]-[NewVersion]"

Fixes https://github.com/SUSE/avant-garde/issues/607