### PR TITLE
Make sure to remove the built skuba

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -77,6 +77,7 @@ pipeline {
             dir("${WORKSPACE}") {
                 deleteDir()
             }
+            sh(script: "rm -f ${SKUBA_BIN_PATH}; ", label: 'Remove built skuba')
         }
         failure {
             sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
             dir("${WORKSPACE}") {
                 deleteDir()
             }
+            sh(script: "rm -f ${SKUBA_BINPATH}; ", label: 'Remove built skuba')
         }
     }
 }

--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
             dir("${WORKSPACE}") {
                 deleteDir()
             }
+            sh(script: "rm -f ${SKUBA_BINPATH}; ", label: 'Remove built skuba')
        }
     }
 }

--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -44,6 +44,7 @@ pipeline {
            dir("${WORKSPACE}") {
                deleteDir()
            }
+           sh(script: "rm -f ${SKUBA_BIN_PATH}; ", label: 'Remove built skuba')
        }
     }
 }


### PR DESCRIPTION


## Why is this PR needed?

The skuba binary we build during the tests was being left behind.

## What does this PR do?

Deletes the skuba binary during cleanup on the Jenkins workers

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
