### PR TITLE
Fix AWS security groups

### DIFF
--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -121,6 +121,14 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # CRI-O streaming - internal only
+  ingress {
+    from_port   = 10010
+    to_port     = 10010
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
   # master -> worker kubelet communication - internal
   ingress {
     from_port   = 10250
@@ -156,6 +164,14 @@ resource "aws_security_group" "allow_workers_traffic" {
   tags = "${merge(local.tags, map(
     "Name", "${var.stack_name}-control-plane",
     "Class", "SecurityGroup"))}"
+
+  # CRI-O streaming - internal only
+  ingress {
+    from_port   = 10010
+    to_port     = 10010
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
 
   # master -> worker kubelet communication - internal
   ingress {

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -150,34 +150,6 @@ resource "aws_security_group" "allow_workers_traffic" {
     "Class", "SecurityGroup"))}"
 
   ingress {
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
-    from_port   = 8080
-    to_port     = 8080
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
-    from_port   = 8081
-    to_port     = 8081
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
     from_port   = 10250
     to_port     = 10250
     protocol    = "tcp"

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -145,6 +145,14 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # kubeproxy health check - internal only
+  ingress {
+    from_port   = 10256
+    to_port     = 10256
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
   # range of ports used by kubernetes when allocating services
   # of type `NodePort` - internal
   ingress {
@@ -193,6 +201,14 @@ resource "aws_security_group" "allow_workers_traffic" {
   ingress {
     from_port   = 10250
     to_port     = 10250
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
+  # kubeproxy health check - internal only
+  ingress {
+    from_port   = 10256
+    to_port     = 10256
     protocol    = "tcp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -129,14 +129,6 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
-  # CRI-O streaming - internal only
-  ingress {
-    from_port   = 10010
-    to_port     = 10010
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
   # master -> worker kubelet communication - internal
   ingress {
     from_port   = 10250
@@ -186,14 +178,6 @@ resource "aws_security_group" "allow_workers_traffic" {
     from_port   = 8471
     to_port     = 8472
     protocol    = "udp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  # CRI-O streaming - internal only
-  ingress {
-    from_port   = 10010
-    to_port     = 10010
-    protocol    = "tcp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -102,8 +102,9 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     "Name", "${var.stack_name}-control-plane",
     "Class", "SecurityGroup"))}"
 
+  # etcd - internal
   ingress {
-    from_port   = 2380
+    from_port   = 2379
     to_port     = 2380
     protocol    = "tcp"
     cidr_blocks = ["${var.vpc_cidr_block}"]

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -45,6 +45,7 @@ resource "aws_security_group" "lbports" {
 }
 
 resource "aws_security_group" "icmp" {
+  # this also allows cilium health checks using the ICMP protocol
   description = "allow ping between instances"
   name        = "${var.stack_name}-icmp"
   vpc_id      = "${aws_vpc.platform.id}"
@@ -121,9 +122,17 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
-  # VXLAN traffic (cilium) - internal
+  # cilium - health check - internal
   ingress {
-    from_port   = 8471
+    from_port   = 4240
+    to_port     = 4240
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
+  # cilium - VXLAN traffic - internal
+  ingress {
+    from_port   = 8472
     to_port     = 8472
     protocol    = "udp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
@@ -173,9 +182,17 @@ resource "aws_security_group" "allow_workers_traffic" {
     "Name", "${var.stack_name}-control-plane",
     "Class", "SecurityGroup"))}"
 
-  # VXLAN traffic (cilium) - internal
+  # cilium - health check - internal
   ingress {
-    from_port   = 8471
+    from_port   = 4240
+    to_port     = 4240
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
+  # cilium - VXLAN traffic - internal
+  ingress {
+    from_port   = 8472
     to_port     = 8472
     protocol    = "udp"
     cidr_blocks = ["${var.vpc_cidr_block}"]

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -111,13 +111,6 @@ resource "aws_security_group" "allow_control_plane_traffic" {
   }
 
   ingress {
-    from_port   = 8285
-    to_port     = 8285
-    protocol    = "udp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
     from_port   = 30000
     to_port     = 32768
     protocol    = "udp"
@@ -166,13 +159,6 @@ resource "aws_security_group" "allow_workers_traffic" {
     from_port   = 10250
     to_port     = 10250
     protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
-    from_port   = 8285
-    to_port     = 8285
-    protocol    = "udp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -121,6 +121,14 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # master -> worker kubelet communication - internal
+  ingress {
+    from_port   = 10250
+    to_port     = 10250
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
   # range of ports used by kubernetes when allocating services
   # of type `NodePort` - internal
   ingress {
@@ -149,6 +157,7 @@ resource "aws_security_group" "allow_workers_traffic" {
     "Name", "${var.stack_name}-control-plane",
     "Class", "SecurityGroup"))}"
 
+  # master -> worker kubelet communication - internal
   ingress {
     from_port   = 10250
     to_port     = 10250

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -163,13 +163,6 @@ resource "aws_security_group" "allow_workers_traffic" {
   }
 
   ingress {
-    from_port   = 2380
-    to_port     = 2380
-    protocol    = "tcp"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
-  }
-
-  ingress {
     from_port   = 10250
     to_port     = 10250
     protocol    = "tcp"

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -196,6 +196,14 @@ resource "aws_security_group" "elb" {
 
   # HTTP access from anywhere
   ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTPS access from anywhere
+  ingress {
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -25,10 +25,21 @@ resource "aws_security_group" "lbports" {
     "Name", "${var.stack_name}-lbport",
     "Class", "SecurityGroup"))}"
 
+  # range of ports used by kubernetes when allocating services
+  # of type `NodePort` - internal
   ingress {
     from_port   = 30000
     to_port     = 32767
     protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
+  # range of ports used by kubernetes when allocating services
+  # of type `NodePort` - internal
+  ingress {
+    from_port   = 30000
+    to_port     = 32767
+    protocol    = "udp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 }
@@ -110,9 +121,20 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # range of ports used by kubernetes when allocating services
+  # of type `NodePort` - internal
   ingress {
     from_port   = 30000
-    to_port     = 32768
+    to_port     = 32767
+    protocol    = "tcp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
+  # range of ports used by kubernetes when allocating services
+  # of type `NodePort` - internal
+  ingress {
+    from_port   = 30000
+    to_port     = 32767
     protocol    = "udp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
@@ -162,16 +184,20 @@ resource "aws_security_group" "allow_workers_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # range of ports used by kubernetes when allocating services
+  # of type `NodePort` - internal
   ingress {
     from_port   = 30000
-    to_port     = 32768
+    to_port     = 32767
     protocol    = "tcp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # range of ports used by kubernetes when allocating services
+  # of type `NodePort` - internal
   ingress {
     from_port   = 30000
-    to_port     = 32768
+    to_port     = 32767
     protocol    = "udp"
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }

--- a/ci/infra/aws/security-groups.tf
+++ b/ci/infra/aws/security-groups.tf
@@ -121,6 +121,14 @@ resource "aws_security_group" "allow_control_plane_traffic" {
     cidr_blocks = ["${var.vpc_cidr_block}"]
   }
 
+  # VXLAN traffic (cilium) - internal
+  ingress {
+    from_port   = 8471
+    to_port     = 8472
+    protocol    = "udp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
+
   # CRI-O streaming - internal only
   ingress {
     from_port   = 10010
@@ -164,6 +172,14 @@ resource "aws_security_group" "allow_workers_traffic" {
   tags = "${merge(local.tags, map(
     "Name", "${var.stack_name}-control-plane",
     "Class", "SecurityGroup"))}"
+
+  # VXLAN traffic (cilium) - internal
+  ingress {
+    from_port   = 8471
+    to_port     = 8472
+    protocol    = "udp"
+    cidr_blocks = ["${var.vpc_cidr_block}"]
+  }
 
   # CRI-O streaming - internal only
   ingress {


### PR DESCRIPTION
## Why is this PR needed?

The deployment of CaaSP on top of AWS is not working due to the security groups rules being wrong.

While this is not yet a supported deployment platform, I'm working on the delivery of a workshop demoing CaaSP on AWS.

## What does this PR do?

This PR does the following actions:

  * Remove rules that are no longer needed by v4
  * Add missing rules

## Anything else a reviewer needs to know?

This is a first iteration, once this code is merged I'll file another PR that organizes the rules in the same way  as other deployments do. I didn't do that right now to make life easier to reviewers.

Reviewing the whole diff at the same time can be a bit confusing. I highly recommend to go over each individual commit: they are well scoped and have nice explanation messages. They will make your life easier.

A similar work has to be done for OpenStack, I'll resume the work done by @ereslibre [here](https://github.com/SUSE/skuba/pull/414).

## Info for QA

This deployment is not yet supported by us, hence there's no QA to be done.

However, if someone is really interested, the steps to verify the fix are really easy (see below).

### Steps to reproduce the bug

  * Deploy the AWS infra: one master and one worker nodes are enough
  * Deploy CaaSP beta 5 on top of it
  * Check the output of `kubectl get pods --namespace kube-system`: all the pods should be running fine (without the patch some of them enter a backoff state because they never ever start properly)

### Related info

While working on this PR I realized our documentation was outdated. That resulted in the creation of [this](https://github.com/SUSE/doc-caasp/pull/398) PR against the CaaSP documentation. Feel free to take a look at it to have a better understanding of the ports that are required.

### Status **BEFORE** applying the patch

PODs like the cilium, cilium-operator stayed in persistent failure mode.

### Status **AFTER** applying the patch

All the PODs are running fine.