### PR TITLE
Add --strict-cap-defaults

### DIFF
--- a/internal/app/skuba/cluster/init.go
+++ b/internal/app/skuba/cluster/init.go
@@ -38,6 +38,7 @@ type initOptions struct {
 	ControlPlane      string
 	KubernetesVersion string
 	CloudProvider     string
+	StrictCapDefaults bool
 }
 
 // NewInitCmd creates a new `skuba cluster init` cobra command
@@ -73,6 +74,7 @@ func NewInitCmd() *cobra.Command {
 				ImageRepository:     skuba.ImageRepository,
 				EtcdImageTag:        kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, kubernetesVersion),
 				CoreDNSImageTag:     kubernetes.ComponentVersionForClusterVersion(kubernetes.CoreDNS, kubernetesVersion),
+				StrictCapDefaults:   initOptions.StrictCapDefaults,
 			}
 
 			err := cluster.Init(initConfig)
@@ -88,6 +90,8 @@ func NewInitCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&initOptions.CloudProvider, "cloud-provider", "", "Enable cloud provider integration with the chosen cloud. Valid values: openstack")
 	cmd.MarkFlagRequired("control-plane")
+
+	cmd.Flags().BoolVar(&initOptions.StrictCapDefaults, "strict-capability-defaults", false, "All the containers will start with CRI-O default capabilities")
 
 	return cmd
 }

