### PR TITLE
Print nodenames and IP for instances

### DIFF
--- a/ci/infra/openstack/output.tf
+++ b/ci/infra/openstack/output.tf
@@ -1,13 +1,13 @@
-output "hostnames_masters" {
-  value = "${openstack_dns_recordset_v2.master.*.name}"
+output "masters" {
+  value = "${zipmap(
+    openstack_compute_instance_v2.master.*.name,
+    openstack_networking_floatingip_v2.master_ext.*.address)}"
 }
 
-output "ip_masters" {
-  value = ["${openstack_networking_floatingip_v2.master_ext.*.address}"]
-}
-
-output "ip_workers" {
-  value = ["${openstack_networking_floatingip_v2.worker_ext.*.address}"]
+output "workers" {
+  value = "${zipmap(
+    openstack_compute_instance_v2.worker.*.name,
+    openstack_networking_floatingip_v2.worker_ext.*.address)}"
 }
 
 output "ip_internal_load_balancer" {


### PR DESCRIPTION
In order to bootstrap/join nodes with skuba, we must use the OpenStack instances names as nodenames. This prints a map of instance names and IP, so we can use those parmeters when bootstrapping/joining as `--target <IP> <NODENAME>`.

Sample `terraform output`:

```
ip_internal_load_balancer = 172.28.0.10
ip_load_balancer = 10.86.3.69
masters = {
  caasp-master-alv-0 = 10.86.2.239
}
workers = {
  caasp-worker-alv-0 = 10.86.3.63
  caasp-worker-alv-1 = 10.86.1.230
}
```

Related to SUSE/avant-garde#578

