### PR TITLE
Add e2e pipeline

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -80,3 +80,9 @@ test_upgrade_apply_from_previous:
 .PHONY: test_upgrade_apply_user_lock
 test_upgrade_apply_user_lock:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_user_lock
+
+.PHONY: test_pr_e2e
+test_pr:
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_cilium.py
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_deployments.py
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -27,6 +27,7 @@ def setup(request, platform, skuba):
 def provision(request, platform):
     platform.provision()
     def cleanup():
+        platform.gather_logs()
         platform.cleanup()
     request.addfinalizer(cleanup)
 

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -13,6 +13,7 @@
         - '{name}-code-author'
         - '{name}-handle-pr'
         - '{name}-jjb-validation'
+        - '{name}-e2e'
 
 - project:
       name: caasp-jobs/caasp-v4-openstack

--- a/ci/jenkins/pipelines/prs/skuba-e2e.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-e2e.Jenkinsfile
@@ -1,0 +1,94 @@
+/**
+ * This pipeline runs any e2e test parametrized
+ */
+
+pipeline {
+    agent { node { label 'caasp-team-private' } }
+
+    environment {
+        SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
+        OPENSTACK_OPENRC = credentials('ecp-openrc')
+        GITHUB_TOKEN = credentials('github-token')
+        VMWARE_ENV_FILE = credentials('vmware-env')
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
+        PR_CONTEXT = 'jenkins/skuba-test'
+        PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
+        REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
+    }
+
+    stages {
+        stage('Jenkins Worker Info') {
+            steps {
+                sh(script: "make -f skuba/ci/Makefile info", label: 'Info')
+            }
+        }
+
+        stage('Setting GitHub in-progress status') {
+            steps {
+                sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")
+            }
+        }
+
+        stage('Git Clone') {
+            steps {
+                deleteDir()
+                checkout([$class: 'GitSCM',
+                          branches: [[name: "*/${BRANCH_NAME}"], [name: '*/master']],
+                          doGenerateSubmoduleConfigurations: false,
+                          extensions: [[$class: 'LocalBranch'],
+                                       [$class: 'WipeWorkspace'],
+                                       [$class: 'RelativeTargetDirectory', relativeTargetDir: 'skuba']],
+                          submoduleCfg: [],
+                          userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/PR-*',
+                                               credentialsId: 'github-token',
+                                               url: 'https://github.com/SUSE/skuba']]])
+
+                dir("${WORKSPACE}/skuba") {
+                    sh(script: "git checkout ${BRANCH_NAME}", label: "Checkout PR Branch")
+                }
+            }
+        }
+
+        stage('Getting Ready For Cluster Deployment') {
+            steps {
+                sh(script: 'make -f skuba/ci/Makefile pr_checks', label: 'PR Checks')
+                sh(script: "pushd skuba; make -f Makefile install; popd", label: 'Build Skuba')
+            }
+        }
+
+        stage('Run Skuba e2e Test') {
+            steps {
+                sh(script: 'make -f skuba/ci/Makefile test_pr_e2e', label: 'test_pr_e2e')
+                archiveArtifacts("skuba/ci/infra/${PLATFORM}/terraform.tfstate")
+                archiveArtifacts("skuba/ci/infra/${PLATFORM}/terraform.tfvars.json")
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts("testrunner_logs/**/*")
+            sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')
+        }
+        cleanup {
+            dir("${WORKSPACE}@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}") {
+                deleteDir()
+            }
+        }
+        failure {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
+        success {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'success'", label: "Sending success status")
+        }
+    }
+}

--- a/ci/jenkins/templates/e2e-pr-template.yaml
+++ b/ci/jenkins/templates/e2e-pr-template.yaml
@@ -1,0 +1,27 @@
+- job-template:
+      name: '{name}-e2e'
+      project-type: multibranch
+      periodic-folder-trigger: 5m
+      number-to-keep: 30
+      days-to-keep: 30
+      script-path: ci/jenkins/pipelines/prs/skuba-e2e.Jenkinsfile
+      wrappers:
+          - timeout:
+                timeout: 120
+                fail: true
+      parameters:
+          - string:
+                name: PLATFORM
+                default: '{platform}'
+                description: The platform to perform the tests on
+      scm:
+          - github:
+                repo: '{repo-name}'
+                repo-owner: '{repo-owner}'
+                credentials-id: '{repo-credentials}'
+                branch-discovery: no-pr
+                disable-pr-notifications: true
+                discover-pr-forks-strategy: current
+                discover-pr-forks-trust: contributors
+                discover-pr-origin: current
+                head-filter-regex: ^(master|release\-\d\.\d|PR\-\d+)$


### PR DESCRIPTION
## Why is this PR needed?

We want to run the testrunner pytest tests against prs. At this time though we're not sure if we want to disable the Ginkgo ones.

Fixes #

## What does this PR do?

Creates a new pipeline to run the testrunner pytest tests.

## Anything else a reviewer needs to know?
