### PR TITLE
Disable automatic trigger for merge PR job

### DIFF
--- a/ci/jenkins/templates/handle-pr.yaml
+++ b/ci/jenkins/templates/handle-pr.yaml
@@ -10,7 +10,6 @@
             timeout: 30
             fail: true
     triggers:
-        - timed: 'H * * * *'
     parameters:
         - string:
             name: branch


### PR DESCRIPTION
Signed-off-by: Pablo Chacin <pchacin@suse.com>

## Why is this PR needed?

Merge will now be executed by QA. Automatic PR merge should be disable

Fixes https://github.com/SUSE/avant-garde/issues/708

## What does this PR do?

Removes the hourly trigger for the PR merge job  

## Anything else a reviewer needs to know?

