### PR TITLE
Fix setup teardown

### DIFF
--- a/ci/infra/testrunner/tests/README.md
+++ b/ci/infra/testrunner/tests/README.md
@@ -35,13 +35,25 @@ The example below shows a fixture that provides a bootstrapped cluster. It also 
 ```
 @pytest.fixture
 def setup(request, platform, skuba):
-    platform.provision()
     def cleanup():
         platform.cleanup()
     request.addfinalizer(cleanup)
 
+    platform.provision()
     skuba.cluster_init()
     skuba.node_bootstrap()
+```
+
+Note: pytest also allow a more idiomatic way of defining teardown logic in fixtures by using python's `yield` statement instead of registering a finalizer, as shown in the code below. However, finalizer functions have the advantage that they will always be called regardless if the fixture setup code raises an exception, provided they are registered before the exception occurs. Therefore, testrunner encourages using finalizer functions.
+
+```
+@pytest.fixture
+def setup(request, platform, skuba):
+    platform.provision()
+    skuba.cluster_init()
+    skuba.node_bootstrap()
+    yield               # return from fixture
+    platform.cleanup()  # teardown logic
 ```
 
 ## Running tests with the Testrunner

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -25,12 +25,12 @@ def provision(request, platform):
     if request.config.getoption("skip_setup") in ['provisioned', 'bootstrapped', 'deployed']:
         return
 
-    platform.provision()
-
     def cleanup():
         platform.gather_logs()
         platform.cleanup()
     request.addfinalizer(cleanup)
+
+    platform.provision()
 
 
 @pytest.fixture

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -8,11 +8,11 @@ CURRENT_VERSION = "1.15.2"
 
 @pytest.fixture
 def setup(request, platform, skuba):
-    platform.provision(num_master=3, num_worker=3)
-
     def cleanup():
         platform.cleanup()
     request.addfinalizer(cleanup)
+
+    platform.provision(num_master=3, num_worker=3)
 
 
 def setup_kubernetes_version(platform, skuba, kubectl, kubernetes_version=None):


### PR DESCRIPTION
## Why is this PR needed?

Fixes # https://github.com/SUSE/avant-garde/issues/810

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Ensure finalizer function are registered before the platform
provisioning is started, to allow cleanup of failed provisionings.

## Info for reviwers

This PR supperseds https://github.com/SUSE/skuba/pull/642 closed by mistake. 

## Info for QA

This PR only affects tests. 
