### PR TITLE
Fix tag detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,18 @@ GOBINPATH     := $(shell $(GO) env GOPATH)/bin
 COMMIT        := $(shell git rev-parse HEAD)
 BUILD_DATE    := $(shell date +%Y%m%d)
 # TAG can be provided as an envvar (provided in the .spec file)
-TAG           ?= $(shell git show-ref --tags | grep $(COMMIT) | awk '{print $2}' | cut -d/ -f3)
-# ANNOTATED_TAG can be provided as an envvar (provided in the .spec file)
-ANNOTATED_TAG ?= $(shell git describe --tag)
-# VERSION is inferred from TAG
+TAG           ?= $(shell git describe --tags --exact-match HEAD 2> /dev/null)
+# CLOSEST_TAG can be provided as an envvar (provided in the .spec file)
+CLOSEST_TAG   ?= $(shell git describe --tags)
+# VERSION is inferred from CLOSEST_TAG
 # It accepts tags of type `vX.Y.Z`, `vX.Y.Z-(alpha|beta|rc|...)` and produces X.Y.Z
-VERSION       := $(shell echo $(TAG) | sed -E 's/v(([0-9]\.?)+).*/\1/')
+VERSION       := $(shell echo $(CLOSEST_TAG) | sed -E 's/v(([0-9]\.?)+).*/\1/')
 TAGS          := development
 PROJECT_PATH  := github.com/SUSE/skuba
 SKUBA_LDFLAGS  = -ldflags "-X=$(PROJECT_PATH)/pkg/skuba.Version=$(VERSION) \
                            -X=$(PROJECT_PATH)/pkg/skuba.BuildDate=$(BUILD_DATE) \
                            -X=$(PROJECT_PATH)/pkg/skuba.Tag=$(TAG) \
-                           -X=$(PROJECT_PATH)/pkg/skuba.AnnotatedTag=$(ANNOTATED_TAG)"
+                           -X=$(PROJECT_PATH)/pkg/skuba.ClosestTag=$(CLOSEST_TAG)"
 
 SKUBA_DIRS     = cmd pkg internal test
 
@@ -95,7 +95,7 @@ lint:
 
 .PHONY: suse-package
 suse-package:
-	ci/packaging/suse/rpmfiles_maker.sh "$(VERSION)" "$(TAG)" "$(ANNOTATED_TAG)"
+	ci/packaging/suse/rpmfiles_maker.sh "$(VERSION)" "$(TAG)" "$(CLOSEST_TAG)"
 
 .PHONY: suse-changelog
 suse-changelog:

--- a/ci/packaging/suse/rpmfiles_maker.sh
+++ b/ci/packaging/suse/rpmfiles_maker.sh
@@ -7,13 +7,13 @@ tmp_dir=$(mktemp -d -t skuba_XXXX)
 rpm_files="${susepkg_dir}/obs_files"
 version="$1"
 tag="$2"
-annotated_tag="$3"
+closest_tag="$3"
 
 log()   { (>&2 echo ">>> $*") ; }
 clean() { log "Cleaning temporary directory ${tmp_dir}"; rm -rf "${tmp_dir}"; }
 
 if [ $# -ne 3 ]; then
-    log "usage: <version> <tag> <annotated-tag>"
+    log "usage: <version> <tag> <closest-tag>"
     exit 1
 fi
 
@@ -22,7 +22,7 @@ trap clean ERR
 rm -rf "${rpm_files}"
 mkdir -p "${rpm_files}"
 git archive --prefix=skuba/ -o "${tmp_dir}/skuba.tar.gz" HEAD
-sed -e "s|%%VERSION|${version}|;s|%%TAG|${tag}|;s|%%ANNOTATED_TAG|${annotated_tag}|" "${susepkg_dir}/skuba_spec_template" \
+sed -e "s|%%VERSION|${version}|;s|%%TAG|${tag}|;s|%%CLOSEST_TAG|${closest_tag}|" "${susepkg_dir}/skuba_spec_template" \
     > "${tmp_dir}/skuba.spec"
 make CHANGES="${tmp_dir}/skuba.changes.append" suse-changelog
 cp "${tmp_dir}"/* "${rpm_files}"

--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -71,9 +71,9 @@ including patches requiring reboot.
 %patch0 -p1
 
 %build
-# TAG and ANNOTATED_TAG envvars are populated so the Makefile will read this information
+# TAG and CLOSEST_TAG envvars are populated so the Makefile will read this information
 export TAG="%%TAG"
-export ANNOTATED_TAG="%%ANNOTATED_TAG"
+export CLOSEST_TAG="%%CLOSEST_TAG"
 mkdir -pv $HOME/go/src/%{go_project}
 cp -avr * $HOME/go/src/%{go_project}
 cd $HOME/go/src/%{go_project}

--- a/pkg/skuba/version.go
+++ b/pkg/skuba/version.go
@@ -23,10 +23,10 @@ import (
 )
 
 var (
-	Version      string
-	BuildDate    string
-	Tag          string
-	AnnotatedTag string
+	Version    string
+	BuildDate  string
+	Tag        string
+	ClosestTag string
 )
 
 type SkubaVersion struct {
@@ -45,8 +45,8 @@ func CurrentVersion() SkubaVersion {
 		Tag:       Tag,
 		GoVersion: runtime.Version(),
 	}
-	if skubaVersion.Version == "" {
-		skubaVersion.Version = fmt.Sprintf("untagged (%s)", AnnotatedTag)
+	if skubaVersion.Tag == "" {
+		skubaVersion.Version = fmt.Sprintf("untagged (%s)", ClosestTag)
 	}
 	return skubaVersion
 }


### PR DESCRIPTION
## Why is this PR needed?
The previous approach for detecting if we were in a tag was not
supporting annotated tags. With this method we are supporting both
lightweight and annotated tags.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)
