### PR TITLE
Pass testrunner arguments explicitly

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -67,20 +67,20 @@ post_run: gather_logs cleanup
 # e2e Tests
 .PHONY: test_upgrade_plan_all_fine
 test_upgrade_plan_all_fine:
-	${TEST_RUNNER} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_plan_all_fine
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_plan_all_fine
 
 .PHONY: test_upgrade_plan_from_previous
 test_upgrade_plan_from_previous:
-	${TEST_RUNNER} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_plan_from_previous
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_plan_from_previous
 
 .PHONY: test_upgrade_apply_all_fine
 test_upgrade_apply_all_fine:
-	${TEST_RUNNER} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_all_fine
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_all_fine
 
 .PHONY: test_upgrade_apply_from_previous
 test_upgrade_apply_from_previous:
-	${TEST_RUNNER} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_from_previous
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_from_previous
 
 .PHONY: test_upgrade_apply_user_lock
 test_upgrade_apply_all_fine:
-	${TEST_RUNNER} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_user_lock
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_user_lock


### PR DESCRIPTION
## Why is this PR needed?

This seems to be an issue within the python argparser, but I have no idea how to fix this. However an easy fix would likely be to pass those arguments explicitly

It should fix this error in CI:

```
ERROR: usage: testrunner.py [options] [file_or_dir] [file_or_dir] [...]
testrunner.py: error: unrecognized arguments: --vars=vars.yaml --platform=openstack
```

see e.g. https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/caasp-v4-upgrade-nightly/17/console

## What does this PR do?

Pass args explicitly to circumvent the python argparser error

## Anything else a reviewer needs to know?

It might be fixable in another way on the python argparser side.
This is needed in order to get https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/caasp-v4-upgrade-nightly/ to work