### PR TITLE
Add skuba binary path to conformance test pipe

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
     agent { node { label 'caasp-team-private' } }
 
     environment {
+        SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
         GITHUB_TOKEN = credentials('github-token')


### PR DESCRIPTION
## Why is this PR needed?

Otherwise skuba build can't be found

```
Exception executing testrunner command 'bootstrap': skuba not found at /home/jenkins/workspace/caasp-jobs/caasp-v4-openstack-conformance/go/bin/skuba
```

## What does this PR do?

set's the correct env to find the skuba binary

## Anything else a reviewer needs to know?

it's a follow up for https://github.com/SUSE/skuba/pull/619
