### PR TITLE
Made it so skuba is built in conformance pipeline

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     stages {
         stage('Getting Ready For Cluster Deployment') { steps {
             sh(script: 'make -f skuba/ci/Makefile pre_deployment', label: 'Pre Deployment')
+            sh(script: 'cd skuba; make install; cd ../', label: 'Install skuba')
         } }
 
         stage('Cluster Deployment') { steps {


### PR DESCRIPTION
## Why is this PR needed?

Recent changes to how skuba is built in pipelines is causing the conformance pipelines to fail

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.


## What does this PR do?

Uses the new way to build skuba in the conformance pipeline
