### PR TITLE
Wait for nodes to be Ready (bsc#1145771)

### DIFF
--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -134,6 +134,14 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		return err
 	}
 
+	// finally wait for the node to be in Ready state
+	err = target.Apply(nil,
+		"kubernetes.wait-for-node-ready",
+	)
+	if err != nil {
+		return err
+	}
+
 	fmt.Printf("[bootstrap] successfully bootstrapped node %q with Kubernetes: %q\n", target.Target, versionToDeploy.String())
 	return nil
 }

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -74,6 +74,7 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 		"kubeadm.join",
 		"cni.cilium-update-configmap",
 		"skuba-update.start",
+		"kubernetes.wait-for-node-ready",
 	}
 
 	client, err := kubernetes.GetAdminClientSet()


### PR DESCRIPTION
## Why is this PR needed?

In the e2e tests we realized that a node is not immediately Ready after
bootstrap/join.

Skuba should check and wait for the node to become Ready before
returning from the procedure.

This ensures that a node is ready to be used right away, and we won't
have to add this check in every e2e test. Customers that script their
deployments will also not have to take care about a busy loop for the
nodes to be in Ready state

## What does this PR do?

Adds a dynamic timeout post bootstrap/join to wait for a node to become `Ready`

## Anything else a reviewer needs to know?

Life is good

## Info for QA

Bootstrap/Join should not finish before a node is in `Ready` state.

### Related info

According to @drpaneas when adding new nodes, it approximately takes 1min more for a node to become `Ready` after a join. So the rule of thumb for the timeout is +60s for every new node of a cluster.

### Status **BEFORE** applying the patch

Run bootstrap/join and immediately afterwards the node stays in `NotReady` state.

### Status **AFTER** applying the patch

Run bootstrap/join and immediately afterwards the node is in `Ready` state.

## Docs

N/A

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
