### PR TITLE
Add verbosity to CI skuba execution

### DIFF
--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -160,7 +160,7 @@ class Skuba:
         path = "{cwd}/test-cluster/admin.conf".format(cwd=self.conf.workspace)
         return path
 
-    def _run_skuba(self, cmd, cwd=None):
+    def _run_skuba(self, cmd, cwd=None, verbosity=None):
         """Running skuba command in cwd.
         The cwd defautls to {workspace}/test-cluster but can be overrided
         for example, for the init command that must run in {workspace}
@@ -170,6 +170,19 @@ class Skuba:
         if cwd is None:
             cwd = self.cwd
 
+        if verbosity is None:
+            verbosity = self.conf.skuba.verbosity
+        try:
+            v = int(verbosity)
+        except ValueError:
+            raise ValueError(f"verbosity '{verbosity}' is not an int")
+        verbosity = v
+
         env = {"SSH_AUTH_SOCK": self.utils.ssh_sock_fn()}
 
-        return self.utils.runshellcommand(self.binpath + " " + cmd, cwd=cwd, env=env)
+
+        return self.utils.runshellcommand(
+          f"{self.binpath} -v {verbosity} {cmd}",
+          cwd=cwd,
+          env=env,
+          )

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -83,6 +83,7 @@ class BaseConfig:
             super().__init__()
             self.binpath = None
             self.srcpath = None
+            self.verbosity = 5
 
     class Test:
         def __init__(self):

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -8,6 +8,7 @@ nodeuser: "sles"  # Default node username
 skuba:
   binpath: "" # path to skuba binary
   srcpath: "" # path to skuba source
+  verbosity: 5 # default value passed to skuba with -v
 
 # platform settings
 terraform:


### PR DESCRIPTION
add verbosity argument to run_skuba

## Why is this PR needed?

This simple PR adds a verbosity parameter to the skuba execution method in testrunner with an elevated default value.

Fixes SUSE/avant-garde#547

## What does this PR do?

Increased default verbosity on skuba executions will increase the output recorded in the test cases, facilitating easier debugging when tests fail.  Passing it as an optional parameter allows specific calls to fine-tune the value as needed.