### PR TITLE
updated to install recommended zypper packages

### DIFF
--- a/ci/infra/testrunner/tests/test_installed_pkg.py
+++ b/ci/infra/testrunner/tests/test_installed_pkg.py
@@ -1,0 +1,24 @@
+import logging
+import time
+
+logger = logging.getLogger("testrunner")
+
+
+def test_installed_pkg(deployment, platform, skuba, kubectl):
+    assert skuba.num_of_nodes('master') > 0
+
+    logger.info('checking for installed packages on control plane')
+    output = platform.ssh_run('master', 0, 'rpm -q nfs-client')
+    assert 'not installed' not in output
+    output = platform.ssh_run('master', 0, 'rpm -q xfsprogs')
+    assert 'not installed' not in output
+    output = platform.ssh_run('master', 0, 'rpm -q ceph-common')
+    assert 'not installed' not in output
+
+    logger.info('checking for installed packages on worker')
+    output = platform.ssh_run('worker', 0, 'rpm -q nfs-client')
+    assert 'not installed' not in output
+    output = platform.ssh_run('worker', 0, 'rpm -q xfsprogs')
+    assert 'not installed' not in output
+    output = platform.ssh_run('worker', 0, 'rpm -q ceph-common')
+    assert 'not installed' not in output

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -73,7 +73,7 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 		updatedVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.UpdatedVersion))
 		patternName = fmt.Sprintf("patterns-caasp-Node-%s-%s", currentVersion, updatedVersion)
 	}
-	_, _, err := t.ssh("zypper", "--non-interactive", "install", "--force", patternName)
+	_, _, err := t.ssh("zypper", "--non-interactive", "install", "--recommends", "--force", patternName)
 	return err
 }
 


### PR DESCRIPTION
when installing the node package zypper will now also install the
recommended packages

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #https://github.com/SUSE/avant-garde/issues/728

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.


## What does this PR do?

adds the --recommends flag to zypper so that recommended packages get installed with it.

## Anything else a reviewer needs to know?

A simple test was added to ensure the packages in question on the issue where installed.

## Info for QA

Please review the test cases and see if there is anything you would like.

### Related info

NONE

### Status **BEFORE** applying the patch

use skuba bootstrap, then ask zypper if ceph-common is installed

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

use skuba bootstrap, then ask zypper if ceph-common is installed

## Docs

None

# Merge restrictions

(Please do not edit this) then why is it in the PR template?

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
