### PR TITLE
Set current kubernetes version in the upgrade e2e tests

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -3,7 +3,7 @@ import time
 
 
 PREVIOUS_VERSION = "1.14.1"
-CURRENT_VERSION = "1.15.0"
+CURRENT_VERSION = "1.15.2"
 
 
 @pytest.fixture


### PR DESCRIPTION
Ideally we have another way of getting the latest version,
e.g. let the testrunner parse the versions.go file