### PR TITLE
Set loglevel ci

### DIFF
--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -25,6 +25,9 @@ vmware:
   env_file: "" #os.getenv("VMWARE_ENV_FILE")
   template_name: "SLES15-SP1-GM-guestinfo" #os.getenv("VMWARE_TEMPLATE_NAME")
 
+log:
+  level: DEBUG
+
 # node settings
 lb:
   count: 1


### PR DESCRIPTION
## Why is this PR needed?

Default log level of testrunner is INFO. When running in the CI, a detailed log is useful for debugging failed executions.

Fixes https://github.com/SUSE/avant-garde/issues/716

## What does this PR do?

Modifies the testrunner configuration file used in the ci setting the log level
