### PR TITLE
Add into the github template a "Docs" section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,5 +41,12 @@ this issue is not fixed.
 
 How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.
 
+
+## Docs
+
+If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
+At the time of creating this issue, This PR can be work in progress (set its title to [WIP]...),
+but it needs to be ready in order to merge this PR.
+
 <!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
     If you can, please apply all applicable labels to help reviews out! -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ How can we validate this issue is fixed? Please provide the steps and the prove 
 ## Docs
 
 If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
-At the time of creating this issue, This PR can be work in progress (set its title to [WIP]...),
+At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
 but it needs to be ready in order to merge this PR.
 
 <!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,7 +46,7 @@ How can we validate this issue is fixed? Please provide the steps and the prove 
 
 If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
 At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
-but it needs to be ready in order to merge this PR.
+but the documentation needs to be finalized before the PR can be merged. 
 
 <!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
     If you can, please apply all applicable labels to help reviews out! -->


### PR DESCRIPTION
## Why is this PR needed?

When creating a PR, this shouldn't be merged unless the documentation
is also updated. Otherwise, we would have code that does not match
the docs.

Obviously, this is only true if the fixes you want to merge need a
documentation update.

In any case, it is good to ask the developer to think if this needs
a documentation update.

Doc team cannot be monitoring all the issues and PRs to this repo,
so the easiest way is that the developer submits a PR to the docs repo.

When creating the PR in this repo, it is understandable that the PR to
the docs repo may not be yet ready. This is fine. You can create a "Work
in Progress" PR to the doc team repo. This will also make them aware
that some work is in the near future for them to review, and so they can
plan accordingly.


## What does this PR do?

Adds doc section into the PR template.

## Anything else a reviewer needs to know?

No,

## Info for QA

This for Doc team.


