### PR TITLE
Added reboot node tests

### DIFF
--- a/ci/infra/testrunner/tests/driver.py
+++ b/ci/infra/testrunner/tests/driver.py
@@ -10,6 +10,8 @@ class PyTestOpts:
 
     SHOW_OUTPUT = "-s"
 
+    VERBOSE = "-v"
+
     COLLECT_TESTS = "--collect-only"
 
     JUNIT = f"--junitxml={TESTRUNNER_DIR}/results.xml"
@@ -33,6 +35,7 @@ class TestDriver:
 
         if verbose:
             opts.append(PyTestOpts.SHOW_OUTPUT)
+            opts.append(PyTestOpts.VERBOSE)
 
         if collect:
             opts.append(PyTestOpts.COLLECT_TESTS)

--- a/ci/infra/testrunner/tests/test_node_reboot.py
+++ b/ci/infra/testrunner/tests/test_node_reboot.py
@@ -1,0 +1,71 @@
+import logging
+import json
+import time
+
+import pytest
+from timeout_decorator import timeout
+
+logger = logging.getLogger("testrunner")
+
+
+@timeout(120)
+def wait_for_node_reboot(node_type, node_number, platform):
+    while True:
+        try:
+            platform.ssh_run(node_type, node_number, 'echo hello')
+        except Exception as ex:
+            logger.debug(ex)
+        else:
+            break
+
+        time.sleep(5)
+
+
+@timeout(120)
+def check_nodes_ready(kubectl):
+    while True:
+        try:
+            kubectl.run_kubectl('wait --for=condition=Ready node --all')
+        except Exception as ex:
+            logger.debug(ex)
+        else:
+            break
+
+        time.sleep(5)
+
+
+@timeout(120)
+def check_pods_ready(kubectl):
+    while True:
+        try:
+            pods = json.loads(kubectl.run_kubectl('get pods --all-namespaces -o json'))['items']
+
+            for pod in pods:
+                pod_status = pod['status']['phase']
+                assert pod_status in ['Running', 'Completed'], f'Pod {pod["metadata"]["name"]} status {pod_status} != Running or Completed'
+        except Exception as ex:
+            logger.debug(ex)
+        else:
+            break
+
+        time.sleep(5)
+
+
+@pytest.mark.parametrize('node_type,node_number', [('master', 1), ('worker', 0)])
+def test_hard_reboot(deployment, platform, skuba, kubectl, node_type, node_number):
+    assert skuba.num_of_nodes(node_type) > node_number
+
+    logger.info('Wait for all the nodes to be ready')
+    kubectl.run_kubectl('wait --for=condition=Ready node --all --timeout=5m')
+
+    logger.info(f'Rebooting {node_type} {node_number}')
+
+    platform.ssh_run(node_type, node_number, 'sudo reboot &')
+
+    # Give the reboot a bit to start
+    logger.info(f'Waiting 30s...')
+    time.sleep(30)
+
+    wait_for_node_reboot(node_type, node_number, platform)
+    check_nodes_ready(kubectl)
+    check_pods_ready(kubectl)


### PR DESCRIPTION
## Why is this PR needed?

We want to test that rebooting a node doesn't break the cluster

Fixes https://github.com/SUSE/avant-garde/issues/264


## What does this PR do?

Adds tests for the different node types that reboots them then waits to see if they come back up and are ready again.

# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
