### PR TITLE
OpenStack security group: fix assignment to instances [bsc#1148711]

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -66,8 +66,8 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.common.id}",
-    "${openstack_networking_secgroup_v2.master_nodes.id}",
+    "${openstack_networking_secgroup_v2.common.name}",
+    "${openstack_networking_secgroup_v2.master_nodes.name}",
   ]
 
   user_data = "${data.template_file.master-cloud-init.rendered}"

--- a/ci/infra/openstack/security-groups-load-balancer.tf
+++ b/ci/infra/openstack/security-groups-load-balancer.tf
@@ -1,5 +1,5 @@
 resource "openstack_networking_secgroup_v2" "load_balancer" {
-  name        = "${var.stack_name}-caasp_common_secgroup"
+  name        = "${var.stack_name}-caasp_lb_secgroup"
   description = "Common security group for CaaSP load balancer"
 }
 

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -78,7 +78,7 @@ resource "openstack_compute_instance_v2" "worker" {
   }
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.common.id}",
+    "${openstack_networking_secgroup_v2.common.name}",
   ]
 
   user_data = "${data.template_file.worker-cloud-init.rendered}"


### PR DESCRIPTION
## Why is this PR needed?

This PR fixes bsc#1148711 which currently is blocking the GMC release.

## What does this PR do?

Change we way we reference security groups inside of OpenStack's instance definitions. We have to rely on the security group name instead of its ID.
    
Referencing a security group by ID is confusing terraform when `terraform apply` is executed against an already (or partially) deployed cluster.

Without this patch terraform thinks the security group associated with the instances changed and tries to change the instance <-> security group association against a live instance. This is something not supported by OpenStack, which leads to an internal server error.
    
While doing this change I also spotted two different security groups had the same name. This has been fixed as well.

## Anything else a reviewer needs to know?

Nothing else

## Info for QA

The issue has been reported by QA. @thehejik worked with me on that.

### Status **BEFORE** applying the patch

Growing an OpenStack cluster, or doing a `terraform apply` against an already existing one will lead to a server error inside of OpenStack.

### Status **AFTER** applying the patch

It's possible to grow clusters and run `terraform apply` against an already deployed cluster.

## Docs

No change needed.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
