### PR TITLE
Cleanup kubectl wrapper

### DIFF
--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -1,12 +1,11 @@
 import os
 import platforms
 
-from timeout_decorator import timeout
-
 from platforms.platform import Platform
 from skuba.skuba import Skuba
 from utils.format import Format
 from utils.utils import (step, Utils)
+
 
 class Kubectl:
 
@@ -17,45 +16,6 @@ class Kubectl:
         self.skuba = Skuba(conf, platform)
 
 
-    def create_deployment(self, name, image):
-        self._run_kubectl("create deployment {name} --image={image}"
-                          .format(name=name, image=image))
-
-    def scale_deployment(self, name, replicas):
-        self._run_kubectl("scale deployment {name} --replicas={replicas}"
-                          .format(name=name, replicas=replicas))
-
-    def expose_deployment(self, name, port, nodeType="NodePort"):
-        self._run_kubectl("expose deployment {name} --port={port} --type={nodeType}"
-                          .format(name=name, port=port, nodeType=nodeType))
-
-    def wait_deployment(self, name, timeout):
-        self._run_kubectl("wait --for=condition=available deploy/{name} --timeout={timeout}m"
-                          .format(name=name, timeout=timeout))
-
-    def count_available_replicas(self, name):
-        result = self._run_kubectl("get deployment/{name} | jq '.status.availableReplicas'"
-                                   .format(name=name))
-        return int(result)
-
-    def get_service_port(self, name):
-        result = self._run_kubectl("get service/{name} | jq '.spec.ports[0].nodePort'"
-                                   .format(name=name))
-        return int(result)
-
-    def test_service(self, name, path="/", worker=0):
-        ip_addresses = self.platform.get_nodes_ipaddrs("worker")
-        if worker >= len(ip_addresses):
-            raise ValueError("Node worker-{} not deployed".format(worker))
-
-        port = self.get_service_port(name)
-        shell_cmd = "curl {ip}:{port}{path}".format(ip=ip_addresses[worker],port=port,path=path)
-        try:
-            return self.utils.runshellcommand(shell_cmd)
-        except Exception as ex:
-            raise Exception("Error testing service {} with path {} at node {}"
-                                .format(name, path, ip_address)) from ex
- 
     def run_kubectl(self, command):
         kubeconfig = self.skuba.get_kubeconfig()
         

--- a/ci/infra/testrunner/tests/test_deployments.py
+++ b/ci/infra/testrunner/tests/test_deployments.py
@@ -1,21 +1,26 @@
-from skuba import Skuba
-from kubectl import Kubectl
 import pytest
-import time
-from timeout_decorator import timeout
+import json
+import requests
 
-def test_nginx_deployment(setup, skuba, kubectl):
-    skuba.node_join(role="worker", nr=0)
-    skuba.node_join(role="worker", nr=1)
-    masters = skuba.num_of_nodes("master")
-    workers = skuba.num_of_nodes("worker")
-    assert masters == 1
-    assert workers == 2
-    kubectl.create_deployment("nginx", "nginx:stable-alpine")
-    kubectl.scale_deployment("nginx", workers)
-    kubectl.expose_deployment("nginx", 80)
-    kubectl.wait_deployment("nginx", 3)
-    assert kubectl.count_available_replicas("nginx") == workers
-    result = kubectl.test_service("nginx")
-    assert "Welcome to nginx" in result
+from kubectl import Kubectl
 
+
+def test_nginx_deployment(deployment, kubectl):
+    workers = kubectl.skuba.num_of_nodes("worker")
+    kubectl.run_kubectl("create deployment nginx --image=nginx:stable-alpine")
+    kubectl.run_kubectl("scale deployment nginx --replicas={replicas}".format(replicas=workers))
+    kubectl.run_kubectl("expose deployment nginx --port=80 --type=NodePort")
+    kubectl.run_kubectl("wait --for=condition=available deploy/nginx --timeout={timeout}m".format(timeout=3))
+    readyReplicas = kubectl.run_kubectl("get deployment/nginx -o jsonpath='{ .status.readyReplicas }'")
+
+    assert int(readyReplicas) == workers
+
+    nodePort = kubectl.run_kubectl("get service/nginx -o jsonpath='{ .spec.ports[0].nodePort }'")
+
+    wrk_idx = 0
+    ip_addresses = kubectl.skuba.platform.get_nodes_ipaddrs("worker")
+
+    url = "{protocol}://{ip}:{port}{path}".format(protocol="http",ip=str(ip_addresses[wrk_idx]),port=str(nodePort),path="/")
+    r = requests.get(url)
+
+    assert "Welcome to nginx" in r.text


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

## Why is this PR needed?

Cleans up `kubectl` wrapper with methods that are no longer needed.

## What does this PR do?

Cleans up `kubectl` wrapper with methods that are no longer needed.

## Info for QA

Deploy test should continue to work

