### PR TITLE
Provide the ability to disable port security


### DIFF
--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -2,9 +2,9 @@ resource "openstack_lb_loadbalancer_v2" "lb" {
   name          = "${var.stack_name}-lb"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
 
-  security_group_ids = [
+  security_group_ids = "${var.enable_openstack_port_security == true ? [
     "${openstack_compute_secgroup_v2.secgroup_master_lb.id}",
-  ]
+  ] : [] }"
 }
 
 resource "openstack_lb_listener_v2" "kube_api_listener" {

--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -2,9 +2,7 @@ resource "openstack_lb_loadbalancer_v2" "lb" {
   name          = "${var.stack_name}-lb"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
 
-  security_group_ids = "${var.enable_openstack_port_security == true ? [
-    "${openstack_compute_secgroup_v2.secgroup_master_lb.id}",
-  ] : [] }"
+  security_group_ids = "${var.enable_openstack_port_security == true ? ["${openstack_compute_secgroup_v2.secgroup_master_lb.id}", ] : []}"
 }
 
 resource "openstack_lb_listener_v2" "kube_api_listener" {

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -44,7 +44,7 @@ data "template_file" "master-cloud-init" {
     register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
     commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
     username        = "${var.username}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+    ntp_servers     = "${join("\n", formatlist("    - %s", var.ntp_servers))}"
   }
 }
 
@@ -64,10 +64,7 @@ resource "openstack_compute_instance_v2" "master" {
     name = "${var.internal_net}"
   }
 
-  security_groups = "${var.enable_openstack_port_security == true ? [
-    "${openstack_compute_secgroup_v2.secgroup_base.name}",
-    "${openstack_compute_secgroup_v2.secgroup_master.name}",
-  ] : [] }"
+  security_groups = "${var.enable_openstack_port_security == true ? ["${openstack_compute_secgroup_v2.secgroup_base.name}", "${openstack_compute_secgroup_v2.secgroup_master.name}", ] : []}"
 
   user_data = "${data.template_file.master-cloud-init.rendered}"
 }

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -64,10 +64,10 @@ resource "openstack_compute_instance_v2" "master" {
     name = "${var.internal_net}"
   }
 
-  security_groups = [
+  security_groups = "${var.enable_openstack_port_security == true ? [
     "${openstack_compute_secgroup_v2.secgroup_base.name}",
     "${openstack_compute_secgroup_v2.secgroup_master.name}",
-  ]
+  ] : [] }"
 
   user_data = "${data.template_file.master-cloud-init.rendered}"
 }

--- a/ci/infra/openstack/network.tf
+++ b/ci/infra/openstack/network.tf
@@ -11,7 +11,8 @@ resource "openstack_networking_subnet_v2" "subnet" {
 }
 
 data "openstack_networking_network_v2" "external_network" {
-  name = "${var.external_net}"
+  name                  = "${var.external_net}"
+  port_security_enabled = "${var.enable_openstack_port_security}"
 }
 
 resource "openstack_networking_router_v2" "router" {

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -116,3 +116,8 @@ variable "rmt_server_name" {
   default     = ""
   description = "SUSE Repository Mirroring Server Name"
 }
+
+variable "enable_openstack_port_security" {
+  default     = "true"
+  description = "Enable Port security on OpenStack instances and ports"
+}

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -76,10 +76,10 @@ resource "openstack_compute_instance_v2" "worker" {
     name = "${var.internal_net}"
   }
 
-  security_groups = [
+  security_groups = "${var.enable_openstack_port_security == true ? [
     "${openstack_compute_secgroup_v2.secgroup_base.name}",
     "${openstack_compute_secgroup_v2.secgroup_worker.name}",
-  ]
+  ] : [] }"
 
   user_data = "${data.template_file.worker-cloud-init.rendered}"
 }

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -44,18 +44,18 @@ data "template_file" "worker-cloud-init" {
     register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
     commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
     username        = "${var.username}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+    ntp_servers     = "${join("\n", formatlist("    - %s", var.ntp_servers))}"
   }
 }
 
 resource "openstack_blockstorage_volume_v2" "worker_vol" {
-  count = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
+  count = "${var.workers_vol_enabled ? "${var.workers}" : 0}"
   size  = "${var.workers_vol_size}"
   name  = "vol_${element(openstack_compute_instance_v2.worker.*.name, count.index)}"
 }
 
 resource "openstack_compute_volume_attach_v2" "worker_vol_attach" {
-  count       = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
+  count       = "${var.workers_vol_enabled ? "${var.workers}" : 0}"
   instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
   volume_id   = "${element(openstack_blockstorage_volume_v2.worker_vol.*.id, count.index)}"
 }
@@ -76,10 +76,7 @@ resource "openstack_compute_instance_v2" "worker" {
     name = "${var.internal_net}"
   }
 
-  security_groups = "${var.enable_openstack_port_security == true ? [
-    "${openstack_compute_secgroup_v2.secgroup_base.name}",
-    "${openstack_compute_secgroup_v2.secgroup_worker.name}",
-  ] : [] }"
+  security_groups = "${var.enable_openstack_port_security == true ? ["${openstack_compute_secgroup_v2.secgroup_base.name}", "${openstack_compute_secgroup_v2.secgroup_worker.name}", ] : []}"
 
   user_data = "${data.template_file.worker-cloud-init.rendered}"
 }


### PR DESCRIPTION


For some fringe cases, the openstack network where the
instanciated caasp lies might have port security disabled,
or the deployer want to disable port security when creating
the network all together.

Without this patch, it is impossible to create a network
with port security disabled, and attaching security groups
to a port security disabled network leads to failures in
the OpenStack API.

This fixes the port security case by adding a boolean,
defaulting to true, to determine if port security is enabled,
and use its value when creating network or attaching security
groups.

