### PR TITLE
Infer kubeadm api version from kubernetes version

### DIFF
--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -62,6 +62,14 @@ func GetCurrentClusterVersion() (*version.Version, error) {
 	return version.MustParseSemantic(initCfg.KubernetesVersion), nil
 }
 
+// GetKubeadmApisVersion returns the api version to use in the kubeadm-init.conf
+func GetKubeadmApisVersion(kubernetesVersion *version.Version) string {
+	if kubernetesVersion.LessThan(version.MustParseSemantic("1.15.0")) {
+		return "v1beta1"
+	}
+	return "v1beta2"
+}
+
 // GetAPIEndpointsFromConfigMap returns the api endpoint held in the config map
 func GetAPIEndpointsFromConfigMap() ([]string, error) {
 	apiEndpoints := []string{}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -30,6 +30,7 @@ import (
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
 	"github.com/SUSE/skuba/pkg/skuba"
@@ -79,7 +80,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 
 	finalInitConfigurationContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(initConfiguration, schema.GroupVersion{
 		Group:   "kubeadm.k8s.io",
-		Version: "v1beta1",
+		Version: kubeadm.GetKubeadmApisVersion(version.MustParseSemantic(initConfiguration.KubernetesVersion)),
 	})
 
 	if err != nil {

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -25,11 +25,13 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmtokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
-	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
@@ -118,7 +120,14 @@ func ConfigPath(role deployments.Role, target *deployments.Target) (string, erro
 		}
 		setCloudConfiguration(joinConfiguration)
 	}
-	finalJoinConfigurationContents, err := kubeadmconfigutil.MarshalKubeadmConfigObject(joinConfiguration)
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get current cluster version")
+	}
+	finalJoinConfigurationContents, err := kubeadmutil.MarshalToYamlForCodecs(joinConfiguration, schema.GroupVersion{
+		Group:   "kubeadm.k8s.io",
+		Version: kubeadm.GetKubeadmApisVersion(currentClusterVersion),
+	}, kubeadmscheme.Codecs)
 	if err != nil {
 		return "", errors.Wrap(err, "could not marshal configuration")
 	}


### PR DESCRIPTION
## Why is this PR needed?

If we are e.g. creating a 1.14.0 cluster and try to join
a node, having a skuba built from 1.15.0 vendored sources,
the init configuration will be altered by kubeadm to have
a later version which is not available

## What does this PR do?

Infer kubeadm api version from kubernetes version
