### PR TITLE
Remove a hardcoded image reference for pause image

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -58,7 +58,7 @@ useHyperKubeImage: true
 ## Default        : ""
 ## ServiceRestart : crio
 #
-CRIO_OPTIONS=--pause-image=registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4/pause:3.1 --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
+CRIO_OPTIONS=--pause-image={{.ImageRepository}}/pause:3.1 --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
   `
 
 	masterConfTemplate = `apiVersion: kubeadm.k8s.io/v1beta1


### PR DESCRIPTION
## Why is this PR needed?

We cannot ship with references to `registry.suse.de` devel or staging projects.

## What does this PR do?

Make use of ImageRepository constant that is dependent on the build environment.

## Anything else a reviewer needs to know?

This should solve pause image references in SUSE namespace

## Info for QA

Needs to validate that pause image is coming from registry registry.suse.com and that /etc/sysconfig/crio includes the proper reference