### PR TITLE
Redirect Testrunner command outputs to log

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -91,8 +91,9 @@ usage:
     This script is meant to be run manually on test servers, developer desktops, or Jenkins.
     This script supposed to run on python virtualenv from testrunner. Requires root privileges.
     Warning: it removes docker containers, VMs, images, and network configuration.
-    
+
        [-h] [-v YAML_PATH] [-p {openstack,vmware,bare-metal,libvirt}]
+       [-l {DEBUG,INFO,WARNING,ERROR}]
        {info,get_logs,cleanup,provision,build-skuba,bootstrap,status,join-node,remove-node,reset-node,ssh,test}
        ...
 
@@ -122,6 +123,9 @@ optional arguments:
                         -v myconfig.yaml
   -p {openstack,vmware,bare-metal,libvirt}, --platform {openstack,vmware,bare-metal,libvirt}
                         The platform you're targeting. Defaults to openstack
+  -l {DEBUG,INFO,WARNING,ERROR}, --log-level {DEBUG,INFO,WARNING,ERROR}
+                        log level
+
 ```
 
 

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -15,7 +15,6 @@ class Kubectl:
 
 
     def create_deployment(self, name, image):
-        print("create a new deployment {}".format(name))
         try:
             self._run_kubectl("create deployment {name}  --image={image}"
                                 .format(name=name, image=image))
@@ -24,7 +23,6 @@ class Kubectl:
 
 
     def scale_deployment(self, name, replicas):
-        print("scale deployment {}".format(name))
         try:
             self._run_kubectl("scale deployment {name} --replicas={replicas}"
                              .format(name=name, replicas=replicas))
@@ -33,7 +31,6 @@ class Kubectl:
 
 
     def expose_deployment(self, name, port, nodeType="NodePort"):
-        print("expose deployment {}".format(name))
         try:
             self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
                              .format(name=name, port=port, nodeType=nodeType))
@@ -42,7 +39,6 @@ class Kubectl:
 
 
     def wait_deployment(self, name, timeout):
-        print("wait deployment {}".format(name))
         try:
             self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
                              .format(name=name, timeout=timeout))
@@ -51,7 +47,6 @@ class Kubectl:
 
 
     def count_available_replicas(self, name):
-        print("count available replicas of deployment {}".format(name))
         try:
             result = self._run_kubectl("get deployment/{name} | jq '.status.availableReplicas'"
                                        .format(name=name))
@@ -61,7 +56,6 @@ class Kubectl:
 
 
     def get_service_port(self, name):
-        print("get port for deployment {}".format(name))
         try:
             result = self._run_kubectl("get service/{name} | jq '.spec.ports[0].nodePort'"
                                        .format(name=name))

--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -14,15 +14,11 @@ class Platform:
         elif platform.lower() == "vmware":
             platform = VMware(conf)
         elif platform.lower() == "bare-metal":
-            # TODO platform = Bare_metal(conf, utils)
-            print("Todo: bare-metal is not available")
-            sys.exit(0)
+            raise Exception("bare-metal is not available")
         elif platform.lower() == "libvirt":
-            # TODO platform = Livbirt(conf, utils)
-            print("Todo: libvirt is not available")
-            sys.exit(0)
+            raise Exception("libvirt is not available")
         else:
-            raise Exception(Format.alert("Platform Error: {} is not applicable".format(platform)))
+            raise Exception("Platform Error: {} is not recognized".format(platform))
 
         return platform
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -226,15 +226,12 @@ class Terraform:
 
     def _runshellcommandterraform(self, cmd, env={}):
         """Running terraform command in {terraform.tfdir}/{platform}"""
-        cwd = self.tfdir
-
         # Terraform needs PATH and SSH_AUTH_SOCK
         sock_fn = self.utils.ssh_sock_fn()
         env["SSH_AUTH_SOCK"] = sock_fn
         env["PATH"] = os.environ['PATH']
 
-        print(Format.alert("$ {} > {}".format(cwd, cmd)))
-        subprocess.check_call(cmd, cwd=cwd, shell=True, env=env)
+        self.utils.runshellcommand(cmd, cwd=self.tfdir, env=env)
 
     def _check_tf_deployed(self):
         if os.path.exists(self.tfjson_path):

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -160,7 +160,7 @@ class Skuba:
 
         test_cluster = os.path.join(self.conf.workspace, "test-cluster")
         cmd = "cd " + test_cluster + "; " + self.binpath + " cluster status"
-        output = self.utils.runshellcommand_withoutput(cmd)
+        output = self.utils.runshellcommand(cmd, output=True)
         return output.count(role)
 
     def _run_skuba(self, cmd, cwd=None):

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -1,9 +1,11 @@
+import logging
 import os
 
 from platforms.platform import Platform
 from utils.format import Format
 from utils.utils import (step, Utils)
 
+logger = logging.getLogger('testrunner')
 
 class Skuba:
 
@@ -16,13 +18,14 @@ class Skuba:
 
     def _verify_skuba_bin_dependency(self):
         if not os.path.isfile(self.binpath):
-            raise FileNotFoundError(Format.alert("skuba not found at {}".format(self.binpath)))
+            raise FileNotFoundError("skuba not found at {}".format(self.binpath))
 
     def _verify_bootstrap_dependency(self):
         if not os.path.exists(os.path.join(self.conf.workspace, "test-cluster")):
-            raise Exception(Format.alert("test-cluster not found. Please run bootstrap and try again"))
+            raise Exception("test-cluster not found. Please run bootstrap and try again")
 
     @staticmethod
+    @step
     def build(conf):
         """Buids skuba from source"""
         utils = Utils(conf)
@@ -30,10 +33,10 @@ class Skuba:
         utils.runshellcommand("mkdir -p go/src/github.com/SUSE")
         utils.runshellcommand("cp -a {} go/src/github.com/SUSE/".format(conf.skuba.srcpath))
         utils.gorun("go version")
-        print("Building skuba")
         utils.gorun("make")
 
     @staticmethod
+    @step
     def cleanup(conf):
         """Cleanup skuba working environment"""
         utils = Utils(conf)
@@ -60,8 +63,8 @@ class Skuba:
                 utils.runshellcommand("rm -rf {}".format(dir))
             except Exception as ex:
                 cleanup_failure = True
-                print("Received the following error {}".format(ex))
-                print("Attempting to finish cleaup")
+                logger.warning("Received the following error {}".format(ex))
+                logger.warning("Attempting to finish cleaup")
 
         if cleanup_failure:
             raise Exception("Failure(s) during cleanup")
@@ -69,7 +72,7 @@ class Skuba:
     @step
     def cluster_init(self):
 
-        print("Cleaning up any previous test-cluster dir")
+        logger.debug("Cleaning up any previous test-cluster dir")
         self.utils.runshellcommand("rm -rf {}".format(self.cwd))
         cmd = "cluster init --control-plane {} test-cluster".format(self.platform.get_lb_ipaddr())
         # Override work directory, because init must run in the parent directory of the
@@ -149,10 +152,12 @@ class Skuba:
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(cmd)) from ex
 
+    @step
     def cluster_status(self):
         self._verify_bootstrap_dependency()
-        self._run_skuba("cluster status")
+        return self._run_skuba("cluster status")
 
+    @step
     def num_of_nodes(self, role):
 
         if role not in ("master", "worker"):
@@ -160,7 +165,7 @@ class Skuba:
 
         test_cluster = os.path.join(self.conf.workspace, "test-cluster")
         cmd = "cd " + test_cluster + "; " + self.binpath + " cluster status"
-        output = self.utils.runshellcommand(cmd, output=True)
+        output = self.utils.runshellcommand(cmd)
         return output.count(role)
 
     def _run_skuba(self, cmd, cwd=None):
@@ -175,5 +180,5 @@ class Skuba:
 
         env = {"SSH_AUTH_SOCK": os.path.join(self.conf.workspace, "ssh-agent-sock")}
 
-        self.utils.runshellcommand(self.binpath + " "+ cmd, cwd=cwd, env=env)
+        return self.utils.runshellcommand(self.binpath + " "+ cmd, cwd=cwd, env=env)
 

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -11,7 +11,7 @@ from argparse import (ArgumentParser, REMAINDER)
 from skuba import Skuba
 from platforms import Platform
 from tests import TestDriver
-from utils import (BaseConfig, Utils)
+from utils import (BaseConfig, Logger, Utils)
 
 __version__ = "0.0.3"
 
@@ -87,6 +87,8 @@ def main():
                         default="openstack",
                         choices=["openstack", "vmware", "bare-metal", "libvirt"],
                         help="The platform you're targeting. Defaults to openstack")
+    parser.add_argument("-l", "--log-level", dest="log_level", default=None, help ="log level", 
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR"]) 
 
     # Sub commands
     commands = parser.add_subparsers()
@@ -156,6 +158,9 @@ def main():
 
     options = parser.parse_args()
     conf = BaseConfig(options.yaml_path)
+
+    Logger.config_logger(conf, level=options.log_level)
+
     options.conf = conf
     options.func(options)
 

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -17,7 +17,7 @@ __version__ = "0.0.3"
 
 
 def info(options):
-    Utils(options.conf).info()
+    print(Utils(options.conf).info())
 
 
 def cleanup(options):
@@ -43,7 +43,7 @@ def bootstrap(options):
 
 
 def cluster_status(options):
-    Skuba(options.conf, options.platform).cluster_status()
+    print(Skuba(options.conf, options.platform).cluster_status())
 
 
 def get_logs(options):

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -5,6 +5,7 @@
     This script can be run from Jenkins or manually, on developer desktops or servers.
 """
 
+import logging
 import sys
 from argparse import (ArgumentParser, REMAINDER)
 
@@ -15,6 +16,7 @@ from utils import (BaseConfig, Logger, Utils)
 
 __version__ = "0.0.3"
 
+logger = logging.getLogger("testrunner")
 
 def info(options):
     print(Utils(options.conf).info())
@@ -91,7 +93,7 @@ def main():
                         choices=["DEBUG", "INFO", "WARNING", "ERROR"]) 
 
     # Sub commands
-    commands = parser.add_subparsers()
+    commands = parser.add_subparsers(help="command", dest="command")
 
     cmd_info = commands.add_parser("info", help='ip info')
     cmd_info.set_defaults(func=info)
@@ -157,14 +159,16 @@ def main():
     cmd_test.set_defaults(func=test)
 
     options = parser.parse_args()
-    conf = BaseConfig(options.yaml_path)
+    try:
+        conf = BaseConfig(options.yaml_path)
+        Logger.config_logger(conf, level=options.log_level)
+        options.conf = conf
+        options.func(options)
+    except Exception as ex:
+        logger.error("Exception executing testrunner command '{}': {}".format(options.command, ex, exc_info=True))
+        sys.exit(255)
 
-    Logger.config_logger(conf, level=options.log_level)
 
-    options.conf = conf
-    options.func(options)
-
-    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/ci/infra/testrunner/utils/__init__.py
+++ b/ci/infra/testrunner/utils/__init__.py
@@ -1,3 +1,4 @@
 from utils.constants import (BaseConfig, Constant)
 from utils.format import Format
+from utils.logger import Logger
 from utils.utils import (Utils, step)

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -32,10 +32,12 @@ class BaseConfig:
         obj.master = BaseConfig.NodeConfig()
         obj.worker = BaseConfig.NodeConfig()
         obj.test = BaseConfig.Test()
+        obj.log = BaseConfig.Log()
 
         config_classes = (
             BaseConfig.NodeConfig,
             BaseConfig.Test,
+            BaseConfig.Log,
             BaseConfig.Openstack,
             BaseConfig.Terraform,
             BaseConfig.Skuba,
@@ -85,6 +87,14 @@ class BaseConfig:
         def __init__(self):
             super().__init__()
             self.no_destroy = False
+
+    class Log:
+        def __init__(self):
+            super().__init__()
+            self.level = "INFO"
+            self.quiet = False
+            self.file  = "testrunner.log"
+            self.overwrite = False
 
     class VMware:
         def __init__(self):

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -70,6 +70,7 @@ class BaseConfig:
     class Terraform:
         def __init__(self):
             super().__init__()
+            self.retries = 5
             self.internal_net = None
             self.mirror = None
             self.stack_name = None

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -113,10 +113,6 @@ class BaseConfig:
     @staticmethod
     def get_var_dict(yaml_path):
         config_yaml_file_path = BaseConfig.get_yaml_path(yaml_path)
-        if not os.path.isfile(config_yaml_file_path):
-            print(Format.alert("You have incorrect -v path for xml file: {}".format(config_yaml_file_path)))
-            raise FileNotFoundError
-
         with open(config_yaml_file_path, 'r') as stream:
             _conf = yaml.safe_load(stream)
         return _conf
@@ -181,7 +177,7 @@ class BaseConfig:
     def verify(conf):
         if not conf.workspace and conf.workspace == "":
             raise ValueError(Format.alert("You should set the workspace value in a configured yaml file e.g. vars.yaml"
-                                          "or set env var WORKSPACE before using testrunner)"))
+                                          " or set env var WORKSPACE before using testrunner)"))
         if not conf.terraform.stack_name:
             raise ValueError(Format.alert("Either a terraform stack name or an user name must be specified"))
 

--- a/ci/infra/testrunner/utils/logger.py
+++ b/ci/infra/testrunner/utils/logger.py
@@ -1,0 +1,30 @@
+import logging
+import os
+
+class Logger:
+
+    def __init__(self, conf):
+        pass
+
+    @staticmethod
+    def config_logger(conf, level=None):
+        logger = logging.getLogger("testrunner")
+        logger.setLevel(logging.getLevelName("DEBUG"))
+        
+        if conf.log.file:
+            mode = 'a'
+            if conf.log.overwrite:
+                mode = 'w'
+            log_file = os.path.join(conf.workspace, conf.log.file)
+            file_handler = logging.FileHandler(log_file)
+            logger.addHandler(file_handler)
+
+        if not conf.log.quiet:
+            if not level:
+                level = conf.log.level
+            console = logging.StreamHandler()
+            console.setLevel(logging.getLevelName(level.upper()))
+            logger.addHandler(console)
+
+        
+

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -1,4 +1,4 @@
-
+import logging
 import os
 import subprocess
 from functools import wraps
@@ -9,6 +9,8 @@ from timeout_decorator import timeout
 from utils.format import Format
 from utils.constants import Constant
 
+logger = logging.getLogger('testrunner')
+
 _stepdepth = 0
 
 
@@ -17,10 +19,10 @@ def step(f):
     def wrapped(*args, **kwargs):
         global _stepdepth
         _stepdepth += 1
-        print("{} entering {} {}".format(Format.DOT * _stepdepth, f.__name__,
+        logger.debug("{} entering {} {}".format(Format.DOT * _stepdepth, f.__name__,
                                   f.__doc__ or ""))
         r = f(*args, **kwargs)
-        print("{}  exiting {}".format(Format.DOT_EXIT * _stepdepth, f.__name__))
+        logger.debug("{}  exiting {}".format(Format.DOT_EXIT * _stepdepth, f.__name__))
         _stepdepth -= 1
         return r
     return wrapped
@@ -45,14 +47,14 @@ class Utils:
             try:
                 self.scp_file(ip_address, log, store_path)
             except Exception as ex:
-                print(f"Error while collecting {log} from {ip_address}\n {ex}")
+                logger.debug(f"Error while collecting {log} from {ip_address}\n {ex}")
                 logging_errors = True
 
         for log in logs.get("dirs", []):
             try:
                 self.rsync(ip_address, log, store_path)
             except Exception as ex:
-                print(f"Error while collecting {log} from {ip_address}\n {ex}")
+                logger.debug(f"Error while collecting {log} from {ip_address}\n {ex}")
                 logging_errors = True
 
         for service in logs.get("services", []):
@@ -60,44 +62,11 @@ class Utils:
                 self.ssh_run(ip_address, f"sudo journalctl -xeu {service} > {service}.log")
                 self.scp_file(ip_address, f"{service}.log", store_path)
             except Exception as ex:
-                print(f"Error while collecting {service}.log from {ip_address}\n {ex}")
+                logger.debug(f"Error while collecting {service}.log from {ip_address}\n {ex}")
                 logging_errors = True
 
         return logging_errors
 
-    def runshellcommand(self, cmd, cwd=None, env=None, output=False, ignore_errors=False):
-        """Running shell command in {workspace} if cwd == None
-           Eg) cwd is "skuba", cmd will run shell in {workspace}/skuba/
-               cwd is None, cmd will run in {workspace}
-               cwd is abs path, cmd will run in cwd
-        Keyword arguments:
-        cmd -- command to run
-        cwd -- dir to run the cmd
-        env -- environment variables
-        ignore_errors -- don't rise exception if command fails
-        """
-        if not cwd:
-            cwd = self.conf.workspace
- 
-        if not os.path.isabs(cwd):
-            cwd = os.path.join(self.conf.workspace, cwd)
- 
-        if not os.path.exists(cwd):
-            raise Exception(Format.alert("Directory {} does not exists".format(cwd)))
- 
-        print("Executing command: {} > {}".format(cwd, cmd))
-        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, 
-                 env=env, cwd=cwd)
-        
-        print(p.stdout.decode())
-        if p.returncode != 0:
-            print(p.stderr.decode())
-            if not ignore_errors:
-                raise RuntimeError("Cannot run command {}".format(cmd))
-
-        if output:
-            return p.stdout.decode()
- 
     def authorized_keys(self):
         public_key_path = self.conf.ssh_key_option + ".pub"
         key_fn = self.conf.ssh_key_option
@@ -150,41 +119,77 @@ class Utils:
                f'{local_dir_path}')
         self.runshellcommand(cmd)
 
+    def runshellcommand(self, cmd, cwd=None, env={}, ignore_errors=False):
+        """Running shell command in {workspace} if cwd == None
+           Eg) cwd is "skuba", cmd will run shell in {workspace}/skuba/
+               cwd is None, cmd will run in {workspace}
+               cwd is abs path, cmd will run in cwd
+        Keyword arguments:
+        cmd -- command to run
+        cwd -- dir to run the cmd
+        env -- environment variables
+        ignore_errors -- don't raise exception if command fails
+        """
+        if not cwd:
+            cwd = self.conf.workspace
+
+        if not os.path.isabs(cwd):
+            cwd = os.path.join(self.conf.workspace, cwd)
+
+        if not os.path.exists(cwd):
+            raise Exception(Format.alert("Directory {} does not exists".format(cwd)))
+
+        if logging.DEBUG >= logger.level:
+            logger.debug("Executing command\n"
+                         "    cwd: {} \n"
+                         "    env: {}\n"
+                         "    cmd: {}".format(cwd, str(env) if env else "{}", cmd)) 
+        else:
+            logger.info("Executing command {}".format(cmd))
+        
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, 
+                 env=env, cwd=cwd)
+        logger.debug(p.stdout.decode())
+        if p.returncode != 0:
+           logger.error(p.stderr)
+           if not ignore_errors:
+                raise RuntimeError("Error executing command {}".format(cmd))
+        return p.stdout.decode()
+
     def ssh_sock_fn(self):
         return os.path.join(self.conf.workspace, "ssh-agent-sock")
 
     @timeout(60)
     @step
     def setup_ssh(self):
-
         self.runshellcommand("chmod 400 " + self.conf.ssh_key_option)
-        print("Starting ssh-agent ")
         # use a dedicated agent to minimize stateful components
         sock_fn = self.ssh_sock_fn()
         try:
             self.runshellcommand("pkill -f 'ssh-agent -a {}'".format(sock_fn))
-            print("Killed previous instance of ssh-agent")
+            logger.warning("Killed previous instance of ssh-agent")
         except:
             pass
         self.runshellcommand("ssh-agent -a {}".format(sock_fn))
-        print("adding id_shared ssh key")
         self.runshellcommand("ssh-add " + self.conf.ssh_key_option, env={"SSH_AUTH_SOCK": sock_fn})
 
     @timeout(30)
     @step
     def info(self):
         """Node info"""
-        print("Env vars: {}".format(sorted(os.environ)))
+        info_lines  = "Env vars: {}\n".format(sorted(os.environ))
+        info_lines += self.runshellcommand('ip a')
+        info_lines += self.runshellcommand('ip r')
+        info_lines += self.runshellcommand('cat /etc/resolv.conf')
 
-        self.runshellcommand('ip a')
-        self.runshellcommand('ip r')
-        self.runshellcommand('cat /etc/resolv.conf')
-
+        # TODO: the logic for retrieving external is platform depedant and should be
+        # moved to the corresponding platform
         try:
             r = requests.get('http://169.254.169.254/2009-04-04/meta-data/public-ipv4', timeout=2)
             r.raise_for_status()
         except (requests.HTTPError, requests.Timeout) as err:
-            print(err)
-            print(Format.alert('Meta Data service unavailable could not get external IP addr{}'))
+            logger.warning(f'Meta Data service unavailable could not get external IP addr{err}')
         else:
-            print('External IP addr: {}'.format(r.text))
+            info_lines += 'External IP addr: {}'.format(r.text)
+
+        return info_lines


### PR DESCRIPTION
## Why is this PR needed?
Presently testrunner prints all output, including the output from commands it invokes (skuba, terraform) producing a large amount of indeferentiate printouts (errors, informative messages, detailed command execution output).

To improve the output handling, it should be redirected to a log whose verbosity level should be controlled by means of the configuration file.

Fixes # https://github.com/SUSE/avant-garde/issues/622

## What does this PR do?

- Consolidate all logic for executing shell commands in `Utils.runshellcommand` to ensure consistent treatment of outputs and consistent tracing of command execution for debugging purposes
- Replaces `print` statements in all libraries for log statements. Remove superfluous outputs. 
- Implement a helper class for setting up logger. Direct output to console and to a file. File always has DEBUG level. Console level is managed by configuration file and by cli option
- Capture command outputs and return to caller. In case of exceptions, include `strerr`

## Anything else a reviewer needs to know?


