### PR TITLE
Fix skuba node join crash if current path admin.conf not exist

### DIFF
--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -44,8 +44,12 @@ import (
 // FIXME: being this a part of the go API accept the toplevel directory instead of
 //        using the PWD
 func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.Target) error {
-	currentClusterVersion, _ := kubeadm.GetCurrentClusterVersion()
-	_, err := target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	if err != nil {
+		return err
+	}
+
+	_, err = target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
 		KubernetesVersion: currentClusterVersion.String(),
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

If execute `skuba node join` command in the path without `admin.conf`, command crash.

## What does this PR do?

Check the error, do not ignore it.

## Anything else a reviewer needs to know?

N/A