### PR TITLE
Allow long code in commit messages

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
@@ -75,7 +75,20 @@ class PrChecks:
                 print('Commit message body is too short')
                 sys.exit(1)
 
-            for body_line in body.splitlines():
+            # strip multi-line '```code```' blocks & lines starting w\ `code`
+            code_pattern = re.compile(
+                r'''
+                 ((?m:^)\s*```)  # multi-line beginning, 0-more whitespace, ```
+                 (?s:.*?)        # non-greedy, zero or more chars, including \n
+                 \1              # whatever matched at the beginning
+                 |               # or...
+                 (?m:^)\s*`      # start of line, optional whitespace, backtick
+                 [^`]+           # oneor more non-backtick chars
+                 `\s*(?m:$)      # and a backtick at the end of the line
+                ''',
+                re.VERBOSE
+                )
+            for body_line in re.sub(code_pattern, '', body).splitlines():
                 if len(body_line) > 72:
                     print('Each line in the commit body should be less than 72 characters')
                     sys.exit(1)


### PR DESCRIPTION
If a long line is inside a code block
```
  like this really long line with a lot of words on the same line that push the length of the line over 72 chars
```
then the line will be allowed.  It'll also be allowed on a
`line with backticks`
in case that makes more sense.

## Why is this PR needed?

Sometimes it makes sense to leave long lines in a commit message.  When including code, for example.  While many tools don't respect markdown formatting in git commit messages, it makes sense to allow a developer to indicate intentionally long lines v/s an error in commit editor configuration.  The semi-standard backtick notations for code seem to me as if they might be a good way to do that.

## What does this PR do?

This code introduces a regex which removes code blocks from the commit body when checking for commit body line length.  That allows a developer to leave long lines in commit messages when necessary, while still facilitating the line length check in "regular" text.

## Anything else a reviewer needs to know?

python3 interactive:
```
>>> import re
>>> body="""
... hello
... this is some code
... ```
...   code
... ```
... and more
... ```
...   code
...   ```
... and some `inline code`
... `other inline code` 
... end
... """
>>> code_pattern = re.compile(r'''
...               ((?m:^)\s*```)  # multi-line beginning, 0-more whitespace, ```
...               (?s:.*?)        # non-greedy, zero or more chars, including \n
...               \1              # whatever matched at the beginning
...               |               # or...
...               (?m:^)\s*`      # start of line, optional whitespace, backtick
...               [^`]+           # oneor more non-backtick chars
...               `\s*(?m:$)      # and a backtick at the end of the line
...               ''',
...               re.VERBOSE
...               )
>>> re.sub(code_pattern, '', body)
'\nhello\nthis is some code\n\nand more\n\nand some `inline code`\n\nend\n'
```

## Info for QA

N/A

### Related info

N/A (aside from _several_ discussions about the commit checks)

### Status **BEFORE** applying the patch

Long lines in commit messages are always rejected

### Status **AFTER** applying the patch

long lines inside code blocks are not rejected, while "regular" long lines are rejected

## Docs

Maybe the contribution guide should be updated?  Looking into that...


# Merge restrictions after RC

(Please do not edit this)

This is the "better safe than sorry" phase, so we will restrict who and what can be merged to prevent unexpected surprises:

    Who can merge: Release Engineers*
    What can be merged (merge criteria):
        3 approvals:
            1 developer
            1 manager (Nuno, Flavio, Klaus, Markos, Stef, David, Rafa or Jordi)
            1 QA
        there is a PR for updating documentation (or a statement that this is not needed)
        it fixes a P2 bug that has not been target for maintenance
        the impact is low: for example, it does not touch a piece of code that has an impact on all features

* *Managers will keep the permissions, but they are supposed to give approval. Merging will be done by Release Engineers because they will coordinate the release of the fix.*

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
