### PR TITLE
Do not add skuba-update to skuba

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -60,7 +60,6 @@ Requires:       python3-setuptools
 Requires:       zypper >= 1.14.15
 Requires:       lsof
 BuildArch:      noarch
-Supplements:    skuba
 %{?systemd_requires}
 
 %description update


### PR DESCRIPTION
## Why is this PR needed?

Normally `skuba-update` package should be installed on _Nodes_ only, but it's being installed as a dependency of skuba package on _Management_ node as well.

## What does this PR do?

This PR removes that dependency.

See https://bugzilla.suse.com/show_bug.cgi?id=1141131

Fixes #1141131
