### PR TITLE
Fix PR got merged, CI test failed

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
@@ -36,7 +36,7 @@ def _read_config(config_path):
 def check_pr(args):
     if CHANGE_ID:
         g = Github(GITHUB_TOKEN)
-        org = g. get_organization(GITHUB_ORG)
+        org = g.get_organization(GITHUB_ORG)
         repo = g.get_repo(GITHUB_REPO)
 
         pr_checks = PrChecks(org, repo)
@@ -46,27 +46,30 @@ def check_pr(args):
         if args.check_pr_details:
             pr_checks.check_pr_details(CHANGE_ID)
     else:
-        print(f'No CHANGE_ID was set assuming this is not a PR. Skipping checks...')
+        print('No CHANGE_ID was set assuming this is not a PR. Skipping checks...')
 
 
 def filter_pr(args):
-    g = Github(GITHUB_TOKEN, per_page=1000)
-    repo = g.get_repo(GITHUB_REPO)
+    if CHANGE_ID:
+        g = Github(GITHUB_TOKEN, per_page=1000)
+        repo = g.get_repo(GITHUB_REPO)
 
-    pull = repo.get_pull(int(CHANGE_ID))
-    changed_files = pull.get_files()
-    files_list = []
+        pull = repo.get_pull(CHANGE_ID)
+        changed_files = pull.get_files()
+        files_list = []
 
-    # change paginated list to normal list
-    for f in changed_files:
-        files_list.append(f.filename)
+        # change paginated list to normal list
+        for f in changed_files:
+            files_list.append(f.filename)
 
-    if any([s for s in files_list if args.filename in s]):
-        msg = "contains"
+        if any([s for s in files_list if args.filename in s]):
+            msg = "contains"
+        else:
+            msg = "does not contain"
+
+        print(f"Pull Request {GITHUB_REPO}#{CHANGE_ID} {msg} changes for {args.filename}")
     else:
-        msg = "does not contain"
-
-    print(f"Pull Request {GITHUB_REPO}#{CHANGE_ID} {msg} changes for {args.filename}")
+        print('No CHANGE_ID was set assuming this is not a PR. Skipping filters...')
 
 
 def merge_prs(args):


### PR DESCRIPTION
check CHANGE_ID is None or not

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

PR approval and got merged, CI always test failed.

![image](https://user-images.githubusercontent.com/49380831/63839221-6442bb00-c9b1-11e9-9095-cb5a1291359d.png)

## What does this PR do?

Bypass filter_pr function when`CHANGE_ID` type is None, which means it's not a PR.

## Anything else a reviewer needs to know?

No way to test it locally, hope it will work as expected.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

N/A

### Status **AFTER** applying the patch

N/A

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
