### PR TITLE
Install the pattern instead of explicit packages (bsc#1145009)

### DIFF
--- a/internal/pkg/skuba/deployments/kubernetes.go
+++ b/internal/pkg/skuba/deployments/kubernetes.go
@@ -18,6 +18,6 @@
 package deployments
 
 type KubernetesBaseOSConfiguration struct {
-	KubeadmVersion    string
-	KubernetesVersion string
+	UpdatedVersion string
+	CurrentVersion string
 }

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -42,7 +42,6 @@ const (
 func init() {
 	stateMap["kubernetes.bootstrap.upload-secrets"] = kubernetesUploadSecrets(KubernetesUploadSecretsContinueOnError)
 	stateMap["kubernetes.join.upload-secrets"] = kubernetesUploadSecrets(KubernetesUploadSecretsFailOnError)
-	stateMap["kubernetes.install-base-packages"] = kubernetesInstallBasePackages
 	stateMap["kubernetes.install-node-pattern"] = kubernetesInstallNodePattern
 	stateMap["kubernetes.install-intermediate-node-pattern"] = kubernetesInstallIntermediateNodePattern
 	stateMap["kubernetes.restart-services"] = kubernetesRestartServices
@@ -60,23 +59,6 @@ func kubernetesUploadSecrets(errorHandling KubernetesUploadSecretsErrorBehavior)
 		}
 		return nil
 	}
-}
-
-func kubernetesInstallBasePackages(t *Target, data interface{}) error {
-	kubernetesBaseOSConfiguration, ok := data.(deployments.KubernetesBaseOSConfiguration)
-	if !ok {
-		return errors.New("couldn't access kubernetes base OS configuration")
-	}
-
-	t.ssh("zypper", "--non-interactive", "install", "--force",
-		fmt.Sprintf("kubernetes-kubeadm=%s", kubernetesBaseOSConfiguration.KubeadmVersion),
-		fmt.Sprintf("cri-o=%s", kubernetesBaseOSConfiguration.KubernetesVersion),
-		fmt.Sprintf("kubernetes-client=%s", kubernetesBaseOSConfiguration.KubernetesVersion),
-		fmt.Sprintf("kubernetes-common=%s", kubernetesBaseOSConfiguration.KubernetesVersion),
-		fmt.Sprintf("kubernetes-kubelet=%s", kubernetesBaseOSConfiguration.KubernetesVersion),
-	)
-	// FIXME: do not ignore error, beta3 to beta4 package conflicts
-	return nil
 }
 
 func kubernetesInstallNodePattern(t *Target, data interface{}) error {

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -68,7 +68,7 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 	}
 
 	_, _, err := t.ssh("zypper", "--non-interactive", "install", "--force",
-		fmt.Sprintf("patterns-caasp-Node-%s", kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.KubernetesVersion))),
+		fmt.Sprintf("patterns-caasp-Node-%s", kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.CurrentVersion))),
 	)
 	return err
 }
@@ -78,10 +78,10 @@ func kubernetesInstallIntermediateNodePattern(t *Target, data interface{}) error
 	if !ok {
 		return errors.New("couldn't access kubernetes base OS configuration")
 	}
-	kubeadmVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.KubeadmVersion))
-	kubernetesVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.KubernetesVersion))
+	updatedVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.UpdatedVersion))
+	currentVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.CurrentVersion))
 	_, _, err := t.ssh("zypper", "--non-interactive", "install", "--force",
-		fmt.Sprintf("patterns-caasp-Node-%s-%s", kubernetesVersion, kubeadmVersion),
+		fmt.Sprintf("patterns-caasp-Node-%s-%s", currentVersion, updatedVersion),
 	)
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -69,8 +69,6 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 
 	_, _, err := t.ssh("zypper", "--non-interactive", "install", "--force",
 		fmt.Sprintf("patterns-caasp-Node-%s", kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.KubernetesVersion))),
