### PR TITLE
Updated to state permanent removal of node

### DIFF
--- a/docs/man/skuba-node-remove.1.md
+++ b/docs/man/skuba-node-remove.1.md
@@ -9,7 +9,9 @@ remove - remove a node to a state prior to join or bootstrap
 *remove* *node-name*
 
 # DESCRIPTION
-**remove** will remove a node from the cluster via kubernetes
+**remove** will permanently remove a node from the cluster via kubernetes.  Note that this node 
+cannot be added back to the cluster or any other skuba-initiated kubernetes cluster without 
+reinstalling first.
 
 # OPTIONS
 


### PR DESCRIPTION
## Why is this PR needed?

Response to [AG#699](https://github.com/SUSE/avant-garde/issues/699).   Clearly indicates that node removal is permanent.

Fixes #

[AG#699](https://github.com/SUSE/avant-garde/issues/699)


## What does this PR do?

Improves `skuba node remove` manpage to clearly indicate that node removal is permanent.

## Docs

https://github.com/SUSE/doc-caasp/pull/429
