### PR TITLE
Add upgrade commands man pages

### DIFF
--- a/docs/man/skuba-cluster-upgrade-plan.1.md
+++ b/docs/man/skuba-cluster-upgrade-plan.1.md
@@ -1,0 +1,18 @@
+% skuba-cluster-upgrade-plan(1) # skuba cluster upgrade plan - Plan cluster upgrade
+
+# NAME
+
+plan - Print the upgrade plan of the cluster
+
+# SYNOPSIS
+**plan**
+[**--help**|**-h**]
+*plan* [-h]
+
+# DESCRIPTION
+**plan** Evaluates and prints to stdout the upgrade plan for the cluster
+
+# OPTIONS
+
+**--help, -h**
+  Print usage statement.

--- a/docs/man/skuba-node-upgrade-apply.1.md
+++ b/docs/man/skuba-node-upgrade-apply.1.md
@@ -1,0 +1,31 @@
+% skuba-node-upgrade-apply(1) # skuba node upgrade apply - Apply the upgrade plan
+
+# NAME
+
+apply - Applies the upgrade plan for the given node
+
+# SYNOPSIS
+**apply**
+[**--help**|**-h**] [**--port**|**-p**] [**--sudo**|**-s**] [**--target**|**-t**]
+[**--user**|**-u**]
+*apply* *-t <fqdn>* [-hs] [-u user] [-p port]
+
+# DESCRIPTION
+**apply** Evaluates the upgrade plan and it also applies it for the given node
+
+# OPTIONS
+
+**--help, -h**
+  Print usage statement.
+
+**--port, -p**
+  Port to connect to using SSH
+
+**--sudo, -s**
+  Run remote command via sudo (defaults to ssh connection user identity)
+
+**--target, -t**
+  IP or host name of the node to connect to using SSH
+
+**--user, -u**
+  User identity used to connect to target (default=root)

--- a/docs/man/skuba-node-upgrade-plan.1.md
+++ b/docs/man/skuba-node-upgrade-plan.1.md
@@ -1,0 +1,18 @@
+% skuba-node-upgrade-plan(1) # skuba node upgrade plan - Plan node upgrade
+
+# NAME
+
+plan - Print the upgrade plan of the node
+
+# SYNOPSIS
+**plan**
+[**--help**|**-h**]
+*plan* *<node-name>* [-h]
+
+# DESCRIPTION
+**plan** Evaluates and prints to stdout the upgrade plan for the given node
+
+# OPTIONS
+
+**--help, -h**
+  Print usage statement.

--- a/docs/man/skuba.1.md
+++ b/docs/man/skuba.1.md
@@ -30,6 +30,9 @@ reconfiguration in an easy way.
 # SEE ALSO
 **skuba-cluster-init**(1),
 **skuba-cluster-status**(1),
+**skuba-cluster-upgrade-plan**(1),
 **skuba-node-bootstrap**(1),
 **skuba-node-join**(1),
 **skuba-node-remove**(1),
+**skuba-node-upgrade-plan**(1),
+**skuba-node-upgrade-apply**(1),


### PR DESCRIPTION
## Why is this PR needed?

This PR adds new man pages for the skuba upgrade related subcommands

Fixes SUSE/avant-garde#696
Fixes SUSE/avant-garde#698
Fixes SUSE/avant-garde#697

## What does this PR do?

This PR adds a very basic man pages for 'cluster upgrade plan',
'node upgrade plan' and 'node upgrade apply' skuba subcommands.

Man pages are basically based on --help messages for each of them.