### PR TITLE
Add QA requirements in github PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@ add a description and link to the issue if one exists.
 
 Fixes #
 
+**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
+appear in the changelog.
+
+
 ## What does this PR do?
 
 please include a brief "management" technical overview (details are in the code)
@@ -13,6 +17,29 @@ please include a brief "management" technical overview (details are in the code)
 ## Anything else a reviewer needs to know?
 
 Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.
+
+## Info for QA
+
+This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
+If this is a new feature, a good description in "What does this PR do" may be enough.
+
+### Steps to reproduce the bug
+
+### Related info
+
+Info that can be relevant for QA:
+* link to other PRs that should be merged together
+* link to packages that should be released together
+* upstream issues
+
+### Status **BEFORE** applying the patch
+
+How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
+this issue is not fixed.
+
+### Status **AFTER** applying the patch
+
+How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.
 
 <!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
     If you can, please apply all applicable labels to help reviews out! -->


### PR DESCRIPTION
In order to make releases predictable, we need to make QA validation
predictable. Thus, we need to add the info about how to validate a PR
that is fixing an issue, and all the info which can be relevant.

In order to make this easier, let's be explicit on the info that it is
required.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

## Why is this PR needed?

To prevent the situation when QA has to validate an RPM update the day before the release and knows nothing about it or it was tested differently by the PR author, and then it does not pass the validation and it ends up blocking the release.

## What does this PR do?

Make release **predictable**.

## Anything else a reviewer needs to know?



<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->