### PR TITLE
Fixes bsc#1144996 run reset before uploading certs

### DIFF
--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -64,7 +64,6 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 	}
 
 	statesToApply := []string{
-		"kubeadm.reset",
 		"kernel.load-modules",
 		"kernel.configure-parameters",
 		"apparmor.start",
@@ -92,6 +91,8 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 	if joinConfiguration.Role == deployments.MasterRole {
 		statesToApply = append([]string{"kubernetes.join.upload-secrets"}, statesToApply...)
 	}
+
+	statesToApply = append([]string{"kubeadm.reset"}, statesToApply...)
 
 	fmt.Println("[join] applying states to new node")
 


### PR DESCRIPTION
## Why is this PR needed?

This changes the order or running task otherwise
kubeadm.reset is run after we upload the cert so
it is not possible to bootstrap a master node.

Signed-off-by: lcavajani <lcavajani@suse.com>