### PR TITLE
[bsc#1142890] allow var.packages to be empty

### DIFF
--- a/ci/infra/aws/cloud-init/cloud-init.yaml.tpl
+++ b/ci/infra/aws/cloud-init/cloud-init.yaml.tpl
@@ -21,8 +21,7 @@ bootcmd:
 runcmd:
 ${register_scc}
 ${register_rmt}
-  - zypper ref
-  - zypper in -y --no-recommends ${packages}
+${commands}
   - /usr/bin/sed -i -e 's/btrfs/overlay2/g' /etc/crio/crio.conf
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/aws/cloud-init/commands.tpl
+++ b/ci/infra/aws/cloud-init/commands.tpl
@@ -1,0 +1,2 @@
+  - [ zypper, -n, install, ${packages} ]
+

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -48,7 +48,6 @@ data "template_file" "lb_cloud_init_userdata" {
     dex_backends       = "${join("      ", data.template_file.haproxy_dex_backends_master.*.rendered)}"
     authorized_keys    = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
     repositories       = "${join("\n", data.template_file.lb_repositories.*.rendered)}"
-    packages           = "${join("\n", formatlist("  - %s", var.packages))}"
     username           = "${var.username}"
     password           = "${var.password}"
     ntp_servers        = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "master_register_rmt" {
 
 data "template_file" "master_commands" {
   template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
 
   vars {
     packages = "${join(", ", var.packages)}"

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "worker_register_rmt" {
 
 data "template_file" "worker_commands" {
   template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
 
   vars {
     packages = "${join(", ", var.packages)}"

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "master_register_rmt" {
 
 data "template_file" "master_commands" {
   template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
 
   vars {
     packages = "${join(", ", var.packages)}"

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "worker_register_rmt" {
 
 data "template_file" "worker_commands" {
   template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
 
   vars {
     packages = "${join(", ", var.packages)}"

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "master_register_rmt" {
 
 data "template_file" "master_commands" {
   template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
 
   vars {
     packages = "${join(", ", var.packages)}"

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -28,6 +28,7 @@ data "template_file" "worker_register_rmt" {
 
 data "template_file" "worker_commands" {
   template = "${file("cloud-init/commands.tpl")}"
+  count    = "${join("", var.packages) == "" ? 0 : 1}"
 
   vars {
     packages = "${join(", ", var.packages)}"


### PR DESCRIPTION
## Why is this PR needed?

We do not install the pattern in terraform anymore
so var.packages is empty by default.

Without this commit, if var.packages is empty
cloud-init will run `zypper in` without packages
and will fail consequently.

fixes bsc#1142890

## Anything else a reviewer needs to know?

I haven't tested with all the platforms, only on `VMware`.

I've tried to use the following but it didn't work, this is why I went with `join` instead

```
   count    = "${var.packages == [] ? 0 : 1}"
```

Signed-off-by: lcavajani <lcavajani@suse.com>