### PR TITLE
Ensure that node name and disarm job name don't exceed the 63 char limit (bsc#1145568)

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
@@ -63,7 +63,7 @@ class PrChecks:
                     sys.exit(1)
 
             title = title.split('(bsc#') # Title may contain (bsc#XXXXXXXX) references so we need to exclude these
-            if len(title[0]) > 50:
+            if len(title[0].rstrip()) > 50:
                 print('Commit message title should be less than 50 characters (excluding the bsc# reference)')
                 sys.exit(1)
 

--- a/internal/app/skuba/node/bootstrap.go
+++ b/internal/app/skuba/node/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
 	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/bootstrap"
+	"github.com/SUSE/skuba/pkg/skuba/actions/validate"
 )
 
 type bootstrapOptions struct {
@@ -40,6 +41,10 @@ func NewBootstrapCmd() *cobra.Command {
 		Use:   "bootstrap <node-name>",
 		Short: "Bootstraps the first master node of the cluster",
 		Run: func(cmd *cobra.Command, nodenames []string) {
+			if err := validate.NodeName(nodenames[0]); err != nil {
+				klog.Fatal(err)
+			}
+
 			bootstrapConfiguration := deployments.BootstrapConfiguration{
 				KubeadmExtraArgs: map[string]string{"ignore-preflight-errors": bootstrapOptions.ignorePreflightErrors},
 			}

--- a/internal/app/skuba/node/join.go
+++ b/internal/app/skuba/node/join.go
@@ -25,6 +25,7 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
 	"github.com/SUSE/skuba/pkg/skuba/actions"
 	node "github.com/SUSE/skuba/pkg/skuba/actions/node/join"
+	"github.com/SUSE/skuba/pkg/skuba/actions/validate"
 )
 
 type joinOptions struct {
@@ -41,6 +42,10 @@ func NewJoinCmd() *cobra.Command {
 		Use:   "join <node-name>",
 		Short: "Joins a new node to the cluster",
 		Run: func(cmd *cobra.Command, nodenames []string) {
+			if err := validate.NodeName(nodenames[0]); err != nil {
+				klog.Fatal(err)
+			}
+
 			joinConfiguration := deployments.JoinConfiguration{
 				KubeadmExtraArgs: map[string]string{"ignore-preflight-errors": joinOptions.ignorePreflightErrors},
 			}

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -18,6 +18,7 @@
 package kubernetes
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"strings"
 
@@ -36,7 +37,8 @@ func DisarmKubelet(node *v1.Node) error {
 }
 
 func disarmKubeletJobName(node *v1.Node) string {
-	return fmt.Sprintf("caasp-kubelet-disarm-%s", node.ObjectMeta.Name)
+	return fmt.Sprintf("caasp-kubelet-disarm-%x",
+		sha1.Sum([]byte(node.ObjectMeta.Name)))
 }
 
 func disarmKubeletJobSpec(node *v1.Node) batchv1.JobSpec {

--- a/internal/pkg/skuba/kubernetes/kubelet_test.go
+++ b/internal/pkg/skuba/kubernetes/kubelet_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package kubernetes
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDisarmKubeletJobName(t *testing.T) {
+	testCases := []struct {
+		node         *v1.Node
+		expectedName string
+	}{
+		{
+			node:         &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "my-master-0"}},
+			expectedName: "caasp-kubelet-disarm-5a5d6b47201c0dab0034cb6959d24ddb35e56546",
+		},
+		{
+			node:         &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "my-worker-0"}},
+			expectedName: "caasp-kubelet-disarm-6db327a52a7ce5599572759bc60bdcbe63664630",
+		},
+		{
+			node:         &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo-bar"}},
+			expectedName: "caasp-kubelet-disarm-db7329d5a3f381875ea6ce7e28fe1ea536d0acaf",
+		},
+		{
+			node:         &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "ayy-lmao"}},
+			expectedName: "caasp-kubelet-disarm-dd07f282f4cf6821a365a3d01b43038d20d5c7fe",
+		},
+	}
+
+	for _, tc := range testCases {
+		name := disarmKubeletJobName(tc.node)
+		if name != tc.expectedName {
+			t.Errorf("expected name \"%s\", but instead got \"%s\"",
+				tc.expectedName, name)
+		}
+	}
+}

--- a/pkg/skuba/actions/validate/validate.go
+++ b/pkg/skuba/actions/validate/validate.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/SUSE/skuba/pkg/skuba"
+)
+
+// NodeName checks whether the node name is valid and accpetable for kubelet.
+func NodeName(nodename string) error {
+	if len(nodename) > skuba.MaxNodeNameLength {
+		return fmt.Errorf(
+			"invalid node name \"%s\": must be no more than %d characters",
+			nodename, skuba.MaxNodeNameLength)
+	}
+	return nil
+}

--- a/pkg/skuba/actions/validate/validate_test.go
+++ b/pkg/skuba/actions/validate/validate_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package validate
+
+import (
+	"testing"
+)
+
+func TestNodeName(t *testing.T) {
+	testCases := []struct {
+		nodename  string
+		expectErr bool
+	}{
+		{
+			nodename:  "my-master-0",
+			expectErr: false,
+		},
+		{
+			nodename:  "my-worker-0",
+			expectErr: false,
+		},
+		{
+			nodename:  "some-too-long-hostname-foo-bar-baz-fizz-buzz-xyz-zzy-kaboom-ayy-lmao",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := NodeName(tc.nodename)
+		if tc.expectErr && (err == nil) {
+			t.Errorf("expected error for node name \"%s\", but no error returned",
+				tc.nodename)
+		} else if !tc.expectErr && (err != nil) {
+			t.Error(err)
+		}
+	}
+}

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -28,6 +28,8 @@ import (
 const (
 	CRISocket  = "/var/run/crio/crio.sock"
 	SUSECNIDir = "/usr/lib/cni"
+	// MaxNodeNameLength is the maximum node name length accepted by kubelet.
+	MaxNodeNameLength = 63
 )
 
 func KubeadmInitConfFile() string {


### PR DESCRIPTION
## Why is this PR needed?

This PR fixes the bug when kubelet is rejecting the node name or the disarm job name because they exceed the 63 characters limit.

Fixes bsc#1145568

## What does this PR do?

This PR introduces the following changes:

* using the node name from CLI arguments as the node name for kubelet
* ensuring that it does not exceed the 63 characters limit
* using the SHA1 sum of the node name as the suffix of the disarm job name, so it does not exceed the 63 characters limit

### Status **BEFORE** applying the patch

The issue can be reproduced by:

* creating the cluster in which hostnames are longer than 63 characters
* creating the cluster in which hostnames after applying the `caasp-kubelet-disarm-` prefix is longer than 63 characters, so the disarm job name is too long for kubelet

### Status **AFTER** applying the patch

The issue should not occur anymore.