### PR TITLE
Deployment test now cleans up after itself

### DIFF
--- a/ci/infra/testrunner/tests/test_deployments.py
+++ b/ci/infra/testrunner/tests/test_deployments.py
@@ -1,8 +1,5 @@
 import pytest
-import json
 import requests
-
-from kubectl import Kubectl
 
 
 def test_nginx_deployment(deployment, kubectl):
@@ -24,3 +21,13 @@ def test_nginx_deployment(deployment, kubectl):
     r = requests.get(url)
 
     assert "Welcome to nginx" in r.text
+
+    # Cleanup
+    kubectl.run_kubectl("delete --wait --timeout=60s service/nginx")
+    kubectl.run_kubectl("delete --wait --timeout=60s deployments/nginx")
+
+    with pytest.raises(Exception):
+        kubectl.run_kubectl("get service/nginx")
+
+    with pytest.raises(Exception):
+        kubectl.run_kubectl("get deployments/nginx")


### PR DESCRIPTION
## Why is this PR needed?

The deployments test was not cleaning up after itself

Fixes #

## What does this PR do?

Removes the deployment and the service at the end of the test

## Anything else a reviewer needs to know?


# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