--- a/internal/pkg/skuba/deployments/deployments.go
+++ b/internal/pkg/skuba/deployments/deployments.go
@@ -44,7 +44,15 @@ type Target struct {
 }
 
 func (t *Target) Apply(data interface{}, states ...string) error {
-	return t.Actionable.Apply(data, states...)
+	filteredStates := []string{}
+	for _, s := range states {
+		if s == "" {
+			continue
+		}
+		filteredStates = append(filteredStates, s)
+	}
+
+	return t.Actionable.Apply(data, filteredStates...)
 }
 
 func (t *Target) UploadFile(sourcePath, targetPath string) error {

--- a/pkg/skuba/actions/cluster/init/constants.go
+++ b/pkg/skuba/actions/cluster/init/constants.go
@@ -65,6 +65,10 @@ var (
 			Location: skuba.GangwayManifestfile(),
 			Content:  gangwayManifest,
 		},
+		{
+			Location: skuba.CriDockerDefaultsConfFile(),
+			Content:  criDockerDefaultsConf,
+		},
 	}
 
 	cloudScaffoldFiles = map[string][]ScaffoldFile{

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/SUSE/skuba/pkg/skuba"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 )
@@ -43,6 +44,7 @@ type InitConfiguration struct {
 	EtcdImageTag        string
 	CoreDNSImageTag     string
 	CloudProvider       string
+	StrictCapDefaults   bool
 }
 
 // Init creates a cluster definition scaffold in the local machine, in the current
@@ -72,6 +74,10 @@ func Init(initConfiguration InitConfiguration) error {
 		return errors.Wrapf(err, "could not change to cluster directory %q", initConfiguration.ClusterName)
 	}
 	for _, file := range scaffoldFilesToWrite {
+		// If '--strict-capability-defaults' is used, then don't modify the /etc/sysconfig/crio
+		if initConfiguration.StrictCapDefaults && file.Location == skuba.CriDockerDefaultsConfFile() {
+			continue
+		}
 		filePath, _ := filepath.Split(file.Location)
 		if filePath != "" {
 			if err := os.MkdirAll(filePath, 0700); err != nil {

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -52,6 +52,14 @@ networking:
   serviceSubnet: 10.96.0.0/12
 useHyperKubeImage: true
 `
+	criDockerDefaultsConf = `## Path           : System/Management
+## Description    : Extra cli switches for crio daemon
+## Type           : string
+## Default        : ""
+## ServiceRestart : crio
+#
+CRIO_OPTIONS=--pause-image=registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4/pause:3.1 --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
+  `
 
 	masterConfTemplate = `apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -91,6 +91,11 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		return errors.Wrap(err, "error writing init configuration")
 	}
 
+	var criConfigure string
+	if _, err := os.Stat(skuba.CriDockerDefaultsConfFile()); err == nil {
+		criConfigure = "cri.configure"
+	}
+
 	fmt.Println("[bootstrap] applying init configuration to node")
 	err = target.Apply(
 		bootstrapConfiguration,
@@ -98,6 +103,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		"kernel.load-modules",
 		"kernel.configure-parameters",
 		"apparmor.start",
+		criConfigure,
 		"cri.start",
 		"kubelet.configure",
 		"kubelet.enable",

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -56,10 +56,16 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 		return err
 	}
 
+	var criConfigure string
+	if _, err := os.Stat(skuba.CriDockerDefaultsConfFile()); err == nil {
+		criConfigure = "cri.configure"
+	}
+
 	statesToApply := []string{
 		"kernel.load-modules",
 		"kernel.configure-parameters",
 		"apparmor.start",
+		criConfigure,
 		"cri.start",
 		"kubelet.configure",
 		"kubelet.enable",

--- a/pkg/skuba/actions/node/reset/reset.go
+++ b/pkg/skuba/actions/node/reset/reset.go
@@ -26,5 +26,5 @@ import (
 // Reset the target node
 func Reset(resetConfiguration deployments.ResetConfiguration, target *deployments.Target) error {
 	fmt.Println("[reset] resetting the node")
-	return target.Apply(resetConfiguration, "kubeadm.reset")
+	return target.Apply(resetConfiguration, "cri.reset", "kubeadm.reset")
 }

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -80,6 +80,14 @@ func PspDir() string {
 	return filepath.Join(AddonsDir(), "psp")
 }
 
+func CriDir() string {
+	return filepath.Join(AddonsDir(), "cri")
+}
+
+func CriDockerDefaultsConfFile() string {
+	return filepath.Join(CriDir(), "default_flags")
+}
+
 func PspUnprivManifestFile() string {
 	return filepath.Join(PspDir(), "podsecuritypolicy-unprivileged.yaml")
 }


### PR DESCRIPTION
Changes the default CRI-O capabilities by adding the missing ones
from the docker container engine. In this way the customers will
be able to run the same containers that were working on v3
without any need for modification. At the same time though,
we are adding a new option at skuba '--strict-cap-defaults'.
This option will _not_ copy the docker defaults into CRI-O. Use
this option if you want a vanilla CRI-O experience.

## Why is this PR needed?

It fixes https://bugzilla.suse.com/show_bug.cgi?id=1142552
Fixes https://github.com/SUSE/avant-garde/issues/638

## What does this PR do?

By default it creates the dockerfied crio-configuration file during `skuba init` and it replaces the node's crio.conf with this file during `bootstrap` or `join`. The file can be found locally inside the `addons/cri/crio.conf`.

e.g.
```go
statesToApply[0]: kernel.load-modules
statesToApply[1]: kernel.configure-parameters
statesToApply[2]: apparmor.start
statesToApply[3]: cri.start
statesToApply[4]: kubelet.configure
statesToApply[5]: kubelet.enable
statesToApply[6]: kubeadm.join
statesToApply[7]: cni.cilium-update-configmap
statesToApply[8]: skuba-update.start


statesToApply[0]: kernel.load-modules
statesToApply[1]: kernel.configure-parameters
statesToApply[2]: apparmor.start
statesToApply[3]: cri.configure // this is now by default
statesToApply[4]: cri.start
statesToApply[5]: kubelet.configure
statesToApply[6]: kubelet.enable
statesToApply[7]: kubeadm.join
statesToApply[8]: cni.cilium-update-configmap
statesToApply[9]: skuba-update.start
```

However, if someone wants pure CRI-O experience, they can use `--strict-cap-defaults` during `skuba init`. This will do use the CRI-O default configuration.

Long story short, now the v3 containers will work to v4 as well without any need for modification in terms of capabilities.

## Anything else a reviewer needs to know?

Here's my testcase:

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: leap
spec:
  containers:
  - name: app
    image: opensuse/leap:latest
    command: ['/bin/sh', '-c', 'sleep 3600']
---
apiVersion: v1
kind: Pod
metadata:
  name: sle12sp4
spec:
  containers:
  - name: app
    image: registry.suse.com/suse/sles12sp4:latest
    command: ['/bin/sh', '-c', 'sleep 3600']
---
apiVersion: v1
kind: Pod
metadata:
  name: sle15
spec:
  containers:
  - name: app
    image: registry.suse.com/suse/sle15:latest
    command: ['/bin/sh', '-c', 'sleep 3600']
---
apiVersion: v1
kind: Pod
metadata:
  name: sle15sp1
spec:
  containers:
  - name: app
    image: registry.suse.de/suse/containers/sle-server/15/containers/suse/sle15:15.1
    command: ['/bin/sh', '-c', 'sleep 3600']
```

```bash
kubectl apply -f test.yaml
declare -a arr=("sle12sp4" "leap" "sle15" "sle15sp1")
for pod in "${arr[@]}"; do echo -n "$pod: "; kubectl exec -it $pod -- su root -c id; done
for pod in "${arr[@]}"; do echo -n "$pod: "; kubectl exec -it $pod -- useradd panos; done
```

There must be no error from the above commands. Without this PR, the sles12sp4 containers fails due to PAM.