### PR TITLE
Print stderr when running shell commands

### DIFF
--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -195,8 +195,8 @@ class Utils:
         p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True,
                  env=env, cwd=cwd)
         logger.debug(p.stdout.decode())
+        logger.error(p.stderr.decode())
         if p.returncode != 0:
-            logger.error(p.stderr)
             if not ignore_errors:
                 raise RuntimeError("Error executing command {}".format(cmd))
         return p.stdout.decode()


### PR DESCRIPTION
## Why is this PR needed?

Some commands, like skuba, print usefull debug level
information to stderr instead of stdout. 

## What does this PR do?

When running those commands, testrunner should print stderr
regardless there was an error executing the command or not.
