### PR TITLE
Fixes bsc#1144829: raise a new error, as there is no error to wrap.

### DIFF
--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -61,7 +61,7 @@ func (initConfiguration InitConfiguration) KubernetesVersionAtLeast(version stri
 //        using the PWD
 func Init(initConfiguration InitConfiguration) error {
 	if _, err := os.Stat(initConfiguration.ClusterName); err == nil {
-		return errors.Wrapf(err, "cluster configuration directory %q already exists", initConfiguration.ClusterName)
+		return errors.Errorf("cluster configuration directory %q already exists", initConfiguration.ClusterName)
 	}
 
 	scaffoldFilesToWrite := scaffoldFiles


### PR DESCRIPTION
Otherwise the function will just execute as in the good case.

Signed-off-by: Florian Bergmann <fbergmann@suse.com>

## Why is this PR needed?

In case the folder the cluster configuration would be written into already exists, nothing would happen.

After this PR `skuba` will print an error that the folder already exists so the user can remove the folder.

Fixes #1144829

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Fix a bug in `cluster init`.

## Info for QA

### Steps to reproduce the bug

Attempt to `cluster init` into a folder that already exists.

```sh
mkdir folder
skuba cluster init --control-plane $IP folder
ls folder
```

The folder is till empty - nothing happened.

### Related info

No related information - this bug is isolated to this patch.

### Status **BEFORE** applying the patch

```sh
mkdir folder
skuba cluster init --control-plane $IP folder
ls folder
```

### Status **AFTER** applying the patch

```sh
mkdir folder
skuba cluster init --control-plane $IP folder
** This is a BETA release and NOT intended for production usage. **
F0808 16:11:31.395724   31511 init.go:82] init failed due to error: cluster configuration directory "folder" already exists
```

The now `fatal` message is printed and `skuba` quits execution.
