### PR TITLE
Remove MustParseSemantic wherever is not needed

### DIFF
--- a/internal/pkg/skuba/addons/generic.go
+++ b/internal/pkg/skuba/addons/generic.go
@@ -21,6 +21,9 @@ import (
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 )
 
+// KubernetesVersionAtLeast will panic if the given version is not a semantic
+// one. Thus, before calling this function, make sure that this version comes
+// from a safe place (i.e skuba source code).
 func (renderContext renderContext) KubernetesVersionAtLeast(version string) bool {
 	return renderContext.config.ClusterVersion.AtLeast(versionutil.MustParseSemantic(version))
 }

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -66,14 +66,18 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 		return errors.New("couldn't access kubernetes base OS configuration")
 	}
 
-	currentVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.CurrentVersion))
+	v, err := version.ParseSemantic(kubernetesBaseOSConfiguration.CurrentVersion)
+	if err != nil {
+		return err
+	}
+	currentVersion := kubernetes.MajorMinorVersion(v)
 	patternName := fmt.Sprintf("patterns-caasp-Node-%s", currentVersion)
 
 	if kubernetesBaseOSConfiguration.UpdatedVersion != "" {
 		updatedVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.UpdatedVersion))
 		patternName = fmt.Sprintf("patterns-caasp-Node-%s-%s", currentVersion, updatedVersion)
 	}
-	_, _, err := t.ssh("zypper", "--non-interactive", "install", "--recommends", "--force", patternName)
+	_, _, err = t.ssh("zypper", "--non-interactive", "install", "--recommends", "--force", patternName)
 	return err
 }
 

--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -54,7 +54,7 @@ func GetCurrentClusterVersion(client clientset.Interface) (*version.Version, err
 	if err != nil {
 		return nil, err
 	}
-	return version.MustParseSemantic(initCfg.KubernetesVersion), nil
+	return version.ParseSemantic(initCfg.KubernetesVersion)
 }
 
 // GetKubeadmApisVersion returns the api version to use in the kubeadm-init.conf

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -69,7 +69,10 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	}
 
 	fmt.Printf("[bootstrap] deploying core add-ons on node %q\n", target.Target)
-	versionToDeploy := version.MustParseSemantic(initConfiguration.KubernetesVersion)
+	versionToDeploy, err := version.ParseSemantic(initConfiguration.KubernetesVersion)
+	if err != nil {
+		return errors.Wrapf(err, "could not parse semantic version: %s", initConfiguration.KubernetesVersion)
+	}
 	addonConfiguration := addons.AddonConfiguration{
 		ClusterVersion: versionToDeploy,
 		ControlPlane:   initConfiguration.ControlPlaneEndpoint,
@@ -111,7 +114,7 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 
 	finalInitConfigurationContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(initConfiguration, schema.GroupVersion{
 		Group:   "kubeadm.k8s.io",
-		Version: kubeadm.GetKubeadmApisVersion(version.MustParseSemantic(initConfiguration.KubernetesVersion)),
+		Version: kubeadm.GetKubeadmApisVersion(versionToDeploy),
 	})
 
 	if err != nil {


### PR DESCRIPTION
## Why is this PR needed?

There are two relevant functions when parsing Kubernetes versions: ParseSemantic and MustParseSemantic. They are identical except that the former returns an error and the latter panics on error.

Before this commit we were abusing of MustParseSemantic, and this in turn blurred some error logs that we have recently faced.

Fixes SUSE/avant-garde#818

## What does this PR do?

This commit changes MustParseSemantic with ParseSemantic wherever possible: whenever the version does not come strictly from the skuba source code.

Last but not least, in some functions it's hard to tell whether the given version comes from a safe place or not (e.g. the version is in a string format). In these cases I've kept the usage of MustParseSemantic and I've written a documentation comment explaining the possibility of the function panicking.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
