### PR TITLE
Fix typo in PSP manifest

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -86,7 +86,6 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.privileged
   annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileName: '*'
     apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
@@ -199,7 +198,7 @@ metadata:
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
     seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-    apparmor.security.beta.kubernetes.io/allowedProfileName: runtime/default
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
     apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged


### PR DESCRIPTION
## Why is this PR needed?

allowedProfileName should be allowedProfileNames,
otherwise the PSP is not valid.

Signed-off-by: lcavajani <lcavajani@suse.com>