-		// to be able to install a fresh 1.14 cluster we have to explicitly install the wanted kubeadm version
-		fmt.Sprintf("kubernetes-kubeadm=%s", kubernetesBaseOSConfiguration.KubernetesVersion), // TODO: remove this line after we're out of the beta phase
 	)
 	return err
 }

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -57,7 +57,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	versionToDeploy := version.MustParseSemantic(initConfiguration.KubernetesVersion)
 
 	_, err = target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
-		KubernetesVersion: versionToDeploy.String(),
+		CurrentVersion: versionToDeploy.String(),
 	})
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -52,7 +52,7 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 	}
 
 	_, err = target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
-		KubernetesVersion: currentClusterVersion.String(),
+		CurrentVersion: currentClusterVersion.String(),
 	})
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -120,8 +120,8 @@ func Apply(target *deployments.Target) error {
 			}
 			if nodeVersionInfoUpdate.HasMajorOrMinorUpdate() {
 				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-					KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
-					KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
+					UpdatedVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
+					CurrentVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
 				}, "kubernetes.install-intermediate-node-pattern")
 				if err != nil {
 					return err
@@ -134,7 +134,7 @@ func Apply(target *deployments.Target) error {
 				return err
 			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-				KubernetesVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
+				CurrentVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 			}, "kubernetes.install-node-pattern")
 			if err != nil {
 				return err
@@ -185,8 +185,8 @@ func Apply(target *deployments.Target) error {
 			}
 			if nodeVersionInfoUpdate.HasMajorOrMinorUpdate() {
 				err := target.Apply(deployments.KubernetesBaseOSConfiguration{
-					KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
-					KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
+					UpdatedVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
+					CurrentVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
 				}, "kubernetes.install-intermediate-node-pattern")
 				if err != nil {
 					return err
@@ -196,7 +196,7 @@ func Apply(target *deployments.Target) error {
 				return err
 			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-				KubernetesVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
+				CurrentVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 			}, "kubernetes.install-node-pattern")
 			if err != nil {
 				return err

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -126,14 +126,6 @@ func Apply(target *deployments.Target) error {
 				if err != nil {
 					return err
 				}
-			} else {
-				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-					KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
-					KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
-				}, "kubernetes.install-base-packages")
-				if err != nil {
-					return err
-				}
 			}
 			err = target.Apply(deployments.UpgradeConfiguration{
 				KubeadmConfigContents: string(initCfgContents),
@@ -142,9 +134,8 @@ func Apply(target *deployments.Target) error {
 				return err
 			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
-			}, "kubernetes.install-base-packages")
+			}, "kubernetes.install-node-pattern")
 			if err != nil {
 				return err
 			}
@@ -200,22 +191,13 @@ func Apply(target *deployments.Target) error {
 				if err != nil {
 					return err
 				}
-			} else {
-				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-					KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
-					KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
-				}, "kubernetes.install-base-packages")
-				if err != nil {
-					return err
-				}
 			}
 			if err := target.Apply(nil, "kubeadm.upgrade.node"); err != nil {
 				return err
 			}
 			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-				KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 				KubernetesVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
-			}, "kubernetes.install-base-packages")
+			}, "kubernetes.install-node-pattern")
 			if err != nil {
 				return err
 			}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -122,7 +122,7 @@ func Apply(target *deployments.Target) error {
 				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 					UpdatedVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
 					CurrentVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
-				}, "kubernetes.install-intermediate-node-pattern")
+				}, "kubernetes.install-node-pattern")
 				if err != nil {
 					return err
 				}
@@ -187,7 +187,7 @@ func Apply(target *deployments.Target) error {
 				err := target.Apply(deployments.KubernetesBaseOSConfiguration{
 					UpdatedVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 					CurrentVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
-				}, "kubernetes.install-intermediate-node-pattern")
+				}, "kubernetes.install-node-pattern")
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
## Why is this PR needed?

When upgrading from 1.14.1 to 1.15.2 we found out that cri-o has
not the right patch level version yet.

Kubernetes and cri-o are not tied to patch levels so we install
the pattern instead.

(bsc#1145009)
