### PR TITLE
Implement Cilium e2e test

### DIFF
--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -4,6 +4,7 @@ import platforms
 from timeout_decorator import timeout
 
 from platforms.platform import Platform
+from skuba.skuba import Skuba
 from utils.format import Format
 from utils.utils import (step, Utils)
 
@@ -13,6 +14,7 @@ class Kubectl:
         self.conf = conf
         self.utils = Utils(self.conf)
         self.platform = platforms.get_platform(conf, platform)
+        self.skuba = Skuba(conf, platform)
 
 
     def create_deployment(self, name, image):
@@ -67,11 +69,11 @@ class Kubectl:
             outputformat="-o jsonpath='{.metadata.annotations.weave\.works/kured-node-lock}'").find("manual") != -1
 
 
-    def _run_kubectl(self, command, outputformat='-o json'):
-        shell_cmd = "kubectl --kubeconfig={cwd}/test-cluster/admin.conf \
-                      {format} {command}".format(format=outputformat, command=command, cwd=self.conf.workspace)
+    def run_kubectl(self, command):
+        kubeconfig = self.skuba.get_kubeconfig()
+        
+        shell_cmd = "kubectl --kubeconfig={} {}".format(kubeconfig, command)
         try:
             return self.utils.runshellcommand(shell_cmd)
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(shell_cmd)) from ex
-

--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -74,6 +74,14 @@ class Platform:
         """
         return []
 
+    def get_num_nodes(self, role):
+        """
+        Get the number of nodes of a  given type
+        :param role: the type of node
+        :return: num of nodes
+        """
+        pass
+
     @step
     def provision(self, num_master=-1, num_worker=-1, retries=4):
         """Provision a cluster"""

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -72,6 +72,9 @@ class Terraform(Platform):
         self._load_tfstate()
         return self.state["modules"][0]["outputs"]["ip_load_balancer"]["value"]
 
+    def get_num_nodes(self, role):
+        return len(self.get_nodes_ipaddrs(role))
+
     def get_nodes_ipaddrs(self, role):
         self._load_tfstate()
 

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -170,6 +170,11 @@ class Skuba:
         output = self.utils.runshellcommand(cmd)
         return output.count(role)
 
+    @step
+    def get_kubeconfig(self):
+         path = "{cwd}/test-cluster/admin.conf".format(cwd=self.conf.workspace)
+         return path
+
     def _run_skuba(self, cmd, cwd=None):
         """Running skuba command in cwd.
         The cwd defautls to {workspace}/test-cluster but can be overrided

--- a/ci/infra/testrunner/tests/test_cilium.py
+++ b/ci/infra/testrunner/tests/test_cilium.py
@@ -1,0 +1,43 @@
+import logging
+import pytest
+import re
+import time
+
+logger = logging.getLogger("testrunner")
+
+def test_cillium(deployment, kubectl):
+
+    landing_req='curl -sm10 -XPOST deathstar.default.svc.cluster.local/v1/request-landing'
+
+    logger.info("Deploy deathstar")
+    kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/minikube/http-sw-app.yaml")
+    kubectl.run_kubectl("wait --for=condition=ready pods --all --timeout=3m")
+
+    # FIXME: this hardcoded wait should be replaces with a (cilum?) condition
+    time.sleep(100)
+
+    logger.info("Check with L3/L4 policy")
+    kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/minikube/sw_l3_l4_policy.yaml")
+    tie_out = kubectl.run_kubectl("exec tiefighter -- {}".format(landing_req))
+    assert 'Ship landed' in tie_out
+
+    xwing_out = kubectl.run_kubectl("exec xwing -- {} 2>&1 || :".format(landing_req))
+    assert 'terminated with exit code 28' in xwing_out
+
+    logger.info("Check status (N/N)")
+    node_list = kubectl.run_kubectl("get nodes -o jsonpath='{ .items[*].metadata.name }'")
+    node_count = len(node_list.split(" "))
+    cilium_podlist = kubectl.run_kubectl("get pods -n kube-system -l k8s-app=cilium -o jsonpath='{ .items[0].metadata.name }'").split(" ")
+    cilium_podid = cilium_podlist[0]
+    cilium_status_cmd = "-n kube-system exec {} -- cilium status".format(cilium_podid)
+    cilium_status = kubectl.run_kubectl(cilium_status_cmd)
+    assert re.search(r'Controller Status:\s+([0-9]+)/\1 healthy', cilium_status) is not None
+
+    for i in range(1, 10):
+        cilium_status = kubectl.run_kubectl(cilium_status_cmd) 
+        all_reachable = re.search(r"Cluster health:\s+({})/\1 reachable".format(node_count), cilium_status)
+        if all_reachable:
+           break
+        time.sleep(30)
+
+    assert all_reachable


### PR DESCRIPTION
## Why is this PR needed?

Implements cilium policies e2e test using the testrunner test library

Fixes https://github.com/SUSE/avant-garde/issues/692

## What does this PR do?

- [X] Implement fixtures to provide a fully deployed cluster (partially address https://github.com/SUSE/avant-garde/issues/693)
- [x] Exposes `run_kubectl` method from `Kubectl` wrapper to allow executing arbitrary kubectl commands
- [X] Implements `get_num_nodes` method in `Platform` to retrieve the number of nodes in the infrastructure (required to join all nodes to cluster)
- [X] Implements cilium test based on scripts used by QA 

## Anything else a reviewer needs to know?

The tests seems to have a timing issue, as it runs if executed step by step, but fails in run without interruption. 

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->