### PR TITLE
Set empty body variable

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
@@ -42,6 +42,7 @@ class PrChecks:
             # Not sure why we need to use the nested commit for the email
             email = commit.commit.author.email
             user_id = f'{author.login}({email})'
+            body = ''
 
             # This could be probably smarter but commit contains something like the following
             # message="$commit_title\n\n$long_commit_message" and as such maybe we can split it and


### PR DESCRIPTION
## Why is this PR needed?

If it's not set and a commit doesn't have a body then an error occurs causing PRs to fail on jenkins

Fixes #

## What does this PR do?


## Anything else a reviewer needs to know?
