### PR TITLE
Set apparmor annotation in PSPs

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -78,8 +78,10 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.privileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+    apparmor.security.beta.kubernetes.io/allowedProfileName: '*'
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged
   privileged: true
@@ -189,6 +191,8 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
     seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
+    apparmor.security.beta.kubernetes.io/allowedProfileName: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged
   privileged: false


### PR DESCRIPTION
## Why is this PR needed?

Apparmor profiles are currently not set in PSPs

Fixes bsc#114297

## Anything else a reviewer needs to know?

By default, any pod is run by crio default profile, here `crio-default-1.15.0`:

```
3 processes are in enforce mode.
   /usr/sbin/nginx (5769) crio-default-1.15.0
   /usr/sbin/nginx (5790) crio-default-1.15.0
   /usr/sbin/nginx (5822) crio-default-1.15.0
0 processes are in complain mode.
0 processes are unconfined but have a profile defined.
```

To test using a different profile with the privileged PSP, I've created a profile on the node **localhost/xtest-lcavajani** and added this to a Deployment:

```
      annotations:
        container.apparmor.security.beta.kubernetes.io/nginx: localhost/xtest-lcavajani
```

1. When using a `serviceAccount` which is not allowed to use `suse:caasp:psp:privileged`, the pods are forbidden to start:

> Error creating: pods "nginx-deployment-7dc89f955b-" is forbidden: unable to validate against any pod security policy: [pod.metadata.annotations[container.apparmor.security.beta.kubernetes.io/nginx]: Forbidden: localhost/xtest-lcavajani is not an allowed profile. Allowed values: "runtime/default"]


2. When using a `serviceAccount` which is allowed to use `suse:caasp:psp:privileged`, the pods start correctly with the following annotations:

```
  annotations:
    container.apparmor.security.beta.kubernetes.io/nginx: localhost/xtest-lcavajani
    kubernetes.io/psp: suse.caasp.psp.privileged
    seccomp.security.alpha.kubernetes.io/pod: runtime/default
```

and the correct apparmor profile is apply on the processes

```
3 processes are in enforce mode.
   /usr/sbin/nginx (10545) xtest-lcavajani
   /usr/sbin/nginx (10566) xtest-lcavajani
   /usr/sbin/nginx (10591) xtest-lcavajani
0 processes are in complain mode.
0 processes are unconfined but have a profile defined.
```

Signed-off-by: lcavajani <lcavajani@suse.com>