### PR TITLE
Add merge restrictions for post RC

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,5 +48,24 @@ If docs need to be updated, please add a link to a PR to https://github.com/SUSE
 At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
 but the documentation needs to be finalized before the PR can be merged. 
 
+
+# Merge restrictions after RC
+
+(Please do not edit this)
+
+This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:
+
+    Who can merge: Release Engineers*
+    What can be merged (merge criteria):
+        3 approvals:
+            1 developer
+            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
+            1 QA
+        there is a PR for updating documentation (or a statement that this is not needed)
+        it fixes a P2 bug that has not been target for maintenance
+        the impact is low: for example, it does not touch a piece of code that has an impact on all features
+
+* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*
+
 <!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
     If you can, please apply all applicable labels to help reviews out! -->


### PR DESCRIPTION
This reflects the configuration and we are writing in here to make it
explicit for the contributor.


## Why is this PR needed?

So contributors know the rules when they create a PR.

## What does this PR do?

Update the github template

## Anything else a reviewer needs to know?

This is reflecting the rules. Please do not discuss the rules in this PR.

## Info for QA

This is not a bug fix

## Docs

Already updated at https://confluence.suse.com/pages/viewpage.action?spaceKey=SUSECaaSPlatform4&title=Development+Workflow+for+CaaSP+v4+%28vnext%29+development

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
