### PR TITLE
Configure pause image on cluster init

### DIFF
--- a/internal/app/skuba/cluster/init.go
+++ b/internal/app/skuba/cluster/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
 	cilium "github.com/SUSE/skuba/internal/pkg/skuba/cni"
 	"github.com/SUSE/skuba/internal/pkg/skuba/dex"
@@ -63,6 +64,7 @@ func NewInitCmd() *cobra.Command {
 				ClusterName:         args[0],
 				CloudProvider:       initOptions.CloudProvider,
 				ControlPlane:        initOptions.ControlPlane,
+				PauseImage:          images.GetGenericImage(skuba.ImageRepository, "pause", kubernetes.ComponentVersionForClusterVersion(kubernetes.Pause, kubernetesVersion)),
 				CiliumImage:         cilium.GetCiliumImage(),
 				CiliumInitImage:     cilium.GetCiliumInitImage(),
 				CiliumOperatorImage: cilium.GetCiliumOperatorImage(),

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -34,6 +34,7 @@ import (
 type InitConfiguration struct {
 	ClusterName         string
 	ControlPlane        string
+	PauseImage          string
 	CiliumImage         string
 	CiliumInitImage     string
 	CiliumOperatorImage string

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -58,7 +58,7 @@ useHyperKubeImage: true
 ## Default        : ""
 ## ServiceRestart : crio
 #
-CRIO_OPTIONS=--pause-image=registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4/pause:3.1 --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
+CRIO_OPTIONS=--pause-image={{.PauseImage}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
   `
 
 	masterConfTemplate = `apiVersion: kubeadm.k8s.io/v1beta1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -485,8 +485,8 @@ k8s.io/kube-proxy/config/v1alpha1
 # k8s.io/kubelet v0.0.0 => k8s.io/kubelet v0.0.0-20190620085838-f1cb295a73c9
 k8s.io/kubelet/config/v1beta1
 # k8s.io/kubernetes v1.15.0
-k8s.io/kubernetes/cmd/kubeadm/app/constants
 k8s.io/kubernetes/cmd/kubeadm/app/images
+k8s.io/kubernetes/cmd/kubeadm/app/constants
 k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient
 k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil
 k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm


### PR DESCRIPTION
## Why is this PR needed?

Configure pause image depending on the build type of `skuba` and the
kubernetes version when setting it to cri-o.