### PR TITLE
Archive conformance results correctly

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
         stage('Conformance Tests') { steps {
             sh(script: "skuba/ci/tasks/sonobuoy_e2e.py run --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Run Conformance')
             sh(script: "skuba/ci/tasks/sonobuoy_e2e.py collect --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Collect Results')
-            archiveArtifacts('results')
+            archiveArtifacts('results/**/*')
             junit('results/plugins/e2e/results/*.xml')
             sh(script: "skuba/ci/tasks/sonobuoy_e2e.py cleanup --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Cleanup Cluster')
         } }


### PR DESCRIPTION
## Why is this PR needed?

Conformance results were not being archived correctly causing the tests to fail.

Fixes #

## What does this PR do?

Treat results as a dir and collect everything in it.

## Anything else a reviewer needs to know?
