### PR TITLE
Fix output for upgrade plan (bsc#1144914)

### DIFF
--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -20,8 +20,6 @@ package upgrade
 import (
 	"fmt"
 
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
 	"github.com/SUSE/skuba/pkg/skuba"
 )
@@ -29,20 +27,20 @@ import (
 func Plan(nodeName string) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
-	if err != nil {
-		return err
-	}
-	currentVersion := currentClusterVersion.String()
-	latestVersion := kubernetes.LatestVersion().String()
-	fmt.Printf("Current Kubernetes cluster version: %s\n", currentVersion)
-	fmt.Printf("Latest Kubernetes version: %s\n", latestVersion)
-	fmt.Println()
-
 	nodeVersionInfoUpdate, err := upgradenode.UpdateStatus(nodeName)
 	if err != nil {
 		return err
 	}
+
+	if nodeVersionInfoUpdate.Current.IsControlPlane() {
+		fmt.Printf("Current Kubernetes cluster version: %s\n", nodeVersionInfoUpdate.Current)
+		fmt.Printf("Latest Kubernetes version: %s\n", nodeVersionInfoUpdate.Update)
+	} else {
+		fmt.Printf("Current worker node version: %s\n", nodeVersionInfoUpdate.Current)
+		fmt.Printf("Current cluster version: %s\n", nodeVersionInfoUpdate.Update)
+	}
+	fmt.Println()
+
 	if nodeVersionInfoUpdate.IsUpdated() {
 		fmt.Printf("Node %s is up to date\n", nodeName)
 	} else {


### PR DESCRIPTION
When worker node plans out for upgrade, worker node's version is
dependent upon cluster version instead of the latest cluster version
available.

## Why is this PR needed?
```skuba node plan``` for worker node is misleading users for planning of upgrading worker nodes.
```
skuba node upgrade plan caasp-worker-clee-0 
skuba version: 0.9.3 (development) 4f6122f 20190809 go1.12.7
Current Kubernetes cluster version: 1.14.1
Latest Kubernetes version: 1.15.2

Node caasp-worker-clee-0 is up to date
```
The above info is correct for master node upgrade. However,  worker node upgrade is dependent upon current cluster version. 

Does it fix an issue? addresses a business case?
The fix is change of the output for worker node
``` 
skuba node upgrade plan caasp-worker-clee-0 
skuba version: 0.9.3 (development) 4f6122f 20190809 go1.12.7
Current worker node version: 1.14.1
Current cluster version: 1.14.1

Node caasp-worker-clee-0 is up to date
```
add a description and link to the issue if one exists.

Fixes #560 



