### PR TITLE
bootstrap: Ensure that BPFFS is mounted on the host (bsc#1146991)

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/bpffs.go
+++ b/internal/pkg/skuba/deployments/ssh/bpffs.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ssh
+
+import (
+	"fmt"
+)
+
+const bpffsFstabEntry = "bpffs /sys/fs/bpf bpf defaults 0 0"
+
+func init() {
+	stateMap["bpffs.mount"] = bpffsMount
+}
+
+func bpffsMount(t *Target, data interface{}) error {
+	if _, _, err := t.ssh("mount | grep bpf"); err != nil {
+		if _, _, err := t.ssh("mount bpffs /sys/fs/bpf -t bpf"); err != nil {
+			return fmt.Errorf("Could not mount the BPFFS filesystem: %s", err)
+		}
+	}
+	if _, _, err := t.ssh(fmt.Sprintf("if ! grep bpf /etc/fstab; then echo \"%s\" >> /etc/fstab; fi", bpffsFstabEntry)); err != nil {
+		return fmt.Errorf("Could not enable the BPFFS mount in fstab")
+	}
+	return nil
+}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -138,6 +138,7 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		"kubernetes.bootstrap.upload-secrets",
 		"kernel.load-modules",
 		"kernel.configure-parameters",
+		"bpffs.mount",
 		"apparmor.start",
 		criConfigure,
 		"cri.start",

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -74,6 +74,7 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 	statesToApply := []string{
 		"kernel.load-modules",
 		"kernel.configure-parameters",
+		"bpffs.mount",
 		"apparmor.start",
 		criConfigure,
 		"cri.start",

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -183,6 +183,9 @@ func Apply(target *deployments.Target) error {
 			return err
 		}
 	}
+	if err := target.Apply(nil, "bpffs.mount"); err != nil {
+		return err
+	}
 
 	fmt.Printf("Node %s (%s) successfully upgraded\n", target.Nodename, target.Target)
 


### PR DESCRIPTION
Before this change, some environments and SLE installations did not have
the BPFFS mount on the host, which resulted in the following warning in
Cilium:

```
level=warning msg="================================= WARNING ==========================================" subsys=bpf
level=warning msg="BPF filesystem is not mounted. This will lead to network disruption when Cilium pods" subsys=bpf
level=warning msg="are restarted. Ensure that the BPF filesystem is mounted in the host." subsys=bpf
level=warning msg="https://docs.cilium.io/en/stable/kubernetes/requirements/#mounted-bpf-filesystem" subsys=bpf
level=warning msg="====================================================================================" subsys=bpf
```

This warning means that restarts of Cilium pod can lead to the small
downtime, because all the BPFFS structure and BPF maps need to be
regenerated after the next BPFFS mount.

This change fixes that behavior and ensures that BPFFS is always
available before Cilium gets deployed.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>