### PR TITLE
Lower timeout on loadbalancer monitor (bsc#1148090)

### DIFF
--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -84,7 +84,7 @@ resource "openstack_lb_monitor_v2" "kube_api_monitor" {
   url_path       = "/healthz"
   expected_codes = 200
   delay          = 10
-  timeout        = 5
+  timeout        = 1
   max_retries    = 3
 }
 
@@ -94,7 +94,7 @@ resource "openstack_lb_monitor_v2" "gangway_monitor" {
   url_path       = "/"
   expected_codes = 200
   delay          = 10
-  timeout        = 5
+  timeout        = 1
   max_retries    = 3
 }
 
@@ -104,6 +104,6 @@ resource "openstack_lb_monitor_v2" "dex_monitor" {
   url_path       = "/healthz"
   expected_codes = 200
   delay          = 10
-  timeout        = 5
+  timeout        = 1
   max_retries    = 3
 }


### PR DESCRIPTION
## Why is this PR needed?

During the upgrade, especially after the 1st master has been
upgraded, there is a time window where kube-apiserver is
restarted, and no more traffic should be routed to the load
balancer.

Fixes https://github.com/SUSE/avant-garde/issues/794

## What does this PR do?

Decreasing the timeout forces an early ping timeout and
therefore marks the master node as INACTIVE and the request
is going to an ACTIVE master instead.

## Anything else a reviewer needs to know?

This just happens in a scripted environment where the time windows are very small.
It was found in one of the upgrade e2e tests, and should not happen in a normal (non-scripted) user scenario.

## Info for QA

Run the upgrade e2e test: `test_upgrade_apply_from_previous`

https://github.com/SUSE/skuba/blob/master/ci/infra/testrunner/tests/test_skuba_upgrade.py#L129-L150

### Related info

Nightly CI job: https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/e2e/job/caasp-v4-openstack-test_upgrade_apply_from_previous-nightly/

### Status **BEFORE** applying the patch

2nd master during upgrade fails with:

```
Unable to apply node upgrade: Get https://10.86.4.78:6443/api/v1/nodes: net/http: TLS handshake timeout
```

### Status **AFTER** applying the patch

Upgrade works fine.
