### PR TITLE
Support other ssh key types

### DIFF
--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -169,8 +169,9 @@ class BaseConfig:
         # TODO: add the path to shared ssh credentials as a configuration parameter
         if conf.ssh_key_option == "id_shared":
             conf.ssh_key_option = os.path.join(conf.skuba.srcpath, "ci/infra/id_shared")
-        elif conf.ssh_key_option == "id_rsa":
-            conf.ssh_key_option = os.path.join(os.path.expanduser("~"), ".ssh/id_rsa")
+        elif os.sep not in conf.ssh_key_option:
+            conf.ssh_key_option = os.path.join(os.path.expanduser("~"), ".ssh", conf.ssh_key_option)
+        # else assume it's a path somewhere else
 
         return conf
 


### PR DESCRIPTION
Make testrunner treat id_shared specially, and assume anything else is in the ~/.ssh directory

## Why is this PR needed?

Current testrunner only supports ssh keys with two names (id_shared and id_rsa).  I wanted to use a key generated in my ~/.ssh directory specific to a cluster, and earlier wanted to use id_ecdsa.  Those should both work fine, but the logic excludes other key names.

Fixes #

No related issue.

## What does this PR do?

This treats any ssh key which is not named "id_shared" and which does not include a UNIX path separator as if it's a key name located in the `~/.ssh directory`.  It also (necessarily) removes the hard-coded separator previously used in the `os.path.join` args.

## Anything else a reviewer needs to know?
N/A

## Info for QA
N/A

### Steps to reproduce the bug
N/A

### Related info
N/A

### Status **BEFORE** applying the patch

Try provisioning a cluster using a key not named id_rsa.  Provisioning silently fails due to failure to import ssh key.

### Status **AFTER** applying the patch

Try provisioning a cluster using a key not named id_rsa.  Provisioning (and subsequent ssh access) works.

## Docs

I don't think documentation needs updated since I didn't see where this was mentioned in the docs, but maybe "you can use other key types" is worth sharing, and maybe the help text should be updated?  Might be worth looking at the ssh implementation in skuba and validating 1) what types that Go client supports and 2) adding a check into the testrunner to verify that the content of the key is a supported type  But that's probably excessive.