### PR TITLE
(bsc#1145599) Explicitly enable ip forward in autoyast

### DIFF
--- a/ci/infra/bare-metal/autoyast.xml
+++ b/ci/infra/bare-metal/autoyast.xml
@@ -122,8 +122,8 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
     <setup_before_proposal config:type="boolean">true</setup_before_proposal>
     <managed config:type="boolean">false</managed>
     <routing>
-      <ipv4_forward config:type="boolean">false</ipv4_forward>
-      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <ipv4_forward config:type="boolean">true</ipv4_forward>
+      <ipv6_forward config:type="boolean">true</ipv6_forward>
     </routing>
   </networking>
 


### PR DESCRIPTION
## Why is this PR needed?

This commit avoids disabling ip_forward
in /etc/sysctl.conf because this file takes
precedence over skuba kernel configuration files
in /etc/sysctl.d.

Without this commit, ip forward is disabled after
the reboot of a node.

Fixes bsc#1145599

Signed-off-by: lcavajani <lcavajani@suse.com>


## Info for QA

### Status **BEFORE** applying the patch

The following is in `/etc/sysctl.conf`

net.ipv4.ip_forward = 0
net.ipv6.conf.all.forwarding = 0

### Status **AFTER** applying the patch

The kernel options are not even defined in `/etc/sysctl.conf`

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
