### PR TITLE
Allow the development build of skuba to deploy 1.14.1

### DIFF
--- a/internal/app/skuba/cluster/init.go
+++ b/internal/app/skuba/cluster/init.go
@@ -70,7 +70,7 @@ func NewInitCmd() *cobra.Command {
 				DexImage:            dex.GetDexImage(),
 				GangwayClientSecret: dex.GenerateClientSecret(),
 				GangwayImage:        gangway.GetGangwayImage(),
-				KubernetesVersion:   kubernetesVersion.String(),
+				KubernetesVersion:   kubernetesVersion,
 				ImageRepository:     skuba.ImageRepository,
 				EtcdImageTag:        kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, kubernetesVersion),
 				CoreDNSImageTag:     kubernetes.ComponentVersionForClusterVersion(kubernetes.CoreDNS, kubernetesVersion),

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -24,9 +24,11 @@ import (
 	"path/filepath"
 	"text/template"
 
+	versionutil "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/klog"
+
 	"github.com/SUSE/skuba/pkg/skuba"
 	"github.com/pkg/errors"
-	"k8s.io/klog"
 )
 
 type InitConfiguration struct {
@@ -39,12 +41,16 @@ type InitConfiguration struct {
 	DexImage            string
 	GangwayClientSecret string
 	GangwayImage        string
-	KubernetesVersion   string
+	KubernetesVersion   *versionutil.Version
 	ImageRepository     string
 	EtcdImageTag        string
 	CoreDNSImageTag     string
 	CloudProvider       string
 	StrictCapDefaults   bool
+}
+
+func (initConfiguration InitConfiguration) KubernetesVersionAtLeast(version string) bool {
+	return initConfiguration.KubernetesVersion.AtLeast(versionutil.MustParseSemantic(version))
 }
 
 // Init creates a cluster definition scaffold in the local machine, in the current

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -86,8 +86,9 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.privileged
   annotations:
-    apparmor.security.beta.kubernetes.io/allowedProfileName: '*'
+{{- if .KubernetesVersionAtLeast "1.15.0" }}
     apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+{{- end }}
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
     seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 spec:
@@ -197,10 +198,12 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.unprivileged
   annotations:
+{{- if .KubernetesVersionAtLeast "1.15.0" }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+{{- end }}
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
     seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
-    apparmor.security.beta.kubernetes.io/allowedProfileName: runtime/default
-    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged
   privileged: false


### PR DESCRIPTION
## Why is this PR needed?

Fixes: https://github.com/SUSE/avant-garde/issues/705

Since we changed the PSP's to have apparmor support, the 1.14.1
version that can be deployed with the latest skuba was not
functional.

This affects the development version only, as it's the only possible
way to deploy Kubernetes 1.14.1 with a newer skuba (because of the
development-only flag `--kubernetes-version`).