### PR TITLE
Skuba auth login supports multiple connectors (bsc#1145878)

### DIFF
--- a/docs/man/skuba-auth-login.1.md
+++ b/docs/man/skuba-auth-login.1.md
@@ -6,8 +6,8 @@ login - Authenticate to a cluster and authorized with kubeconfig
 # SYNOPSIS
 **login**
 [**--help**|**-h**] [**--server|-s**] [**--username|-u**]
-[**--password|-p**] [**--root-ca**|**-r**] [**--insecure**|**-k**]
-[**--cluster-name**|**-n**] [**--kubeconfig**|**-c**]
+[**--password|-p**] [**--auth-connector|-a**] [**--root-ca**|**-r**]
+[**--insecure**|**-k**] [**--cluster-name**|**-n**] [**--kubeconfig**|**-c**]
 *login* [--server https://<ip/fqdn>:<port>] [--username username] [--password password]
 
 # DESCRIPTION
@@ -26,6 +26,9 @@ login - Authenticate to a cluster and authorized with kubeconfig
 
 **--password, -p**
   The authentication password
+
+**--auth-connector, -a**
+  The authentication connector ID
 
 **--root-ca, -r**
   The cluster root certificate authority chain file

--- a/internal/app/skuba/auth/login.go
+++ b/internal/app/skuba/auth/login.go
@@ -99,6 +99,7 @@ func NewLoginCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&cfg.DexServer, "server", "s", "", "OIDC dex server url https://<IP/FQDN>:<Port> (required)")
 	cmd.Flags().StringVarP(&cfg.Username, "username", "u", "", "Username")
 	cmd.Flags().StringVarP(&cfg.Password, "password", "p", "", "Password")
+	cmd.Flags().StringVarP(&cfg.AuthConnector, "auth-connector", "a", "", "Authentication connector ID")
 	cmd.Flags().StringVarP(&cfg.RootCAPath, "root-ca", "r", "", "Root certificate authority chain file")
 	cmd.Flags().BoolVarP(&cfg.InsecureSkipVerify, "insecure", "k", false, "Insecure SSL connection")
 	cmd.Flags().StringVarP(&cfg.ClusterName, "cluster-name", "n", "local", "Kubernetes cluster name")

--- a/pkg/skuba/actions/auth/auth_test.go
+++ b/pkg/skuba/actions/auth/auth_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package auth
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_processSingleConnector(t *testing.T) {
+	tests := []struct {
+		name              string
+		body              string
+		expectedConnector connector
+	}{
+		{
+			name: "single connector",
+			body: `
+			<!DOCTYPE html>
+			<html>
+				<head>
+				<title>SUSE CaaS Platform</title>
+				</head>
+				<body class="theme-body">
+				<div class="theme-navbar">
+					<div class="theme-navbar__logo-wrap">
+						<img class="theme-navbar__logo" src="https://10.86.4.17:32000/theme/logo.png">
+					</div>
+				</div>
+				<div class="dex-container">
+				<div class="theme-panel">
+				<h2 class="theme-heading">Log in to Your Account</h2>
+				<form method="post" action="/auth/ldap000?req=yfzclhtr4twoqqvixmdt75goe">
+				<div class="theme-form-row">
+					<div class="theme-form-label">
+						<label for="userid">Email Address</label>
+					</div>
+					<input tabindex="1" required id="login" name="login" type="text" class="theme-form-input" placeholder="email address"  autofocus />
+				</div>
+				<div class="theme-form-row">
+					<div class="theme-form-label">
+						<label for="password">Password</label>
+					</div>
+					<input tabindex="2" required id="password" name="password" type="password" class="theme-form-input" placeholder="password" />
+				</div>		
+				<button tabindex="3" id="submit-login" type="submit" class="dex-btn theme-btn--primary">Login</button>
+				</form>	
+				</body>
+			</html>
+			`,
+			expectedConnector: connector{
+				id:  "ldap000",
+				url: "/auth/ldap000?req=yfzclhtr4twoqqvixmdt75goe",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotConnectors := processSingleConnector(strings.NewReader(tt.body))
+
+			if !reflect.DeepEqual(gotConnectors, tt.expectedConnector) {
+				t.Errorf("got %v, want %v", gotConnectors, tt.expectedConnector)
+				return
+			}
+		})
+	}
+}
+
+func Test_processMultipleConnectors(t *testing.T) {
+	tests := []struct {
+		name               string
+		body               string
+		expectedConnectors []connector
+	}{
+		{
+			name: "multiple connectors",
+			body: `
+				<!DOCTYPE html>
+				<html>
+					<head>
+					<title>SUSE CaaS Platform</title>
+					</head>
+					<body class="theme-body">
+					<div class="dex-container">
+						<div class="theme-panel">
+							<h2 class="theme-heading">Log in to SUSE CaaS Platform</h2>
+							<div>
+							<div class="theme-form-row">
+								<a href="/auth/local?req=ft6cvb6b4om3y7cbe3ncfw6mf" target="_self">
+								<button class="dex-btn theme-btn-provider">
+									<span class="dex-btn-icon dex-btn-icon--local"></span>
+									<span class="dex-btn-text">Log in with Email</span>
+								</button>
+								</a>
+							</div>
+							<div class="theme-form-row">
+								<a href="/auth/ldap?req=ft6cvb6b4om3y7cbe3ncfw6mf" target="_self">
+								<button class="dex-btn theme-btn-provider">
+									<span class="dex-btn-icon dex-btn-icon--ldap"></span>
+									<span class="dex-btn-text">Log in with openLDAP</span>
+								</button>
+								</a>
+							</div>
+						</div>
+					</div>
+					</body>
+				</html>
+				`,
+			expectedConnectors: []connector{
+				{
+					id:  "local",
+					url: "/auth/local?req=ft6cvb6b4om3y7cbe3ncfw6mf",
+				},
+				{
+					id:  "ldap",
+					url: "/auth/ldap?req=ft6cvb6b4om3y7cbe3ncfw6mf",
+				},
+			},
+		},
+		{
+			name: "no connector found",
+			body: `
+				<!DOCTYPE html>
+				<html>
+					<head>
+					<title>SUSE CaaS Platform</title>
+					</head>
+					<body class="theme-body">
+					<div class="dex-container">
+						<div class="theme-panel">
+							<h2 class="theme-heading">Log in to SUSE CaaS Platform</h2>
+							<div>
+						</div>
+					</div>
+					</body>
+				</html>
+				`,
+			expectedConnectors: []connector{},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			gotConnectors := processMultipleConnectors(strings.NewReader(tt.body))
+
+			if !reflect.DeepEqual(gotConnectors, tt.expectedConnectors) {
+				t.Errorf("got %v, want %v", gotConnectors, tt.expectedConnectors)
+				return
+			}
+		})
+	}
+}
+
+func Example_printConnectors() {
+	c := []connector{
+		{id: "local", url: "/auth/local?req=ft6cvb6b4om3y7cbe3ncfw6mf"},
+		{id: "ldap", url: "/auth/ldap?req=ft6cvb6b4om3y7cbe3ncfw6mf"},
+	}
+	printConnectors(c)
+
+	// Output:
+	// Available authentication connector IDs are:
+	//   local
+	//   ldap
+}

