### PR TITLE
Disable kured and skuba-update.timer during upgrade

### DIFF
--- a/internal/pkg/skuba/deployments/deployments.go
+++ b/internal/pkg/skuba/deployments/deployments.go
@@ -29,6 +29,7 @@ type Actionable interface {
 	Apply(data interface{}, states ...string) error
 	UploadFileContents(targetPath, contents string) error
 	DownloadFileContents(sourcePath string) (string, error)
+	IsServiceEnabled(serviceName string) (bool, error)
 }
 
 type TargetCache struct {
@@ -60,4 +61,8 @@ func (t *Target) UploadFileContents(targetPath, contents string) error {
 
 func (t *Target) DownloadFileContents(sourcePath string) (string, error) {
 	return t.Actionable.DownloadFileContents(sourcePath)
+}
+
+func (t *Target) IsServiceEnabled(serviceName string) (bool, error) {
+	return t.Actionable.IsServiceEnabled(serviceName)
 }

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -20,9 +20,12 @@ package ssh
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
@@ -33,6 +36,7 @@ type KubernetesUploadSecretsErrorBehavior uint
 const (
 	KubernetesUploadSecretsFailOnError     KubernetesUploadSecretsErrorBehavior = iota
 	KubernetesUploadSecretsContinueOnError KubernetesUploadSecretsErrorBehavior = iota
+	kubeletTimeOutWait                                                          = 300
 )
 
 func init() {
@@ -42,6 +46,7 @@ func init() {
 	stateMap["kubernetes.install-node-pattern"] = kubernetesInstallNodePattern
 	stateMap["kubernetes.install-intermediate-node-pattern"] = kubernetesInstallIntermediateNodePattern
 	stateMap["kubernetes.restart-services"] = kubernetesRestartServices
+	stateMap["kubernetes.wait-for-kubelet"] = kubernetesWaitForKubelet
 }
 
 func kubernetesUploadSecrets(errorHandling KubernetesUploadSecretsErrorBehavior) Runner {
@@ -104,4 +109,21 @@ func kubernetesInstallIntermediateNodePattern(t *Target, data interface{}) error
 func kubernetesRestartServices(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "restart", "crio", "kubelet")
 	return err
+}
+
+func kubernetesWaitForKubelet(t *Target, data interface{}) error {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return errors.Wrap(err, "Error getting client set")
+	}
+	for i := 0; i < kubeletTimeOutWait; i++ {
+		_, err := clientSet.CoreV1().Nodes().Get(t.target.Nodename, metav1.GetOptions{})
+		if err != nil {
+			klog.V(1).Infof("Still waiting for %s node to be registered, continuing...", t.target.Nodename)
+		} else {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return errors.Wrap(err, fmt.Sprintf("Timed out waiting for %s", t.target.Nodename))
 }

--- a/internal/pkg/skuba/deployments/ssh/kured.go
+++ b/internal/pkg/skuba/deployments/ssh/kured.go
@@ -22,13 +22,24 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 func init() {
 	stateMap["kured.deploy"] = kuredDeploy
+	stateMap["kured.lock"] = kuredLock
+	stateMap["kured.unlock"] = kuredUnlock
 }
+
+const (
+	kuredDSName             = "kured"
+	kuredLockAnnotationJson = `{"metadata":{"annotations":{"weave.works/kured-node-lock":"'{\"nodeID\":\"manual\"}'"}}}`
+)
 
 func kuredDeploy(t *Target, data interface{}) error {
 	kuredFiles, err := ioutil.ReadDir(skuba.KuredDir())
@@ -45,5 +56,34 @@ func kuredDeploy(t *Target, data interface{}) error {
 	}
 
 	_, _, err = t.ssh("kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/kured.d")
+	return err
+}
+
+func kuredLock(t *Target, data interface{}) error {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return errors.Wrap(err, "unable to get admin client set")
+	}
+	_, err = clientSet.AppsV1().DaemonSets(metav1.NamespaceSystem).Patch(kuredDSName, types.StrategicMergePatchType, []byte(kuredLockAnnotationJson))
+	if err != nil {
+		return errors.Wrap(err, "unable to patch daemonset with kured locking annotation")
+	}
+	klog.V(1).Info("successfully annotated daemonset with kured locking annotation")
+	return err
+}
+
+func kuredUnlock(t *Target, data interface{}) error {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return errors.Wrap(err, "unable to get admin client set")
+	}
+	// jsonpatch expects a ~1 escape sequence for a forward slash '/'
+	// the annotation we want to remove is 'weave.works/kured-node-lock'
+	payload := []byte(`[{"op":"remove","path":"/metadata/annotations/weave.works~1kured-node-lock"}]`)
+	_, err = clientSet.AppsV1().DaemonSets(metav1.NamespaceSystem).Patch(kuredDSName, types.JSONPatchType, payload)
+	if err != nil {
+		return errors.Wrap(err, "unable to patch daemonset with kured unlocking annotation")
+	}
+	klog.V(1).Info("successfully removed kured locking annotation")
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/skuba-update.go
+++ b/internal/pkg/skuba/deployments/ssh/skuba-update.go
@@ -19,9 +19,15 @@ package ssh
 
 func init() {
 	stateMap["skuba-update.start"] = skubaUpdateStart
+	stateMap["skuba-update.stop"] = skubaUpdateStop
 }
 
 func skubaUpdateStart(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "enable", "--now", "skuba-update.timer")
+	return err
+}
+
+func skubaUpdateStop(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "disable", "--now", "skuba-update.timer")
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/systemd.go
+++ b/internal/pkg/skuba/deployments/ssh/systemd.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ssh
+
+import (
+	"k8s.io/klog"
+)
+
+// IsServiceEnabled returns if a service is enabled
+func (t *Target) IsServiceEnabled(serviceName string) (bool, error) {
+	klog.V(1).Info("checking if skuba-update.timer is enabled")
+	if stdout, _, err := t.silentSsh("systemctl", "is-enabled", serviceName); stdout == "enabled" {
+		return true, err
+	} else {
+		return false, err
+	}
+}

--- a/internal/pkg/skuba/deployments/ssh/systemd.go
+++ b/internal/pkg/skuba/deployments/ssh/systemd.go
@@ -24,7 +24,7 @@ import (
 // IsServiceEnabled returns if a service is enabled
 func (t *Target) IsServiceEnabled(serviceName string) (bool, error) {
 	klog.V(1).Info("checking if skuba-update.timer is enabled")
-	if stdout, _, err := t.silentSsh("systemctl", "is-enabled", serviceName); stdout == "enabled" {
+	if stdout, _, err := t.silentSsh("systemctl", "is-enabled", serviceName, "||", ":"); stdout == "enabled" {
 		return true, err
 	} else {
 		return false, err

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
@@ -115,11 +116,14 @@ func Apply(target *deployments.Target) error {
 			if err := target.Apply(nil, "kubernetes.restart-services"); err != nil {
 				return err
 			}
+			if err := target.Apply(nil, "kubernetes.wait-for-kubelet"); err != nil {
+				klog.Errorf("Kubelet could not register node %s. Please check the kubelet system logs and be aware that services kured or skuba-update will stay disabled", target.Nodename)
+				return err
+			}
 			err = target.Apply(nil, "skuba-update.start")
 			if err != nil {
 				return err
 			}
-			// TODO: we have to wait for kube-apiserver to be back before continuing
 			err = target.Apply(nil, "kured.unlock")
 			if err != nil {
 				return err
@@ -165,11 +169,14 @@ func Apply(target *deployments.Target) error {
 			if err := target.Apply(nil, "kubernetes.restart-services"); err != nil {
 				return err
 			}
+			if err := target.Apply(nil, "kubernetes.wait-for-kubelet"); err != nil {
+				klog.Errorf("Kubelet could not register node %s. Please check the kubelet system logs and be aware that services kured or skuba-update will stay disabled", target.Nodename)
+				return err
+			}
 			err = target.Apply(nil, "skuba-update.start")
 			if err != nil {
 				return err
 			}
-			// TODO: we have to wait for kube-apiserver to be back before continuing
 			err = target.Apply(nil, "kured.unlock")
 			if err != nil {
 				return err

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -88,6 +88,10 @@ func Apply(target *deployments.Target) error {
 			if err != nil {
 				return err
 			}
+			err = target.Apply(nil, "kured.lock")
+			if err != nil {
+				return err
+			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
@@ -115,6 +119,11 @@ func Apply(target *deployments.Target) error {
 			if err != nil {
 				return err
 			}
+			// TODO: we have to wait for kube-apiserver to be back before continuing
+			err = target.Apply(nil, "kured.unlock")
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		// there is already at least one updated control plane node
@@ -129,6 +138,10 @@ func Apply(target *deployments.Target) error {
 			fmt.Printf("Performing node %s (%s) upgrade, please wait...\n", target.Nodename, target.Target)
 
 			err = target.Apply(nil, "skuba-update.stop")
+			if err != nil {
+				return err
+			}
+			err = target.Apply(nil, "kured.lock")
 			if err != nil {
 				return err
 			}
@@ -153,6 +166,11 @@ func Apply(target *deployments.Target) error {
 				return err
 			}
 			err = target.Apply(nil, "skuba-update.start")
+			if err != nil {
+				return err
+			}
+			// TODO: we have to wait for kube-apiserver to be back before continuing
+			err = target.Apply(nil, "kured.unlock")
 			if err != nil {
 				return err
 			}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -61,6 +61,12 @@ func Apply(target *deployments.Target) error {
 		return nil
 	}
 
+	// Check if skuba-update.timer is already disabled
+	skubaUpdateWasEnabled, err := target.IsServiceEnabled("skuba-update.timer")
+	if err != nil {
+		return err
+	}
+
 	// Check if a lock on kured already exists
 	kuredWasLocked, err := kured.KuredLockExists()
 	if err != nil {
@@ -92,10 +98,11 @@ func Apply(target *deployments.Target) error {
 
 			fmt.Printf("Performing node %s (%s) upgrade, please wait...\n", target.Nodename, target.Target)
 
-			// FIXME: check if skuba-update is already disabled
-			err = target.Apply(nil, "skuba-update.stop")
-			if err != nil {
-				return err
+			if skubaUpdateWasEnabled {
+				err = target.Apply(nil, "skuba-update.stop")
+				if err != nil {
+					return err
+				}
 			}
 			if !kuredWasLocked {
 				err = target.Apply(nil, "kured.lock")
@@ -130,10 +137,11 @@ func Apply(target *deployments.Target) error {
 				klog.Errorf("Kubelet could not register node %s. Please check the kubelet system logs and be aware that services kured or skuba-update will stay disabled", target.Nodename)
 				return err
 			}
-			// FIXME: check if skuba-update was already disabled
-			err = target.Apply(nil, "skuba-update.start")
-			if err != nil {
-				return err
+			if skubaUpdateWasEnabled {
+				err = target.Apply(nil, "skuba-update.start")
+				if err != nil {
+					return err
+				}
 			}
 			if !kuredWasLocked {
 				err = target.Apply(nil, "kured.unlock")
@@ -154,10 +162,11 @@ func Apply(target *deployments.Target) error {
 		if upgradeable {
 			fmt.Printf("Performing node %s (%s) upgrade, please wait...\n", target.Nodename, target.Target)
 
-			// FIXME: check if skuba-update is already disabled
-			err = target.Apply(nil, "skuba-update.stop")
-			if err != nil {
-				return err
+			if skubaUpdateWasEnabled {
+				err = target.Apply(nil, "skuba-update.stop")
+				if err != nil {
+					return err
+				}
 			}
 			if !kuredWasLocked {
 				err = target.Apply(nil, "kured.lock")
@@ -189,10 +198,11 @@ func Apply(target *deployments.Target) error {
 				klog.Errorf("Kubelet could not register node %s. Please check the kubelet system logs and be aware that services kured or skuba-update will stay disabled", target.Nodename)
 				return err
 			}
-			// FIXME: check if skuba-update was already disabled
-			err = target.Apply(nil, "skuba-update.start")
-			if err != nil {
-				return err
+			if skubaUpdateWasEnabled {
+				err = target.Apply(nil, "skuba-update.start")
+				if err != nil {
+					return err
+				}
 			}
 			if !kuredWasLocked {
 				err = target.Apply(nil, "kured.unlock")

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -84,6 +84,10 @@ func Apply(target *deployments.Target) error {
 
 			fmt.Printf("Performing node %s (%s) upgrade, please wait...\n", target.Nodename, target.Target)
 
+			err = target.Apply(nil, "skuba-update.stop")
+			if err != nil {
+				return err
+			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
@@ -107,6 +111,10 @@ func Apply(target *deployments.Target) error {
 			if err := target.Apply(nil, "kubernetes.restart-services"); err != nil {
 				return err
 			}
+			err = target.Apply(nil, "skuba-update.start")
+			if err != nil {
+				return err
+			}
 		}
 	} else {
 		// there is already at least one updated control plane node
@@ -120,6 +128,10 @@ func Apply(target *deployments.Target) error {
 		if upgradeable {
 			fmt.Printf("Performing node %s (%s) upgrade, please wait...\n", target.Nodename, target.Target)
 
+			err = target.Apply(nil, "skuba-update.stop")
+			if err != nil {
+				return err
+			}
 			err := target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
@@ -138,6 +150,10 @@ func Apply(target *deployments.Target) error {
 				return err
 			}
 			if err := target.Apply(nil, "kubernetes.restart-services"); err != nil {
+				return err
+			}
+			err = target.Apply(nil, "skuba-update.start")
+			if err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Why is this PR needed?

as a follow up to SUSE/skuba#505 we have to make sure to stop skuba-update.timer during the upgrade to prevent package updates during a node upgrade

and to prevent kured rebooting a node we have to flag the node temporarily during a node upgrade
