### PR TITLE
Fix multiple kubectl wrapper issues

### DIFF
--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -16,53 +16,30 @@ class Kubectl:
 
 
     def create_deployment(self, name, image):
-        try:
-            self._run_kubectl("create deployment {name} --image={image}"
-                                .format(name=name, image=image))
-        except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
-
+        self._run_kubectl("create deployment {name} --image={image}"
+                          .format(name=name, image=image))
 
     def scale_deployment(self, name, replicas):
-        try:
-            self._run_kubectl("scale deployment {name} --replicas={replicas}"
-                             .format(name=name, replicas=replicas))
-        except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
-
+        self._run_kubectl("scale deployment {name} --replicas={replicas}"
+                          .format(name=name, replicas=replicas))
 
     def expose_deployment(self, name, port, nodeType="NodePort"):
-        try:
-            self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
-                             .format(name=name, port=port, nodeType=nodeType))
-        except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
-
+        self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
+                          .format(name=name, port=port, nodeType=nodeType))
 
     def wait_deployment(self, name, timeout):
-        try:
-            self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
-                             .format(name=name, timeout=timeout))
-        except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
-
+        self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
+                          .format(name=name, timeout=timeout))
 
     def count_available_replicas(self, name):
-        try:
-            result = self._run_kubectl("get deployment/{name} | jq '.status.availableReplicas'"
-                                       .format(name=name))
-            return int(result)
-        except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
-
+        result = self._run_kubectl("get deployment/{name} | jq '.status.availableReplicas'"
+                                   .format(name=name))
+        return int(result)
 
     def get_service_port(self, name):
-        try:
-            result = self._run_kubectl("get service/{name} | jq '.spec.ports[0].nodePort'"
-                                       .format(name=name))
-            return int(result)
-        except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+        result = self._run_kubectl("get service/{name} | jq '.spec.ports[0].nodePort'"
+                                   .format(name=name))
+        return int(result)
 
     def test_service(self, name, path="/", worker=0):
         ip_addresses = self.platform.get_nodes_ipaddrs("worker")
@@ -81,7 +58,7 @@ class Kubectl:
         shell_cmd = "kubectl --kubeconfig={cwd}/test-cluster/admin.conf \
                       -o json {command}".format(command=command, cwd=self.conf.workspace)
         try:
-            return self.utils.runshellcommand(shell_cmd, output=True)
+            return self.utils.runshellcommand(shell_cmd)
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(shell_cmd)) from ex
 

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -72,7 +72,7 @@ class Kubectl:
         port = self.get_service_port(name)
         shell_cmd = "curl {ip}:{port}{path}".format(ip=ip_addresses[worker],port=port,path=path)
         try:
-            return self.utils.runshellcommand(shell_cmd, output=True)
+            return self.utils.runshellcommand(shell_cmd)
         except Exception as ex:
             raise Exception("Error testing service {} with path {} at node {}"
                                 .format(name, path, ip_address)) from ex

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -66,11 +66,11 @@ class Kubectl:
 
     def test_service(self, name, path="/", worker=0):
         ip_addresses = self.platform.get_nodes_ipaddrs("worker")
-        if worker >= len(ip_address):
+        if worker >= len(ip_addresses):
             raise ValueError("Node worker-{} not deployed".format(worker))
 
         port = self.get_service_port(name)
-        shell_cmd = "curl {ip}:{port}{path}".format(ip=ip_address[worker],port=port,path=path)
+        shell_cmd = "curl {ip}:{port}{path}".format(ip=ip_addresses[worker],port=port,path=path)
         try:
             return self.utils.runshellcommand(shell_cmd, output=True)
         except Exception as ex:

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -1,4 +1,5 @@
 import os
+import platforms
 
 from timeout_decorator import timeout
 
@@ -11,7 +12,7 @@ class Kubectl:
     def __init__(self, conf, platform):
         self.conf = conf
         self.utils = Utils(self.conf)
-        self.platform = Platform.get_platform(conf, platform)
+        self.platform = platforms.get_platform(conf, platform)
 
 
     def create_deployment(self, name, image):


### PR DESCRIPTION
## Why is this PR needed?

Kubectl was not updated to adapt to recent changes in testrunner's platform and utils modules.

## What does this PR do?
* Fixes instantiation of platform
* Fixes invalid additional argument to `utils.runshellcommand`
* Fixes reference to invalid symbol when retrieving node addresses
* Removes unnecessary try blocks when calling `_run_kubectl`
