### PR TITLE
fix typo in dex clusterrole

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -1025,7 +1025,7 @@ rules:
   verbs: ["create", "get", "list", "update", "watch"]
 - apiGroups: ["dex.coreos.com"]
   resources: ["oauth2clients", "connectors", "passwords", "refreshtokens"]
-  verbs: ["get", list"]
+  verbs: ["get", "list"]
 - apiGroups: ["dex.coreos.com"]
   resources: ["signingkeies"]
   verbs: ["create", "get", "list", "update"]


### PR DESCRIPTION
Dex can't start currently because the clusterrole is wrong.

Signed-off-by: lcavajani <lcavajani@suse.com>
