### PR TITLE
Upgrade: do not check container runtime version

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -83,7 +83,7 @@ var (
 			},
 			ComponentsVersion: ComponentsVersion{
 				KubeletVersion:          "1.15.2",
-				ContainerRuntimeVersion: "1.15.2",
+				ContainerRuntimeVersion: "1.15.0",
 			},
 			AddonsVersion: AddonsVersion{
 				CiliumVersion:  "1.5.3",

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -36,7 +36,13 @@ type NodeVersionInfoUpdate struct {
 }
 
 func (nviu NodeVersionInfoUpdate) IsUpdated() bool {
-	return reflect.DeepEqual(nviu.Current, nviu.Update)
+	return reflect.DeepEqual(nviu.Current.KubeletVersion, nviu.Update.KubeletVersion) &&
+		reflect.DeepEqual(nviu.Current.APIServerVersion, nviu.Update.APIServerVersion) &&
+		reflect.DeepEqual(nviu.Current.ControllerManagerVersion, nviu.Update.ControllerManagerVersion) &&
+		reflect.DeepEqual(nviu.Current.SchedulerVersion, nviu.Update.SchedulerVersion) &&
+		reflect.DeepEqual(nviu.Current.EtcdVersion, nviu.Update.EtcdVersion) &&
+		nviu.Current.ContainerRuntimeVersion.Major() == nviu.Update.ContainerRuntimeVersion.Major() &&
+		nviu.Current.ContainerRuntimeVersion.Minor() == nviu.Update.ContainerRuntimeVersion.Minor()
 }
 
 func (nviu NodeVersionInfoUpdate) IsFirstControlPlaneNodeToBeUpgraded() bool {


### PR DESCRIPTION
## Why is this PR needed?

Fixes: https://github.com/SUSE/avant-garde/issues/729

When upgrading do not check the full container runtime version.

cri-o releases are not up to speed with Kubernetes releases, and while
we have already a new Kubernetes version to upgrade to, cri-o may be
lagging behind yet.

Since the patchlevel version drift is tolerable, do not take
explicitly into account the exact version when determining if a node
is up to date when it comes to checking the container runtime version.