### PR TITLE
[WIP] [GMC] Remove beta flag

### DIFF
--- a/cmd/skuba/skuba.go
+++ b/cmd/skuba/skuba.go
@@ -49,7 +49,6 @@ func newRootCmd() *cobra.Command {
 }
 
 func main() {
-	fmt.Println("** This is a BETA release and NOT intended for production usage. **")
 	klog.InitFlags(nil)
 	cmd := newRootCmd()
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
## Why is this PR needed?

This removes the "Beta" message from skuba. This is needed for GMC release.



## Anything else a reviewer needs to know?

## Info for QA

### Steps to reproduce the bug

### Related info


### Status **BEFORE** applying the patch



Run "skuba version" or any other command, and you will see the text

** This is a BETA release and NOT intended for production usage. **



### Status **AFTER** applying the patch

The above text should not be printed.

## Docs



https://github.com/SUSE/avant-garde/issues/686

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
