### PR TITLE
Add dex/gangway certificate renewal

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -110,6 +110,14 @@ func Apply(target *deployments.Target) error {
 					return err
 				}
 			}
+			err = target.Apply(nil, "gangway.renewCert")
+			if err != nil {
+				return err
+			}
+			err = target.Apply(nil, "dex.renewCert")
+			if err != nil {
+				return err
+			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,6 +271,7 @@ k8s.io/apiextensions-apiserver/pkg/features
 k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/resource
@@ -281,11 +282,11 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/watch
-k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/util/validation
+k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/json
@@ -296,7 +297,6 @@ k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/apis/meta/internalversion
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
-k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/util/mergepatch


### PR DESCRIPTION
## Why is this PR needed?

Kubernetes components renew its certificates during upgrade. Dex and Gangway certificates should also renew upon control plane upgrade.

## What does this PR do?

Dex and Gangway certificates renew upon control plane upgrade.

## Anything else a reviewer needs to know?

N/A