### PR TITLE
Collect node logs after e2e tests

### DIFF
--- a/ci/infra/testrunner/tests/README.md
+++ b/ci/infra/testrunner/tests/README.md
@@ -9,7 +9,7 @@ Following pytest's standard test organization, tests must be defined in python f
 See the following example:
 
 ```
-def test_add_worker(setup, skuba):
+def test_add_worker(bootstrap, skuba):
     skuba.node_join(role="worker", nr=0)
     masters = skuba.num_of_nodes("master")
     workers = skuba.num_of_nodes("worker")

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -16,6 +16,7 @@ def pytest_addoption(parser):
 def provision(request, platform):
     platform.provision()
     def cleanup():
+        platform.gather_logs()
         platform.cleanup()
     request.addfinalizer(cleanup)
 

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -12,17 +12,6 @@ def pytest_addoption(parser):
     parser.addoption("--vars", action="store",help="vars yaml" )
     parser.addoption("--platform", action="store",help="target platform" )
 
-# TODO: Deprecated. Remove from tests
-@pytest.fixture
-def setup(request, platform, skuba):
-    platform.provision()
-    def cleanup():
-        platform.cleanup()
-    request.addfinalizer(cleanup)
-
-    skuba.cluster_init()
-    skuba.node_bootstrap()
-
 @pytest.fixture
 def provision(request, platform):
     platform.provision()

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -27,7 +27,7 @@ def setup_kubernetes_version(skuba, kubectl, kubernetes_version=None):
     kubectl.run_kubectl("wait --for=condition=ready nodes --all --timeout=5m")
 
 
-def test_upgrade_plan_all_fine(setup, skuba, kubectl):
+def test_upgrade_plan_all_fine(bootstrap, skuba, kubectl):
     """
     Starting from a up-to-date cluster, check what cluster/node plan report.
     """
@@ -40,7 +40,7 @@ def test_upgrade_plan_all_fine(setup, skuba, kubectl):
     ) != -1
 
 
-def test_upgrade_plan_from_previous(setup, skuba, kubectl):
+def test_upgrade_plan_from_previous(bootstrap, skuba, kubectl):
     """
     Starting from an outdated cluster, check what cluster/node plan report.
     """
@@ -83,7 +83,7 @@ def test_upgrade_plan_from_previous(setup, skuba, kubectl):
     assert worker.find("Node my-worker-0 is up to date")
 
 
-def test_upgrade_apply_all_fine(setup, platform, skuba, kubectl):
+def test_upgrade_apply_all_fine(bootstrap, platform, skuba, kubectl):
     """
     Starting from a up-to-date cluster, check what node upgrade apply reports.
     """
@@ -107,7 +107,7 @@ def test_upgrade_apply_all_fine(setup, platform, skuba, kubectl):
     ) != -1
 
 
-def test_upgrade_apply_from_previous(setup, platform, skuba, kubectl):
+def test_upgrade_apply_from_previous(bootstrap, platform, skuba, kubectl):
     """
     Starting from an outdated cluster, check what node upgrade apply reports.
     """
@@ -126,7 +126,7 @@ def test_upgrade_apply_from_previous(setup, platform, skuba, kubectl):
     assert worker.find("successfully upgraded") != -1
 
 
-def test_upgrade_apply_user_lock(setup, platform, kubectl, skuba):
+def test_upgrade_apply_user_lock(bootstrap, platform, kubectl, skuba):
     """
     Starting from an outdated cluster, check what node upgrade apply reports.
     """

--- a/ci/infra/testrunner/tests/test_workers.py
+++ b/ci/infra/testrunner/tests/test_workers.py
@@ -2,7 +2,7 @@ from skuba import Skuba
 import pytest
 import time
 
-def test_add_worker(setup, skuba):
+def test_add_worker(bootstrap, skuba):
    skuba.node_join(role="worker", nr=0)
    masters = skuba.num_of_nodes("master")
    workers = skuba.num_of_nodes("worker")


### PR DESCRIPTION
## Why is this PR needed?

We are destroying the cluster before collecting logs that could help us debug issues.

## What does this PR do?

Removed the deprecated setup fixture and added gather logs before cleaning up the cluster. 

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
