### PR TITLE
Fix ssh-agent cleanup.

### DIFF
--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -53,9 +53,11 @@ class Utils:
         if os.path.exists(file):
             logger.info(f"Cleaning up {file}")
             try:
-                if os.path.isfile(file):
+                try:
+                    # Attempt to remove the file first, because a socket (e.g.
+                    # ssh-agent) is not a file but has to be removed like one.
                     os.remove(file)
-                else:
+                except IsADirectoryError:
                     shutil.rmtree(file)
             except Exception as ex:
                 logger.exception(ex)
@@ -191,7 +193,7 @@ class Utils:
             logger.info("Executing command {}".format(cmd))
 
         p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True,
-                           env=env, cwd=cwd)
+                 env=env, cwd=cwd)
         logger.debug(p.stdout.decode())
         if p.returncode != 0:
             logger.error(p.stderr)


### PR DESCRIPTION
Remove the ssh-agent socket will not work with `rmtree` - it needs to be removed
like a file.

However the `os.path.isfile()` function returns false for a UNIX socket.

## Why is this PR needed?

Fixes an issue when the testrunner attempt to cleanup the `ssh-agent` socket that was created during the run.

## Anything else a reviewer needs to know?

This PR is to fix the CI runner.

## Info for QA

Attempt to run the testrunner and watch it fail, because it can't remove the `ssh-agent` socket that was created:

```
ERROR    testrunner:utils.py:60 [Errno 6] No such device or address: '/tmp/9b51dc82e9a5f8a7390bacf3e6f669f8/ssh-agent-sock'                                                                                       
Traceback (most recent call last):                                                                                                                                                                                
  File "/home/florian/go/src/github.com/SUSE/skuba/ci/infra/testrunner/utils/utils.py", line 58, in cleanup_file                                                                                                  
    shutil.rmtree(file)                                                                                                                                                                                           
  File "/usr/lib64/python3.6/shutil.py", line 476, in rmtree                                                                                                                                                      
    onerror(os.lstat, path, sys.exc_info())                                                                                                                                                                       
  File "/usr/lib64/python3.6/shutil.py", line 474, in rmtree                                                                                                                                                      
    fd = os.open(path, os.O_RDONLY)                                                                                                                                                                               
OSError: [Errno 6] No such device or address: '/tmp/9b51dc82e9a5f8a7390bacf3e6f669f8/ssh-agent-sock'
```

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

The testrunner is able to cleanup the socket.

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