--- a/pkg/skuba/actions/auth/login.go
+++ b/pkg/skuba/actions/auth/login.go
@@ -49,6 +49,7 @@ type LoginConfig struct {
 	Password           string
 	RootCAPath         string
 	InsecureSkipVerify bool
+	AuthConnector      string
 	ClusterName        string
 	KubeConfigPath     string
 	Debug              bool
@@ -79,6 +80,7 @@ func Login(cfg LoginConfig) (*clientcmdapi.Config, error) {
 		Password:           cfg.Password,
 		RootCAData:         rootCAData,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
+		AuthConnector:      cfg.AuthConnector,
 		Debug:              cfg.Debug,
 	})
 	if err != nil {

--- a/pkg/skuba/actions/auth/testing.go
+++ b/pkg/skuba/actions/auth/testing.go
@@ -105,11 +105,50 @@ func openIDHandlerNoScopes() func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func authHandler() func(w http.ResponseWriter, r *http.Request) {
+func authSingleConnectorHandler() func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		url := fmt.Sprintf("%s://%s", defaultScheme, r.Host)
 
 		http.Redirect(w, r, fmt.Sprintf("%s/auth/local", url)+"?req="+newID(), http.StatusFound)
+	}
+}
+
+func authMultipleConnectorsHandler() func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		htmlOutput := fmt.Sprintf(`
+		<!DOCTYPE html>
+		<html>
+  		<head>
+    		<title>SUSE CaaS Platform</title>
+  		</head>
+  		<body class="theme-body">
+    		<div class="dex-container">
+			<div class="theme-panel">
+  				<h2 class="theme-heading">Log in to SUSE CaaS Platform </h2>
+  				<div>
+					<div class="theme-form-row">
+						<a href="/auth/local?req=ocg6tiqn525sadbm2ul6h77mk" target="_self">
+							<button class="dex-btn theme-btn-provider">
+								<span class="dex-btn-icon dex-btn-icon--local"></span>
+								<span class="dex-btn-text">Log in with Email</span>
+							</button>
+						</a>
+					</div>
+					<div class="theme-form-row">
+						<a href="/auth/ldap?req=ocg6tiqn525sadbm2ul6h77mk" target="_self">
+							<button class="dex-btn theme-btn-provider">
+								<span class="dex-btn-icon dex-btn-icon--ldap"></span>
+								<span class="dex-btn-text">Log in with openLDAP</span>
+							</button>
+						</a>
+					</div>
+  				</div>
+			</div>
+    		</div>
+		</body>
+		</html>		
+		`)
+		_, _ = w.Write([]byte(htmlOutput))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

