### PR TITLE
Openstack config file gets made read-only on bootstrap and join

### DIFF
--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -87,6 +87,7 @@ func Init(initConfiguration InitConfiguration) error {
 			return errors.Wrap(err, "unable to render template")
 		}
 		f.WriteString(str)
+		f.Chmod(0600)
 		f.Close()
 	}
 

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -68,6 +68,9 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	}
 
 	if cloud.HasCloudIntegration() {
+		if !cloud.ConfigHasRestrictedPermissions(skuba.OpenstackCloudConfFile()) {
+			return errors.New(fmt.Sprintf("Cloud config file %s should be accessible only by the owner (eg 600)", skuba.OpenstackCloudConfFile()))
+		}
 		setCloudConfiguration(initConfiguration)
 		setCloudConfigurationPath(initConfiguration)
 	}

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -109,6 +109,9 @@ func ConfigPath(role deployments.Role, target *deployments.Target) (string, erro
 	addFreshTokenToJoinConfiguration(target.Target, joinConfiguration)
 	addTargetInformationToJoinConfiguration(target, role, joinConfiguration)
 	if cloud.HasCloudIntegration() {
+		if !cloud.ConfigHasRestrictedPermissions(skuba.OpenstackCloudConfFile()) {
+			return "", errors.New(fmt.Sprintf("Cloud config file %s should be accessible only by the owner (eg 600)", skuba.OpenstackCloudConfFile()))
+		}
 		setCloudConfiguration(joinConfiguration)
 	}
 	finalJoinConfigurationContents, err := kubeadmconfigutil.MarshalKubeadmConfigObject(joinConfiguration)

--- a/pkg/skuba/cloud/cloud.go
+++ b/pkg/skuba/cloud/cloud.go
@@ -25,13 +25,26 @@ import (
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
+// HasCloudIntegration checks if the cluster has a cloud integration
 func HasCloudIntegration() bool {
 	if _, err := os.Stat(skuba.OpenstackCloudConfFile()); err == nil {
-		os.Chmod(skuba.OpenstackCloudConfFile(), 0400)
 		return true
 	} else if _, err := os.Stat(skuba.OpenstackCloudConfTemplateFile()); err == nil {
 		klog.Fatalf("%q file exists, but %q file does not. Please create this file with the expected contents to enable cloud integration", skuba.OpenstackCloudConfTemplateFile(), skuba.OpenstackCloudConfFile())
 	}
-
 	return false
+}
+
+// ConfigHasRestrictedPermissions returns true if
+func ConfigHasRestrictedPermissions(file string) bool {
+	info, err := os.Stat(file)
+	if err != nil {
+		return false
+	}
+	mode := info.Mode()
+	var mask os.FileMode = 077
+	if (mode & mask) > 0 {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
## Why is this PR needed?
Currently once deployed your openstack config file becomes read only on the machine you run init from. This file should maintain its edit-ability from the deployment machine for the owner of the file.