### PR TITLE
Upgrade: install intermediate pattern when needed

### DIFF
--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -35,6 +35,17 @@ type NodeVersionInfoUpdate struct {
 	Update  kubernetes.NodeVersionInfo
 }
 
+func (nviu NodeVersionInfoUpdate) HasMajorOrMinorUpdate() bool {
+	if nviu.Current.IsControlPlane() {
+		if nviu.Update.APIServerVersion.Major() > nviu.Current.APIServerVersion.Major() ||
+			nviu.Update.APIServerVersion.Minor() > nviu.Current.APIServerVersion.Minor() {
+			return true
+		}
+	}
+	return nviu.Update.KubeletVersion.Major() > nviu.Current.KubeletVersion.Major() ||
+		nviu.Update.KubeletVersion.Minor() > nviu.Current.KubeletVersion.Minor()
+}
+
 func (nviu NodeVersionInfoUpdate) IsUpdated() bool {
 	return reflect.DeepEqual(nviu.Current, nviu.Update)
 }

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -118,12 +118,22 @@ func Apply(target *deployments.Target) error {
 			if err != nil {
 				return err
 			}
-			err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-				KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
-				KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
-			}, "kubernetes.install-intermediate-node-pattern")
-			if err != nil {
-				return err
+			if nodeVersionInfoUpdate.HasMajorOrMinorUpdate() {
+				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
+					KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
+					KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
+				}, "kubernetes.install-intermediate-node-pattern")
+				if err != nil {
+					return err
+				}
+			} else {
+				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
+					KubeadmVersion:    nodeVersionInfoUpdate.Update.APIServerVersion.String(),
+					KubernetesVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
+				}, "kubernetes.install-base-packages")
+				if err != nil {
+					return err
+				}
 			}
 			err = target.Apply(deployments.UpgradeConfiguration{
 				KubeadmConfigContents: string(initCfgContents),
@@ -182,12 +192,22 @@ func Apply(target *deployments.Target) error {
 					return err
 				}
 			}
-			err := target.Apply(deployments.KubernetesBaseOSConfiguration{
-				KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
-				KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
-			}, "kubernetes.install-intermediate-node-pattern")
-			if err != nil {
-				return err
+			if nodeVersionInfoUpdate.HasMajorOrMinorUpdate() {
+				err := target.Apply(deployments.KubernetesBaseOSConfiguration{
+					KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
+					KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
+				}, "kubernetes.install-intermediate-node-pattern")
+				if err != nil {
+					return err
+				}
+			} else {
+				err = target.Apply(deployments.KubernetesBaseOSConfiguration{
+					KubeadmVersion:    nodeVersionInfoUpdate.Update.KubeletVersion.String(),
+					KubernetesVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
+				}, "kubernetes.install-base-packages")
+				if err != nil {
+					return err
+				}
 			}
 			if err := target.Apply(nil, "kubeadm.upgrade.node"); err != nil {
 				return err


### PR DESCRIPTION
## Why is this PR needed?

Do not install the intermediate pattern unless the upgrade of
Kubernetes is a major or minor one.