### PR TITLE
Explicitly pass kubernetes.Interface to functions that need it

### DIFF
--- a/internal/app/skuba/cluster/status.go
+++ b/internal/app/skuba/cluster/status.go
@@ -21,16 +21,21 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	cluster "github.com/SUSE/skuba/pkg/skuba/actions/cluster/status"
 )
 
 // NewStatusCmd creates a new `skuba cluster status` cobra command
 func NewStatusCmd() *cobra.Command {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		klog.Warningf("Can not retrieve the ClientSet from kubernetes: %v", err)
+	}
 	return &cobra.Command{
 		Use:   "status",
 		Short: "Show cluster status",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := cluster.Status(); err != nil {
+			if err := cluster.Status(clientSet); err != nil {
 				klog.Errorf("unable to get cluster status: %s", err)
 			}
 		},

--- a/internal/app/skuba/cluster/upgrade.go
+++ b/internal/app/skuba/cluster/upgrade.go
@@ -19,6 +19,8 @@ package cluster
 
 import (
 	"fmt"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"k8s.io/klog"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -41,11 +43,15 @@ func NewUpgradeCmd() *cobra.Command {
 }
 
 func newUpgradePlanCmd() *cobra.Command {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		klog.Warningf("Can not retrieve the ClientSet from kubernetes: %v", err)
+	}
 	return &cobra.Command{
 		Use:   "plan",
 		Short: "Plan cluster upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := upgrade.Plan(); err != nil {
+			if err := upgrade.Plan(clientSet); err != nil {
 				fmt.Printf("Unable to plan cluster upgrade: %s\n", err)
 				os.Exit(1)
 			}

--- a/internal/app/skuba/node/join.go
+++ b/internal/app/skuba/node/join.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/join"
 )
@@ -36,6 +37,10 @@ type joinOptions struct {
 func NewJoinCmd() *cobra.Command {
 	joinOptions := joinOptions{}
 	target := ssh.Target{}
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		klog.Warningf("Can not retrieve the ClientSet from kubernetes: %v", err)
+	}
 
 	cmd := &cobra.Command{
 		Use:   "join <node-name>",
@@ -47,7 +52,7 @@ func NewJoinCmd() *cobra.Command {
 
 			joinConfiguration.Role = deployments.MustGetRoleFromString(joinOptions.role)
 
-			if err := node.Join(joinConfiguration, target.GetDeployment(nodenames[0])); err != nil {
+			if err := node.Join(clientSet, joinConfiguration, target.GetDeployment(nodenames[0])); err != nil {
 				klog.Fatalf("error joining node %s: %s", nodenames[0], err)
 			}
 		},

--- a/internal/app/skuba/node/upgrade.go
+++ b/internal/app/skuba/node/upgrade.go
@@ -22,8 +22,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba/actions/node/upgrade"
 )
 
@@ -43,11 +45,15 @@ func NewUpgradeCmd() *cobra.Command {
 }
 
 func newUpgradePlanCmd() *cobra.Command {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		klog.Warningf("Can not retrieve the ClientSet from kubernetes: %v", err)
+	}
 	return &cobra.Command{
 		Use:   "plan <node-name>",
 		Short: "Plan node upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := upgrade.Plan(args[0]); err != nil {
+			if err := upgrade.Plan(clientSet, args[0]); err != nil {
 				fmt.Printf("Unable to plan node upgrade: %s\n", err)
 				os.Exit(1)
 			}
@@ -57,12 +63,16 @@ func newUpgradePlanCmd() *cobra.Command {
 }
 
 func newUpgradeApplyCmd() *cobra.Command {
+	clientSet, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		klog.Warningf("Can not retrieve the ClientSet from kubernetes: %v", err)
+	}
 	target := ssh.Target{}
 	cmd := cobra.Command{
 		Use:   "apply",
 		Short: "Apply node upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := upgrade.Apply(target.GetDeployment("")); err != nil {
+			if err := upgrade.Apply(clientSet, target.GetDeployment("")); err != nil {
 				fmt.Printf("Unable to apply node upgrade: %s\n", err)
 				os.Exit(1)
 			}

--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
 	"github.com/SUSE/skuba/pkg/skuba/actions/node/join"
 )
@@ -58,12 +59,16 @@ func kubeadmInit(t *Target, data interface{}) error {
 }
 
 func kubeadmJoin(t *Target, data interface{}) error {
+	api, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		errors.Wrap(err, "could not retrieve the clientset from kubernetes")
+	}
 	joinConfiguration, ok := data.(deployments.JoinConfiguration)
 	if !ok {
 		return errors.New("couldn't access join configuration")
 	}
 
-	configPath, err := join.ConfigPath(joinConfiguration.Role, t.target)
+	configPath, err := join.ConfigPath(api, joinConfiguration.Role, t.target)
 	if err != nil {
 		return errors.Wrap(err, "unable to configure path")
 	}

--- a/internal/pkg/skuba/kubernetes/clientset.go
+++ b/internal/pkg/skuba/kubernetes/clientset.go
@@ -25,7 +25,7 @@ import (
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func GetAdminClientSet() (*clientset.Clientset, error) {
+func GetAdminClientSet() (clientset.Interface, error) {
 	client, err := kubeconfigutil.ClientSetFromFile(skuba.KubeConfigAdminFile())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load admin kubeconfig file")

--- a/internal/pkg/skuba/kubernetes/jobs.go
+++ b/internal/pkg/skuba/kubernetes/jobs.go
@@ -21,18 +21,16 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 )
 
-func CreateJob(name string, spec batchv1.JobSpec) (*batchv1.Job, error) {
-	clientSet, err := GetAdminClientSet()
-	if err != nil {
-		return nil, errors.Wrap(err, "Error getting client set")
-	}
-	_, err = clientSet.BatchV1().Jobs(metav1.NamespaceSystem).Create(&batchv1.Job{
+func CreateJob(clientSet kubernetes.Interface, name string, spec batchv1.JobSpec) (*batchv1.Job, error) {
+	_, err := clientSet.BatchV1().Jobs(metav1.NamespaceSystem).Create(&batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceSystem,
@@ -42,25 +40,17 @@ func CreateJob(name string, spec batchv1.JobSpec) (*batchv1.Job, error) {
 	return nil, err
 }
 
-func DeleteJob(name string) error {
-	clientSet, err := GetAdminClientSet()
-	if err != nil {
-		return errors.Wrap(err, "Error getting client set")
-	}
+func DeleteJob(clientSet kubernetes.Interface, name string) error {
 	return clientSet.BatchV1().Jobs(metav1.NamespaceSystem).Delete(name, &metav1.DeleteOptions{})
 }
 
-func CreateAndWaitForJob(name string, spec batchv1.JobSpec) error {
-	_, err := CreateJob(name, spec)
-	defer DeleteJob(name)
+func CreateAndWaitForJob(clientSet kubernetes.Interface, name string, spec batchv1.JobSpec) error {
+	_, err := CreateJob(clientSet, name, spec)
+	defer DeleteJob(clientSet, name)
 	if err != nil {
 		return err
 	}
 	for i := 0; i < 300; i++ {
-		clientSet, err := GetAdminClientSet()
-		if err != nil {
-			return errors.Wrap(err, "Error getting client set")
-		}
 		job, err := clientSet.BatchV1().Jobs(metav1.NamespaceSystem).Get(name, metav1.GetOptions{})
 		if err != nil {
 			klog.V(1).Infof("failed to get status for job %s, continuing...", name)

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -19,6 +19,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"k8s.io/client-go/kubernetes"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -28,8 +29,9 @@ import (
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func DisarmKubelet(node *v1.Node) error {
+func DisarmKubelet(clientSet kubernetes.Interface, node *v1.Node) error {
 	return CreateAndWaitForJob(
+		clientSet,
 		disarmKubeletJobName(node),
 		disarmKubeletJobSpec(node),
 	)

--- a/internal/pkg/skuba/kubernetes/nodes.go
+++ b/internal/pkg/skuba/kubernetes/nodes.go
@@ -33,11 +33,7 @@ import (
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func GetControlPlaneNodes() (*v1.NodeList, error) {
-	clientSet, err := GetAdminClientSet()
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to get admin client set")
-	}
+func GetControlPlaneNodes(clientSet kubernetes.Interface) (*v1.NodeList, error) {
 	return clientSet.CoreV1().Nodes().List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=", kubeadmconstants.LabelNodeRoleMaster),
 	})

--- a/internal/pkg/skuba/upgrade/cluster/drift.go
+++ b/internal/pkg/skuba/upgrade/cluster/drift.go
@@ -18,10 +18,10 @@
 package cluster
 
 import (
-	"k8s.io/apimachinery/pkg/util/version"
-
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"k8s.io/apimachinery/pkg/util/version"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
 func driftedNodesWithVersions(currentClusterVersion *version.Version, nodesVersionInfo kubernetes.NodeVersionInfoMap) []kubernetes.NodeVersionInfo {
@@ -42,8 +42,8 @@ func driftedNodesWithVersions(currentClusterVersion *version.Version, nodesVersi
 // major version than the current cluster version are considered. If the difference on
 // the node version with regards to the current cluster version is only the patch level
 // version, the node won't be included in the list.
-func DriftedNodes() ([]kubernetes.NodeVersionInfo, error) {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+func DriftedNodes(clientSet k8s.Interface) ([]kubernetes.NodeVersionInfo, error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return []kubernetes.NodeVersionInfo{}, err
 	}

--- a/internal/pkg/skuba/upgrade/cluster/versions.go
+++ b/internal/pkg/skuba/upgrade/cluster/versions.go
@@ -18,10 +18,10 @@
 package cluster
 
 import (
-	"k8s.io/apimachinery/pkg/util/version"
-
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"k8s.io/apimachinery/pkg/util/version"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
 func nextAvailableVersionsForVersion(currentClusterVersion *version.Version, availableVersions []*version.Version) (nextPatch *version.Version, nextMinor *version.Version, nextMajor *version.Version, err error) {
@@ -54,8 +54,8 @@ func nextAvailableVersionsForVersion(currentClusterVersion *version.Version, ava
 // NextAvailableVersions return the next patch version available (if any) for
 // the current minor version, the next minor version (if any) for the current
 // major version, and the next major version (if any)
-func NextAvailableVersions() (nextPatch *version.Version, nextMinor *version.Version, nextMajor *version.Version, err error) {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+func NextAvailableVersions(clientSet k8s.Interface) (nextPatch *version.Version, nextMinor *version.Version, nextMajor *version.Version, err error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -101,8 +101,8 @@ func UpgradePathWithAvailableVersions(currentClusterVersion *version.Version, av
 
 // UpgradePath returns the list of versions the cluster needs to go through
 // in order to upgrade to the latest available version
-func UpgradePath() ([]*version.Version, error) {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+func UpgradePath(clientSet k8s.Interface) ([]*version.Version, error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return []*version.Version{}, err
 	}

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -40,8 +40,9 @@ func (nviu NodeVersionInfoUpdate) IsUpdated() bool {
 }
 
 func (nviu NodeVersionInfoUpdate) IsFirstControlPlaneNodeToBeUpgraded() bool {
+	clientSet, _ := kubernetes.GetAdminClientSet()
 	isControlPlane := nviu.Current.IsControlPlane()
-	currentClusterVersion, _ := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, _ := kubeadm.GetCurrentClusterVersion(clientSet)
 	allControlPlanesMatchVersion, _ := kubernetes.AllControlPlanesMatchVersion(currentClusterVersion)
 	matchesClusterVersion := (currentClusterVersion.String() == nviu.Current.KubeletVersion.String())
 
@@ -53,7 +54,7 @@ func UpdateStatus(nodeName string) (NodeVersionInfoUpdate, error) {
 	if err != nil {
 		return NodeVersionInfoUpdate{}, errors.Wrap(err, "unable to get admin client set")
 	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return NodeVersionInfoUpdate{}, err
 	}

--- a/pkg/skuba/actions/cluster/status/status.go
+++ b/pkg/skuba/actions/cluster/status/status.go
@@ -20,11 +20,11 @@ package cluster
 import (
 	"os"
 
+	k8s "k8s.io/client-go/kubernetes"
+
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectlget "k8s.io/kubernetes/pkg/kubectl/cmd/get"
-
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 )
 
 // Status prints the status of the cluster on the standard output by reading the
@@ -32,14 +32,8 @@ import (
 //
 // FIXME: being this a part of the go API accept a io.Writer parameter instead of
 //        using os.Stdout
-func Status() error {
-	client, err := kubernetes.GetAdminClientSet()
-
-	if err != nil {
-		return errors.Wrap(err, "unable to get admin client set")
-	}
-
-	nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+func Status(clientSet k8s.Interface) error {
+	nodeList, err := clientSet.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve node list")
 	}

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -26,12 +26,13 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradecluster "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/cluster"
 	"github.com/SUSE/skuba/pkg/skuba"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
-func Plan() error {
+func Plan(clientSet k8s.Interface) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return err
 	}
@@ -46,7 +47,7 @@ func Plan() error {
 		return nil
 	}
 
-	upgradePath, err := upgradecluster.UpgradePath()
+	upgradePath, err := upgradecluster.UpgradePath(clientSet)
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func Plan() error {
 		tmpVersion = version.String()
 	}
 
-	driftedNodes, err := upgradecluster.DriftedNodes()
+	driftedNodes, err := upgradecluster.DriftedNodes(clientSet)
 	if err != nil {
 		return err
 	}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -43,7 +43,7 @@ import (
 //        of using the PWD
 func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target *deployments.Target) error {
 	if clientSet, err := kubernetes.GetAdminClientSet(); err == nil {
-		_, err := clientSet.ServerVersion()
+		_, err := clientSet.Discovery().ServerVersion()
 		if err == nil {
 			return errors.New("cluster is already bootstrapped")
 		}

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8s "k8s.io/client-go/kubernetes"
 	bootstraputil "k8s.io/cluster-bootstrap/token/util"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
@@ -45,8 +46,8 @@ import (
 //
 // FIXME: being this a part of the go API accept the toplevel directory instead of
 //        using the PWD
-func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.Target) error {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+func Join(clientSet k8s.Interface, joinConfiguration deployments.JoinConfiguration, target *deployments.Target) error {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return err
 	}
@@ -76,13 +77,7 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 		"skuba-update.start",
 	}
 
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		fmt.Print("[join] failed to get admin client set\n")
-		return err
-	}
-
-	_, err = client.CoreV1().Nodes().Get(target.Nodename, metav1.GetOptions{})
+	_, err = clientSet.CoreV1().Nodes().Get(target.Nodename, metav1.GetOptions{})
 	if err == nil {
 		fmt.Printf("[join] failed to join the node with name %q since a node with the same name already exists in the cluster\n", target.Nodename)
 		return err
@@ -110,7 +105,7 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 //
 // FIXME: being this a part of the go API accept the toplevel directory instead of
 //        using the PWD
-func ConfigPath(role deployments.Role, target *deployments.Target) (string, error) {
+func ConfigPath(clientSet k8s.Interface, role deployments.Role, target *deployments.Target) (string, error) {
 	configPath := skuba.MachineConfFile(target.Target)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		configPath = skuba.TemplatePathForRole(role)
@@ -120,7 +115,7 @@ func ConfigPath(role deployments.Role, target *deployments.Target) (string, erro
 	if err != nil {
 		return "", errors.Wrap(err, "error parsing configuration")
 	}
-	addFreshTokenToJoinConfiguration(target.Target, joinConfiguration)
+	addFreshTokenToJoinConfiguration(clientSet, target.Target, joinConfiguration)
 	addTargetInformationToJoinConfiguration(target, role, joinConfiguration)
 	if cloud.HasCloudIntegration() {
 		if !cloud.ConfigHasRestrictedPermissions(skuba.OpenstackCloudConfFile()) {
@@ -128,7 +123,7 @@ func ConfigPath(role deployments.Role, target *deployments.Target) (string, erro
 		}
 		setCloudConfiguration(joinConfiguration)
 	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return "", errors.Wrap(err, "could not get current cluster version")
 	}
@@ -147,12 +142,12 @@ func ConfigPath(role deployments.Role, target *deployments.Target) (string, erro
 	return skuba.MachineConfFile(target.Target), nil
 }
 
-func addFreshTokenToJoinConfiguration(target string, joinConfiguration *kubeadmapi.JoinConfiguration) error {
+func addFreshTokenToJoinConfiguration(clientSet k8s.Interface, target string, joinConfiguration *kubeadmapi.JoinConfiguration) error {
 	if joinConfiguration.Discovery.BootstrapToken == nil {
 		joinConfiguration.Discovery.BootstrapToken = &kubeadmapi.BootstrapTokenDiscovery{}
 	}
 	var err error
-	joinConfiguration.Discovery.BootstrapToken.Token, err = createBootstrapToken(target)
+	joinConfiguration.Discovery.BootstrapToken.Token, err = createBootstrapToken(clientSet, target)
 	joinConfiguration.Discovery.TLSBootstrapToken = ""
 	return err
 }
@@ -175,12 +170,7 @@ func addTargetInformationToJoinConfiguration(target *deployments.Target, role de
 	return nil
 }
 
-func createBootstrapToken(target string) (string, error) {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return "", errors.Wrap(err, "unable to get admin client set")
-	}
-
+func createBootstrapToken(clientSet k8s.Interface, target string) (string, error) {
 	bootstrapTokenRaw, err := bootstraputil.GenerateBootstrapToken()
 	if err != nil {
 		return "", errors.Wrap(err, "could not generate a new bootstrap token")
@@ -203,7 +193,7 @@ func createBootstrapToken(target string) (string, error) {
 		},
 	}
 
-	if err := kubeadmtokenphase.CreateNewTokens(client, bootstrapTokens); err != nil {
+	if err := kubeadmtokenphase.CreateNewTokens(clientSet, bootstrapTokens); err != nil {
 		return "", errors.Wrap(err, "could not create new bootstrap token")
 	}
 

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -66,23 +66,23 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 
 	if isControlPlane {
 		fmt.Printf("[remove-node] removing etcd from node %s\n", targetName)
-		etcd.RemoveMember(node)
+		etcd.RemoveMember(client, node)
 	}
 
-	if err := kubernetes.DisarmKubelet(node); err != nil {
+	if err := kubernetes.DisarmKubelet(client, node); err != nil {
 		fmt.Printf("[remove-node] failed disarming kubelet: %v; node could be down, continuing with node removal...\n", err)
 	}
 
 	if isControlPlane {
-		if err := kubeadm.RemoveAPIEndpointFromConfigMap(node); err != nil {
+		if err := kubeadm.RemoveAPIEndpointFromConfigMap(client, node); err != nil {
 			return errors.Wrapf(err, "[remove-node] could not remove the APIEndpoint for %s from the kubeadm-config configmap", targetName)
 		}
 
-		if err := cni.CreateOrUpdateCiliumConfigMap(); err != nil {
+		if err := cni.CreateOrUpdateCiliumConfigMap(client); err != nil {
 			return errors.Wrap(err, "[remove-node] could not update cilium-config configmap")
 		}
 
-		if err := cni.AnnotateCiliumDaemonsetWithCurrentTimestamp(); err != nil {
+		if err := cni.AnnotateCiliumDaemonsetWithCurrentTimestamp(client); err != nil {
 			fmt.Printf("[remove-node] could not annonate cilium daemonset: %v\n", err)
 		}
 	}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -32,16 +32,17 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
 	"github.com/SUSE/skuba/pkg/skuba"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
-func Apply(target *deployments.Target) error {
+func Apply(clientSet k8s.Interface, target *deployments.Target) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
 	if err := fillTargetWithNodeName(target); err != nil {
 		return err
 	}
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return err
 	}
@@ -82,7 +83,7 @@ func Apply(target *deployments.Target) error {
 		if upgradeable {
 			fmt.Println("Fetching the cluster configuration...")
 
-			initCfg, err := kubeadm.GetClusterConfiguration()
+			initCfg, err := kubeadm.GetClusterConfiguration(clientSet)
 			if err != nil {
 				return err
 			}

--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -24,12 +24,13 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
 	"github.com/SUSE/skuba/pkg/skuba"
+	k8s "k8s.io/client-go/kubernetes"
 )
 
-func Plan(nodeName string) error {
+func Plan(clientSet k8s.Interface, nodeName string) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -241,6 +241,7 @@ k8s.io/api/batch/v1
 k8s.io/api/apps/v1
 k8s.io/api/rbac/v1
 k8s.io/api/admissionregistration/v1beta1
+k8s.io/api/autoscaling/v1
 k8s.io/api/apps/v1beta1
 k8s.io/api/apps/v1beta2
 k8s.io/api/auditregistration/v1alpha1
@@ -248,7 +249,6 @@ k8s.io/api/authentication/v1
 k8s.io/api/authentication/v1beta1
 k8s.io/api/authorization/v1
 k8s.io/api/authorization/v1beta1
-k8s.io/api/autoscaling/v1
 k8s.io/api/autoscaling/v2beta1
 k8s.io/api/autoscaling/v2beta2
 k8s.io/api/batch/v1beta1
@@ -256,13 +256,13 @@ k8s.io/api/batch/v2alpha1
 k8s.io/api/certificates/v1beta1
 k8s.io/api/coordination/v1
 k8s.io/api/coordination/v1beta1
+k8s.io/api/policy/v1beta1
 k8s.io/api/events/v1beta1
 k8s.io/api/extensions/v1beta1
 k8s.io/api/networking/v1
 k8s.io/api/networking/v1beta1
 k8s.io/api/node/v1alpha1
 k8s.io/api/node/v1beta1
-k8s.io/api/policy/v1beta1
 k8s.io/api/rbac/v1alpha1
 k8s.io/api/rbac/v1beta1
 k8s.io/api/scheduling/v1
@@ -310,6 +310,9 @@ k8s.io/apimachinery/pkg/apis/meta/v1beta1
 k8s.io/apimachinery/pkg/util/validation/field
 k8s.io/apimachinery/pkg/util/yaml
 k8s.io/apimachinery/third_party/forked/golang/reflect
+k8s.io/apimachinery/pkg/version
+k8s.io/apimachinery/pkg/runtime/serializer/streaming
+k8s.io/apimachinery/pkg/util/clock
 k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/pkg/runtime/serializer/streaming
@@ -346,6 +349,7 @@ k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/hash
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/transformer/patch
 k8s.io/cli-runtime/pkg/kustomize/k8sdeps/kv
 # k8s.io/client-go v0.0.0 => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+k8s.io/client-go/kubernetes
 k8s.io/client-go/util/cert
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/kubernetes
@@ -395,10 +399,17 @@ k8s.io/client-go/kubernetes/typed/settings/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1beta1
+k8s.io/client-go/rest
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/tools/clientcmd/api/v1
 k8s.io/client-go/tools/watch
 k8s.io/client-go/util/jsonpath
+k8s.io/client-go/tools/reference
+k8s.io/client-go/pkg/version
+k8s.io/client-go/plugin/pkg/client/auth/exec
+k8s.io/client-go/rest/watch
+k8s.io/client-go/tools/metrics
+k8s.io/client-go/transport
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake
 k8s.io/client-go/kubernetes/typed/apps/v1/fake
@@ -436,14 +447,8 @@ k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake
 k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake
-k8s.io/client-go/pkg/version
-k8s.io/client-go/plugin/pkg/client/auth/exec
-k8s.io/client-go/rest/watch
-k8s.io/client-go/tools/metrics
-k8s.io/client-go/transport
 k8s.io/client-go/tools/auth
 k8s.io/client-go/util/homedir
-k8s.io/client-go/tools/reference
 k8s.io/client-go/discovery/cached/disk
 k8s.io/client-go/restmapper
 k8s.io/client-go/tools/cache


### PR DESCRIPTION
## Why is this PR needed?

Supersedes #429 (it seems after the skuba rename, fork <-> origin connection is lost).

Instead of having every function retrieving the `GetAdminClientSet` explicitly this will dependency inject this into every function that needs it.
