### PR TITLE
upgrade: use kubelet version to install pattern bsc#1148700

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -138,8 +138,8 @@ func Apply(target *deployments.Target) error {
 	}
 	if nodeVersionInfoUpdate.HasMajorOrMinorUpdate() {
 		err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-			UpdatedVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
-			CurrentVersion: nodeVersionInfoUpdate.Current.APIServerVersion.String(),
+			UpdatedVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
+			CurrentVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
 		}, "kubernetes.install-node-pattern")
 		if err != nil {
 			return err
@@ -156,7 +156,7 @@ func Apply(target *deployments.Target) error {
 		return err
 	}
 	err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-		CurrentVersion: nodeVersionInfoUpdate.Update.APIServerVersion.String(),
+		CurrentVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 	}, "kubernetes.install-node-pattern")
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why is this PR needed?

When performing an upgrade on any kind of node (control plane or
worker node), use the kubelet version that is available for all nodes.

Signed-off-by: Rafael Fernández López <rfernandezlopez@suse.com>

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
