### PR TITLE
Handle node upgrade plan output better (bsc#1144914)

### DIFF
--- a/internal/pkg/skuba/kubernetes/node_version.go
+++ b/internal/pkg/skuba/kubernetes/node_version.go
@@ -221,24 +221,35 @@ func allWorkerNodesTolerateVersionWithVersioningInfo(allNodesVersioningInfo Node
 	return true
 }
 
-// AllControlPlanesMatchVersion checks that all control planes are on the same version, and that they match the current cluster version
-func AllControlPlanesMatchVersion(currentClusterVersion *version.Version) (bool, error) {
+// AllControlPlanesMatchVersion checks that all control planes are on the same version, and that they match a cluster version
+func AllControlPlanesMatchVersion(clusterVersion *version.Version) (bool, error) {
 	allNodesVersioningInfo, err := AllNodesVersioningInfo()
 	if err != nil {
 		return false, err
 	}
-	return AllControlPlanesMatchVersionWithVersioningInfo(allNodesVersioningInfo, currentClusterVersion), nil
+	return AllControlPlanesMatchVersionWithVersioningInfo(allNodesVersioningInfo, clusterVersion), nil
 }
 
-// AllControlPlanesMatchVersionWithVersioningInfo checks that all control planes are on the same version, and that they match the current cluster version
+// AllControlPlanesMatchVersionWithVersioningInfo checks that all control planes are on the same version, and that they match a cluster version
 // With the addition of passing in a NodeVersionInfoMap to make it easily testable
-func AllControlPlanesMatchVersionWithVersioningInfo(allNodesVersioningInfo NodeVersionInfoMap, currentClusterVersion *version.Version) bool {
+func AllControlPlanesMatchVersionWithVersioningInfo(allNodesVersioningInfo NodeVersionInfoMap, clusterVersion *version.Version) bool {
 	for _, nodeInfo := range allNodesVersioningInfo {
 		// skip workers
 		if !nodeInfo.IsControlPlane() {
 			continue
 		}
-		if !nodeInfo.ToleratesClusterVersion(currentClusterVersion) {
+		if !nodeInfo.ToleratesClusterVersion(clusterVersion) {
+			return false
+		}
+	}
+	return true
+}
+
+// AllNodesMatchVersionWithVersioningInfo returns if all nodes match a specific kubernetes version
+// This can be used to determine e.g. if an upgrade is ongoing
+func AllNodesMatchClusterVersionWithVersioningInfo(allNodesVersioningInfo NodeVersionInfoMap, clusterVersion *version.Version) bool {
+	for _, version := range allNodesVersioningInfo {
+		if !version.EqualsClusterVersion(clusterVersion) {
 			return false
 		}
 	}

--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -20,8 +20,6 @@ package upgrade
 import (
 	"fmt"
 
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
 	"github.com/SUSE/skuba/pkg/skuba"
 )
@@ -29,20 +27,20 @@ import (
 func Plan(nodeName string) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
-	if err != nil {
-		return err
-	}
-	currentVersion := currentClusterVersion.String()
-	latestVersion := kubernetes.LatestVersion().String()
-	fmt.Printf("Current Kubernetes cluster version: %s\n", currentVersion)
-	fmt.Printf("Latest Kubernetes version: %s\n", latestVersion)
-	fmt.Println()
-
 	nodeVersionInfoUpdate, err := upgradenode.UpdateStatus(nodeName)
 	if err != nil {
 		return err
 	}
+
+	if nodeVersionInfoUpdate.Current.IsControlPlane() {
+		fmt.Printf("Current Kubernetes cluster version: %s\n", nodeVersionInfoUpdate.Current)
+		fmt.Printf("Latest Kubernetes version: %s\n", nodeVersionInfoUpdate.Update)
+	} else {
+		fmt.Printf("Current worker node version: %s\n", nodeVersionInfoUpdate.Current)
+		fmt.Printf("Current cluster version: %s\n", nodeVersionInfoUpdate.Update)
+	}
+	fmt.Println()
+
 	if nodeVersionInfoUpdate.IsUpdated() {
 		fmt.Printf("Node %s is up to date\n", nodeName)
 	} else {

--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -20,6 +20,8 @@ package upgrade
 import (
 	"fmt"
 
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
 	"github.com/SUSE/skuba/pkg/skuba"
 )
@@ -27,18 +29,19 @@ import (
 func Plan(nodeName string) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	if err != nil {
+		return err
+	}
 	nodeVersionInfoUpdate, err := upgradenode.UpdateStatus(nodeName)
 	if err != nil {
 		return err
 	}
 
-	if nodeVersionInfoUpdate.Current.IsControlPlane() {
-		fmt.Printf("Current Kubernetes cluster version: %s\n", nodeVersionInfoUpdate.Current)
-		fmt.Printf("Latest Kubernetes version: %s\n", nodeVersionInfoUpdate.Update)
-	} else {
-		fmt.Printf("Current worker node version: %s\n", nodeVersionInfoUpdate.Current)
-		fmt.Printf("Current cluster version: %s\n", nodeVersionInfoUpdate.Update)
-	}
+	fmt.Printf("Current Kubernetes cluster version: %s\n", currentClusterVersion.String())
+	fmt.Printf("Latest Kubernetes version: %s\n", kubernetes.LatestVersion().String())
+	fmt.Println()
+	fmt.Printf("Current Node version: %s\n", nodeVersionInfoUpdate.Current.KubeletVersion.String())
 	fmt.Println()
 
 	if nodeVersionInfoUpdate.IsUpdated() {


### PR DESCRIPTION
## Why is this PR needed?

When control plane nodes are not yet upgraded, the skuba node upgrade
plan command run against a worker node outputs a misleading:

"Node my-worker-0 is up to date"

In this case we propagate a custom error that will enhance and
clarify the output.

https://bugzilla.suse.com/show_bug.cgi?id=1144914

## What does this PR do?

We propagate a custom error that will enhance and
clarify the output.

Also generalize AllControlPlanesMatchVersion function.
This function can be used to check against any clusterVersion.

## Anything else a reviewer needs to know?

Unit tests will be fixed later, therefore setting WIP

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Steps to reproduce the bug

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

Create a 1.14.1 cluster and run `skuba node upgrade plan` on a worker, output will be:

`Node is up to date`

### Status **AFTER** applying the patch

Create a 1.14.1 cluster and run `skuba node upgrade plan` on a worker, output will be:

`Unable to plan node upgrade: my-worker-0 is not upgradeable until all control plane nodes are upgraded`

## Docs

not necessary, the docs are treating `node upgrade plan` more generically
