### PR TITLE
skuba: Show skuba version on stdout

### DIFF
--- a/internal/app/skuba/version.go
+++ b/internal/app/skuba/version.go
@@ -19,7 +19,6 @@ package skuba
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -31,7 +30,7 @@ func NewVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "Print version information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(os.Stderr, "%s\n", skuba.CurrentVersion().String())
+			fmt.Printf("%s\n", skuba.CurrentVersion().String())
 		},
 	}
 }


### PR DESCRIPTION
Output from `skuba version` command is going to stderr instead of stdout.
This change is fixing this.

## Why is this PR needed?

Output from `skuba version` command is going to stderr instead of stdout.
This change is fixing this.

Fixes #

Issue #412

## What does this PR do?

`skuba version` command is writing output to `Stdout`