Right now, `skuba auth login` does not support dex server with multiple authentication connectors.
Therefore, when dex with multiple connectors setting, `skuba auth login` always failed.

Fixes [bsc#1145878](https://bugzilla.suse.com/show_bug.cgi?id=1145878)

## What does this PR do?

1. Add a new flag `auth-connector` to let the user specifying the dex authentication connector ID.
If the user does not provide it and dex currently in multiple connectors setting, `skuba auth login` would bump out interactive user input connector ID. Like this:
```
Available authentication connector IDs are:
  local
  ldap

Enter authentication connector ID:
```

2. How to know dex with single connector/multiple connectors setting?
`skuba auth login` would parse the response body.

  - If contains `required id="password"`, it's single connector.
  - If contains `dex-btn-icon--`, it's multiple connectors

## Anything else a reviewer needs to know?

Test cases at [confluence page](https://confluence.suse.com/pages/viewpage.action?pageId=271352458#Authentication&RBACTestCases-MultipleConnectors).

## Info for QA

### Related info

N/A

### Status **BEFORE** applying the patch

1. Dex configures multiple connectors (local database + external LDAP database)
2. Use `skuba auth login` to get kubeconfig
3. It could not authentication success either use local database username/password or external LDAP database username/password

### Status **AFTER** applying the patch

1. Dex configures multiple connectors (local database + external LDAP database)
2. Use `skuba auth login` to get kubeconfig. The user could specifying authentication connector ID by flag `--auth-connector`. If the user does not provide flag, `skuba auth login` would bump out interactive user input authentication connector ID.
3. `skuba auth login` success with specifying authentication connector ID.

## Docs

`skuba auth login` command manpage document updated.

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
