### PR TITLE
Make libvirt tfvars example more complete

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -37,6 +37,14 @@ password = "linux"
 # }
 repositories = {}
 
+# define the repositories to use for the loadbalancer node
+# EXAMPLE:
+# repositories = {
+#   repository1 = "http://example.my.repo.com/repository3/"
+#   repository2 = "http://example.my.repo.com/repository4/"
+# }
+lb_repositories = {}
+
 # Minimum required packages. Do not remove them.
 # Feel free to add more packages
 packages = [

--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -21,6 +21,14 @@
         "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/",
         "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
     },
+    "lb_repositories": {
+        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/",
+        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
+        "ha_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15/x86_64/product/",
+        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/",
+        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/",
+        "ha_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15/x86_64/update/"
+    },
     "packages": [
         "kernel-default",
         "-kernel-default-base",


### PR DESCRIPTION
## Why is this PR needed?

For making it easier to adapt the libvirt terraform files to own needes.

## What does this PR do?

Mention the "lb_repositories" setting, which allows to specific repos
specifically for the load balancer node. The loadbalancer node needs at
least the SLE-15 Basesystem and the HA addon (for haproxy).

