### PR TITLE
Added ability to skip deployment steps

### DIFF
--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -170,7 +170,12 @@ def main():
                            help="only list tests to be executed")
     test_args.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
                            help="show all output")
-    test_args.add_argument("--skip-setup", help="setup step to skip")
+    test_args.add_argument("--skip-setup",
+                           choices=['provisioned', 'bootstrapped', 'deployed'],
+                           help="Skip the given setup step.\n"
+                                "'provisioned' For when you have already provisioned the nodes.\n"
+                                "'bootstrapped' For when you have already bootstrapped the cluster.\n"
+                                "'deployed' For when you already have a fully deployed cluster.")
     cmd_test = commands.add_parser(
         "test", parents=[test_args], help="execute tests")
     cmd_test.set_defaults(func=test)

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -74,7 +74,8 @@ def node_upgrade(options):
 
 def test(options):
     TestDriver(options.conf, options.platform).run(test_suite=options.test_suite, test=options.test,
-                                                   verbose=options.verbose, collect=options.collect)
+                                                   verbose=options.verbose, collect=options.collect,
+                                                   skip_setup=options.skip_setup)
 
 
 def ssh(options):
@@ -169,6 +170,7 @@ def main():
                            help="only list tests to be executed")
     test_args.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
                            help="show all output")
+    test_args.add_argument("--skip-setup", help="setup step to skip")
     cmd_test = commands.add_parser(
         "test", parents=[test_args], help="execute tests")
     cmd_test.set_defaults(func=test)

--- a/ci/infra/testrunner/tests/driver.py
+++ b/ci/infra/testrunner/tests/driver.py
@@ -17,7 +17,7 @@ class TestDriver:
         self.conf = conf
         self.platform = platform
         
-    def run(self, module="tests", test_suite=None, test=None, verbose=False, collect=False):
+    def run(self, module="tests", test_suite=None, test=None, verbose=False, collect=False, skip_setup=None):
         
         opts = []
         
@@ -32,6 +32,9 @@ class TestDriver:
 
         if collect:
             opts.append(PyTestOpts.COLLECT_TESTS)
+
+        if skip_setup is not None:
+            opts.append(f"--skip-setup={skip_setup}")
 
         test_path = module
 


### PR DESCRIPTION

## Why is this PR needed?

Using the `--skip-setup` arg when running tests you can now skip different deployment
 stages during setup.

Previously the test would setup and teardown a cluster each time.

Fixes https://github.com/SUSE/avant-garde/issues/789

## What does this PR do?

Adds the `--skip-setup` arg

## Anything else a reviewer needs to know?

I manually tested all the different choices

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
