### PR TITLE
Improves error handling on kubectl wrapper

### DIFF
--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -16,75 +16,75 @@ class Kubectl:
 
     def create_deployment(self, name, image):
         print("create a new deployment {}".format(name))
+        cmd = "create deployment {name} --image={image}".format(name=name, image=image)
         try:
-            self._run_kubectl("create deployment {name}  --image={image}"
-                                .format(name=name, image=image))
+            self._run_kubectl(cmd)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def scale_deployment(self, name, replicas):
         print("scale deployment {}".format(name))
+        cmd = "scale deployment {name} --replicas={replicas}".format(name=name, replicas=replicas)
         try:
-            self._run_kubectl("scale deployment {name} --replicas={replicas}"
-                             .format(name=name, replicas=replicas))
+            self._run_kubectl(cmd)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def expose_deployment(self, name, port, nodeType="NodePort"):
         print("expose deployment {}".format(name))
+        cmd = "expose deployment {name} --port={port} --type={nodeType}".format(name=name, port=port, nodeType=nodeType)
         try:
-            self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
-                             .format(name=name, port=port, nodeType=nodeType))
+            self._run_kubectl(cmd)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def wait_deployment(self, name, timeout):
         print("wait deployment {}".format(name))
+        cmd = "wait --for=condition=available deploy/{name} --timeout={timeout}m".format(name=name, timeout=timeout)
         try:
-            self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
-                             .format(name=name, timeout=timeout))
+            self._run_kubectl(cmd)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def count_available_replicas(self, name):
         print("count available replicas of deployment {}".format(name))
+        cmd = "get deployment/{name} | jq '.status.availableReplicas'".format(name=name)
         try:
-            result = self._run_kubectl("get deployment/{name} | jq '.status.availableReplicas'"
-                                       .format(name=name))
+            result = self._run_kubectl(cmd)
             return int(result)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def get_service_port(self, name):
         print("get port for deployment {}".format(name))
+        cmd = "get service/{name} | jq '.spec.ports[0].nodePort'".format(name=name)
         try:
-            result = self._run_kubectl("get service/{name} | jq '.spec.ports[0].nodePort'"
-                                       .format(name=name))
+            result = self._run_kubectl(cmd)
             return int(result)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def test_service(self, name, path="/", worker=0):
         print("curl deployment {}".format(name))
         ip_address = self.platform.get_nodes_ipaddrs("worker")
         port = self.get_service_port(name)
+        cmd = "curl {ip}:{port}{path}".format(ip=ip_address[worker],port=port,path=path)
         try:
-            return self.utils.runshellcommand_withoutput("curl {ip}:{port}{path}"
-                                                        .format(ip=ip_address[worker],port=port,path=path), False)
+            return self.utils.runshellcommand_withoutput(cmd, False)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 
 
     def _run_kubectl(self, command):
+        cmd = "kubectl --kubeconfig={cwd}/test-cluster/admin.conf -o json {command}".format(command=command,cwd=self.conf.workspace)
         try:
-            return self.utils.runshellcommand_withoutput("kubectl --kubeconfig={cwd}/test-cluster/admin.conf -o json {command}"
-                                                        .format(command=command,cwd=self.conf.workspace), False)
+            return self.utils.runshellcommand_withoutput(cmd, False)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception("Error executing cmd {}".format(cmd)) from ex
 

--- a/ci/infra/testrunner/tests/test_deployments.py
+++ b/ci/infra/testrunner/tests/test_deployments.py
@@ -3,7 +3,6 @@ from skuba import Skuba
 from kubectl import Kubectl
 import pytest
 import time
-from timeout_decorator import timeout
 
 def test_nginx_deployment(setup, skuba, kubectl):
     skuba.node_join(role="worker", nr=0)


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

## Why is this PR needed?

Currently error handling in `kubectl` wrapper is swallowing important message when tests fail, this PR fixes that behavior.

## What does this PR do?

Fixing poor error handling in `kubectl` wrapper.
