### PR TITLE
add release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,14 @@ This will be checked automatically by our CI linter bot.
 
 ## Releasing
 
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ If you are releasing a new kubernetes version, or any other container, +
++ make sure the versions.go has been updated accordingly. See as an      +
++ example:                                                               +
++   https://github.com/SUSE/skuba/pull/573                               +
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+
 In order to create a new release, create a Pull Request with these changes:
 
   * Update the VERSION file:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,3 +46,35 @@ This list is not comprehensive, meaning if you want to include more detail than 
 ## Go style
 
 This will be checked automatically by our CI linter bot.
+
+## Releasing
+
+In order to create a new release, create a Pull Request with these changes:
+
+  * Update the VERSION file:
+    echo "x.y.z" > VERSION
+
+  * Commit with the message "Bump version: x.y.z", being x.y.z the version. Please use semantic versioning.
+    git commit -m "Bump version: x.y.z" -s
+
+Ask for a reviewer. Once reviewed, checkout master branch:
+
+    * git checkout master && git pull
+
+And tag:
+
+  * Tag with vx.y.z
+    git tag vx.y.z
+
+* Push
+  git push --tags origin master
+
+* Checkout the tag
+  git checkout vx.y.z
+
+* Create the changelog:
+  make suse-package 
+
+* Add a new release at https://github.com/SUSE/skuba/releases with the contents from the file ci/packaging/suse/obs_files/skuba.changes.append
+
+* Use the files in ci/packaging/suse/obs_files to update the skuba package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ Ask for a reviewer. Once reviewed, checkout master branch:
 And tag:
 
   * Tag with vx.y.z
-    git tag vx.y.z
+    git tag -s vx.y.z -m "Tag x.y.z"
 
 * Push
   git push --tags origin master


### PR DESCRIPTION
Why is this PR needed?

To have clear instructions on how to do the releases.

Replaces https://github.com/SUSE/skuba/pull/506