### PR TITLE
[GMC] Configure loadbalancer to handle upgrades (bsc#1148090)

### DIFF
--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -83,9 +83,9 @@ resource "openstack_lb_monitor_v2" "kube_api_monitor" {
   type           = "HTTPS"
   url_path       = "/healthz"
   expected_codes = 200
-  delay          = 10
+  delay          = 3
   timeout        = 1
-  max_retries    = 3
+  max_retries    = 1
 }
 
 resource "openstack_lb_monitor_v2" "gangway_monitor" {

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -178,7 +178,10 @@ class Skuba:
             raise ValueError(f"verbosity '{verbosity}' is not an int")
         verbosity = v
 
-        env = {"SSH_AUTH_SOCK": self.utils.ssh_sock_fn()}
+        env = {
+            "SSH_AUTH_SOCK": self.utils.ssh_sock_fn(),
+            "PATH": os.environ['PATH']
+        }
 
 
         return self.utils.runshellcommand(


### PR DESCRIPTION
## Why is this PR needed?

In an upgrade, especially having multiple master nodes it is
important to have a quick reaction time of the loadbalancer.

Marking a member (master node) of the load balancer pool as
INACTIVE needs to happen almost instantly to avoid routing
requests for a master node that restarts the apiserver during
an upgrade.

This happens mostly in scripted upgrade scenarios, when master
nodes are upgraded without pause in between.

## What does this PR do?

It reduces the time to check if a load balancer member node (apiserver) is still available

## Anything else a reviewer needs to know?

Backport of https://github.com/SUSE/skuba/pull/649
Follow up of https://github.com/SUSE/skuba/pull/638
https://www.terraform.io/docs/providers/openstack/r/lb_monitor_v2.html

## Info for QA

Run the upgrade e2e test: `test_upgrade_apply_from_previous`

https://github.com/SUSE/skuba/blob/master/ci/infra/testrunner/tests/test_skuba_upgrade.py#L129-L150

### Related info

Nightly CI job: https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/e2e/job/caasp-v4-openstack-test_upgrade_apply_from_previous-nightly/

### Status **BEFORE** applying the patch
2nd master during upgrade fails with:

```
ERROR    testrunner:utils.py:199 b'I0828 05:11:09.445030   14098 files.go:40] downloading remote file "/etc/machine-id" contents
I0828 05:11:10.669042   14098 request.go:530] Throttling request took 71.2245ms, request: GET:https://10.86.4.76:6443/api/v1/namespaces/kube-system/pods/etcd-my-master-1
I0828 05:11:10.868699   14098 request.go:530] Throttling request took 186.865286ms, request: GET:https://10.86.4.76:6443/api/v1/nodes/my-master-2
I0828 05:11:11.068776   14098 request.go:530] Throttling request took 191.686032ms, request: GET:https://10.86.4.76:6443/api/v1/namespaces/kube-system/pods/kube-apiserver-my-master-2
I0828 05:11:11.268776   14098 request.go:530] Throttling request took 191.884666ms, request: GET:https://10.86.4.76:6443/api/v1/namespaces/kube-system/pods/kube-controller-manager-my-master-2
I0828 05:11:11.471395   14098 request.go:530] Throttling request took 193.691552ms, request: GET:https://10.86.4.76:6443/api/v1/namespaces/kube-system/pods/kube-scheduler-my-master-2
I0828 05:11:11.669031   14098 request.go:530] Throttling request took 181.75337ms, request: GET:https://10.86.4.76:6443/api/v1/namespaces/kube-system/pods/etcd-my-master-2
I0828 05:11:11.868814   14098 request.go:530] Throttling request took 189.054046ms, request: GET:https://10.86.4.76:6443/api/v1/nodes/my-worker-0
I0828 05:11:12.068753   14098 request.go:530] Throttling request took 191.637834ms, request: GET:https://10.86.4.76:6443/api/v1/nodes/my-worker-1
I0828 05:11:12.271542   14098 request.go:530] Throttling request took 192.927531ms, request: GET:https://10.86.4.76:6443/api/v1/nodes/my-worker-2
I0828 05:11:12.321062   14098 systemd.go:27] checking if skuba-update.timer is enabled
panic: could not parse "" as version

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/version.MustParseSemantic(0x0, 0x0, 0xc000710140)
skuba/vendor/k8s.io/apimachinery/pkg/util/version/version.go:119 +0x72
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes.nodeVersioningInfoWithClientset(0x18a8da0, 0xc00081c140, 0xc00032ae70, 0xb, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
skuba/internal/pkg/skuba/kubernetes/node_version.go:194 +0x6e5
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes.AllNodesVersioningInfo(0xc00062cc20, 0x7, 0xc0006af840)
skuba/internal/pkg/skuba/kubernetes/node_version.go:141 +0x1a8
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes.AllControlPlanesMatchVersion(0xc0006af840, 0x0, 0x0, 0xc000682210)
skuba/internal/pkg/skuba/kubernetes/node_version.go:226 +0x22
github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node.NodeVersionInfoUpdate.IsFirstControlPlaneNodeToBeUpgraded(0xc000730eb4, 0xb, 0xc000649d80, 0xc000649d40, 0xc0000ac400, 0xc0000aca00, 0xc0000acb40, 0xc0000acd00, 0x0, 0xc0000b2050, ...)
skuba/internal/pkg/skuba/upgrade/node/versions.go:71 +0x95
github.com/SUSE/skuba/pkg/skuba/actions/node/upgrade.Apply(0xc000397540, 0xc000397580, 0xc00055cc00)
skuba/pkg/skuba/actions/node/upgrade/apply.go:77 +0x436
github.com/SUSE/skuba/internal/app/skuba/node.newUpgradeApplyCmd.func1(0xc0005ae780, 0xc0005940e0, 0x0, 0x7)
skuba/internal/app/skuba/node/upgrade.go:65 +0x10a
github.com/spf13/cobra.(*Command).execute(0xc0005ae780, 0xc000594000, 0x7, 0x7, 0xc0005ae780, 0xc000594000)
skuba/vendor/github.com/spf13/cobra/command.go:760 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0xc0004e4500, 0x133ae5e, 0xc0000e9f88, 0xc00008e058)
skuba/vendor/github.com/spf13/cobra/command.go:846 +0x2ec
github.com/spf13/cobra.(*Command).Execute(...)
skuba/vendor/github.com/spf13/cobra/command.go:794
main.main()
skuba/cmd/skuba/skuba.go:57 +0x3a
```

### Status **AFTER** applying the patch

Requests get routed only to the available masters.

## Docs

https://github.com/SUSE/doc-caasp/pull/445
