### PR TITLE
Add dex/gangway certificate renewal

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/dex.go
+++ b/internal/pkg/skuba/deployments/ssh/dex.go
@@ -33,7 +33,7 @@ import (
 
 func init() {
 	stateMap["dex.deploy"] = dexDeploy
-	stateMap["dex.renewCert"] = dexRenewCertificate
+	stateMap["dex.cert.renew"] = dexRenewCertificate
 }
 
 func dexDeploy(t *Target, data interface{}) error {

--- a/internal/pkg/skuba/deployments/ssh/dex.go
+++ b/internal/pkg/skuba/deployments/ssh/dex.go
@@ -18,6 +18,7 @@
 package ssh
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -26,10 +27,13 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/dex"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
 	stateMap["dex.deploy"] = dexDeploy
+	stateMap["dex.renewCert"] = dexRenewCertificate
 }
 
 func dexDeploy(t *Target, data interface{}) error {
@@ -56,5 +60,25 @@ func dexDeploy(t *Target, data interface{}) error {
 	}
 
 	_, _, err = t.ssh("kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/dex.d")
+	return err
+}
+
+func dexRenewCertificate(t *Target, data interface{}) error {
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return errors.Wrap(err, "could not get admin client set")
+	}
+
+	err = dex.CreateCert(client, skuba.PkiDir(), skuba.KubeadmInitConfFile())
+	if err != nil {
+		return errors.Wrap(err, "unable to create dex certificate")
+	}
+
+	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", dex.CertCommonName)}
+	err = client.CoreV1().Pods(metav1.NamespaceSystem).DeleteCollection(&metav1.DeleteOptions{}, listOptions)
+	if err != nil {
+		return errors.Wrap(err, "unable to delete dex pod")
+	}
+
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/gangway.go
+++ b/internal/pkg/skuba/deployments/ssh/gangway.go
@@ -18,6 +18,7 @@
 package ssh
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -26,10 +27,13 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/gangway"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
 	stateMap["gangway.deploy"] = gangwayDeploy
+	stateMap["gangway.renewCert"] = gangwayRenewCertificate
 }
 
 func gangwayDeploy(t *Target, data interface{}) error {
@@ -64,5 +68,25 @@ func gangwayDeploy(t *Target, data interface{}) error {
 	}
 
 	_, _, err = t.ssh("kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /tmp/gangway.d")
+	return err
+}
+
+func gangwayRenewCertificate(t *Target, data interface{}) error {
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return errors.Wrap(err, "could not get admin client set")
+	}
+
+	err = gangway.CreateCert(client, skuba.PkiDir(), skuba.KubeadmInitConfFile())
+	if err != nil {
+		return errors.Wrap(err, "unable to create gangway certificate")
+	}
+
+	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", gangway.CertCommonName)}
+	err = client.CoreV1().Pods(metav1.NamespaceSystem).DeleteCollection(&metav1.DeleteOptions{}, listOptions)
+	if err != nil {
+		return errors.Wrap(err, "unable to delete gangway pod")
+	}
+
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/gangway.go
+++ b/internal/pkg/skuba/deployments/ssh/gangway.go
@@ -33,7 +33,7 @@ import (
 
 func init() {
 	stateMap["gangway.deploy"] = gangwayDeploy
-	stateMap["gangway.renewCert"] = gangwayRenewCertificate
+	stateMap["gangway.cert.renew"] = gangwayRenewCertificate
 }
 
 func gangwayDeploy(t *Target, data interface{}) error {

--- a/internal/pkg/skuba/dex/dex.go
+++ b/internal/pkg/skuba/dex/dex.go
@@ -36,8 +36,8 @@ import (
 const (
 	imageName = "caasp-dex"
 
-	certCommonName = "oidc-dex"
-	secretCertName = "oidc-dex-cert"
+	CertCommonName = "oidc-dex"
+	SecretCertName = "oidc-dex-cert"
 )
 
 // CreateCert creates a signed certificate for dex
@@ -60,13 +60,13 @@ func CreateCert(
 
 	// Generate dex certificate
 	cert, key, err := util.NewServerCertAndKey(caCert, caKey,
-		certCommonName, cfg.ClusterConfiguration.APIServer.CertSANs)
+		CertCommonName, cfg.ClusterConfiguration.APIServer.CertSANs)
 	if err != nil {
 		return errors.Wrap(err, "could not genenerate dex server cert")
 	}
 
 	// Create or update secret resource
-	if err := util.CreateOrUpdateCertToSecret(client, caCert, cert, key, secretCertName); err != nil {
+	if err := util.CreateOrUpdateCertToSecret(client, caCert, cert, key, SecretCertName); err != nil {
 		return errors.Wrap(err, "unable to create/update cert to secret")
 	}
 

--- a/internal/pkg/skuba/gangway/gangway.go
+++ b/internal/pkg/skuba/gangway/gangway.go
@@ -39,8 +39,8 @@ import (
 const (
 	imageName = "gangway"
 
-	certCommonName = "oidc-gangway"
-	secretCertName = "oidc-gangway-cert"
+	CertCommonName = "oidc-gangway"
+	SecretCertName = "oidc-gangway-cert"
 
 	sessionKey    = "session-key"
 	secretKeyName = "oidc-gangway-secret"
@@ -96,13 +96,13 @@ func CreateCert(
 
 	// Generate gangway certificate
 	cert, key, err := util.NewServerCertAndKey(caCert, caKey,
-		certCommonName, cfg.ClusterConfiguration.APIServer.CertSANs)
+		CertCommonName, cfg.ClusterConfiguration.APIServer.CertSANs)
 	if err != nil {
 		return errors.Wrap(err, "could not genenerate gangway server cert")
 	}
 
 	// Create or update certificate to secret
-	if err := util.CreateOrUpdateCertToSecret(client, caCert, cert, key, secretCertName); err != nil {
+	if err := util.CreateOrUpdateCertToSecret(client, caCert, cert, key, SecretCertName); err != nil {
 		return errors.Wrap(err, "unable to create/update cert to secret")
 	}
 

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -110,11 +110,11 @@ func Apply(target *deployments.Target) error {
 					return err
 				}
 			}
-			err = target.Apply(nil, "gangway.renewCert")
+			err = target.Apply(nil, "gangway.cert.renew")
 			if err != nil {
 				return err
 			}
-			err = target.Apply(nil, "dex.renewCert")
+			err = target.Apply(nil, "dex.cert.renew")
 			if err != nil {
 				return err
 			}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -110,6 +110,14 @@ func Apply(target *deployments.Target) error {
 					return err
 				}
 			}
+			err = target.Apply(nil, "gangway.renewCert")
+			if err != nil {
+				return err
+			}
+			err = target.Apply(nil, "dex.renewCert")
+			if err != nil {
+				return err
+			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,6 +271,7 @@ k8s.io/apiextensions-apiserver/pkg/features
 k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/resource
@@ -281,11 +282,11 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/watch
-k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/util/validation
+k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/json
@@ -296,7 +297,6 @@ k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/apis/meta/internalversion
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
-k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/util/mergepatch

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -271,7 +271,6 @@ k8s.io/apiextensions-apiserver/pkg/features
 k8s.io/apimachinery/pkg/util/version
 k8s.io/apimachinery/pkg/apis/meta/v1
 k8s.io/apimachinery/pkg/types
-k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/api/resource
@@ -282,11 +281,11 @@ k8s.io/apimachinery/pkg/labels
 k8s.io/apimachinery/pkg/selection
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/watch
+k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/strategicpatch
 k8s.io/apimachinery/pkg/util/wait
 k8s.io/apimachinery/pkg/util/validation
-k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/conversion/queryparams
 k8s.io/apimachinery/pkg/util/errors
 k8s.io/apimachinery/pkg/util/json
@@ -297,6 +296,7 @@ k8s.io/apimachinery/pkg/api/meta
 k8s.io/apimachinery/pkg/apis/meta/internalversion
 k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 k8s.io/apimachinery/pkg/apis/meta/v1beta1
+k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/third_party/forked/golang/reflect
 k8s.io/apimachinery/pkg/util/mergepatch


### PR DESCRIPTION
Signed-off-by: clark.hsu clark.hsu@suse.com

## Why is this PR needed?

Kubernetes components renew its certificates during upgrade. Dex and Gangway certificates should also renew upon control plane upgrade.

## What does this PR do?

Dex and Gangway certificates renew upon control plane upgrade.

## Anything else a reviewer needs to know?

N/A