### PR TITLE
Fix aggressive cleanup exceptions in testrunner

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -32,29 +32,22 @@ class Terraform:
 
     def cleanup(self):
         """ Clean up """
-        cleanup_failure = False
         try:
             self._cleanup_platform()
         except Exception as ex:
             cleanup_failure = True
-            logger.warning("Received the following error: '{}'\nAttempting to finish cleanup".format(ex))
-
-        dirs = [os.path.join(self.conf.workspace, "tfout"),
+            logger.warning("Received the following error: '{}'\n"
+                           "Attempting to finish cleanup".format(ex))
+            raise Exception("Failure(s) during cleanup") from ex
+        finally:
+            dirs = [os.path.join(self.conf.workspace, "tfout"),
                 self.tfjson_path]
-
-        if cleanup_failure:
-            raise Exception(Format.alert("Failure(s) during cleanup"))
-        cleanup_failure = False
-        for dir in dirs:
-            try: 
-                self.utils.runshellcommand("rm -rf {}".format(dir))
-            except Exception as ex:
-                cleanup_failure = True
-                logger.warning("Received the following error: '{}'\nAttempting to finish cleanup".format(ex))
-
-        if cleanup_failure:
-            raise Exception("Failure(s) during cleanup")
-
+            for dir in dirs:
+                try: 
+                    self.utils.runshellcommand("rm -rf {}".format(dir))
+                except Exception as ex:
+                    logger.warning("Received the following error: '{}'\n"
+                                   "Attempting to finish cleanup".format(ex))
 
     @timeout(600)
     @step

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -57,7 +57,6 @@ class Skuba:
                 #TODO: move this to utils as ssh_cleanup
                 os.path.join(conf.workspace, "ssh-agent-sock")]
 
-        cleanup_failure = False
         for dir in dirs:
             try: 
                 utils.runshellcommand("rm -rf {}".format(dir))
@@ -65,9 +64,6 @@ class Skuba:
                 cleanup_failure = True
                 logger.warning("Received the following error {}".format(ex))
                 logger.warning("Attempting to finish cleaup")
-
-        if cleanup_failure:
-            raise Exception("Failure(s) during cleanup")
 
     @step
     def cluster_init(self):


### PR DESCRIPTION
# Why is this PR needed?

The error handling logic in clean functions for terraform and
skuba generates exceptions in cases which may not be any critical
error such as trying to remove non-existing files.

## What does this PR do?

Reports exception only if critical errors occurs. Considers file removal failures as non critical, but reports them as warnings.
