### PR TITLE
Add worker and master removal tests

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -124,3 +124,11 @@ test_e2e:
 .PHONY: test_cpi_openstack
 test_cpi_openstack:
 	${TEST_RUNNER} -v vars.yaml -p openstack test --verbose --suite test_cpi_openstack.py
+
+.PHONY: test_remove_master
+test_remove_master:
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_masters.py --test test_remove_master
+
+.PHONY: test_remove_worker
+test_remove_worker:
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_workers.py --test test_remove_worker

--- a/ci/infra/testrunner/tests/test_masters.py
+++ b/ci/infra/testrunner/tests/test_masters.py
@@ -10,4 +10,4 @@ def test_remove_master(deployment, conf, platform, skuba, kubectl):
     skuba.node_remove(role="master", nr=initial_masters - 1)
     assert skuba.num_of_nodes("master") == initial_masters - 1
 
-    wait(kubectl.run_kubectl, 'wait --timeout=5m --for=condition=Ready pods --all --namespace=kube-system', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))
+    wait(kubectl.run_kubectl, 'wait --timeout=5m --for=condition=Ready pods --all --namespace=kube-system  --field-selector=status.phase!=Succeeded', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))

--- a/ci/infra/testrunner/tests/test_masters.py
+++ b/ci/infra/testrunner/tests/test_masters.py
@@ -1,0 +1,13 @@
+import pytest
+from tests.utils import wait
+
+
+@pytest.mark.disruptive
+def test_remove_master(deployment, conf, platform, skuba, kubectl):
+    initial_masters = skuba.num_of_nodes("master")
+
+    # Remove the master
+    skuba.node_remove(role="master", nr=initial_masters - 1)
+    assert skuba.num_of_nodes("master") == initial_masters - 1
+
+    wait(kubectl.run_kubectl, 'wait --timeout=5m --for=condition=Ready pods --all --namespace=kube-system', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))

--- a/ci/infra/testrunner/tests/test_workers.py
+++ b/ci/infra/testrunner/tests/test_workers.py
@@ -1,4 +1,5 @@
 import pytest
+from tests.utils import wait
 
 
 @pytest.mark.disruptive
@@ -8,3 +9,14 @@ def test_add_worker(bootstrap, skuba):
     workers = skuba.num_of_nodes("worker")
     assert masters == 1
     assert workers == 1
+
+
+@pytest.mark.disruptive
+def test_remove_worker(deployment, conf, platform, skuba, kubectl):
+    initial_workers = skuba.num_of_nodes("worker")
+
+    # Remove the worker
+    skuba.node_remove(role="worker", nr=initial_workers - 1)
+    assert skuba.num_of_nodes("worker") == initial_workers - 1
+
+    wait(kubectl.run_kubectl, 'wait --timeout=5m --for=condition=Ready pods --all --namespace=kube-system', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -54,6 +54,8 @@
         - '{name}-test_dockercaps-nightly'
         - '{name}-test_addon_upgrade_plan-nightly'
         - '{name}-test_addon_upgrade_apply-nightly'
+        - '{name}-test_remove_master'
+        - '{name}-test_remove_worker'
 
 - project:
     name: caasp-jobs/e2e/caasp-v4-vmware
@@ -73,6 +75,8 @@
         - '{name}-test_dockercaps-nightly'
         - '{name}-test_addon_upgrade_plan-nightly'
         - '{name}-test_addon_upgrade_apply-nightly'
+        - '{name}-test_remove_master'
+        - '{name}-test_remove_worker'
 
 - project:
     name: caasp-jobs/validator/caasp-v4-openstack

--- a/ci/jenkins/templates/e2e-nightly-template.yaml
+++ b/ci/jenkins/templates/e2e-nightly-template.yaml
@@ -404,3 +404,78 @@
                 suppress-automatic-scm-triggering: true
                 basedir: skuba
         script-path: skuba/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+
+- job-template:
+    name: '{name}-test_remove_master'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    branch: master
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
+    triggers:
+        - timed: 'H H(3-5) * * *'
+    parameters:
+        - string:
+            name: BRANCH
+            default: '{branch}'
+            description: The branch to checkout
+        - string:
+              name: PLATFORM
+              default: '{platform}'
+              description: The platform to perform the tests on
+        - string:
+            name: E2E_MAKE_TARGET_NAME
+            default: 'test_remove_master'
+            description: The make target to run (only e2e tests)
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://github.com/{repo-owner}/{repo-name}.git'
+                credentials-id: '{repo-credentials}'
+                branches:
+                    - '{branch}'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+                basedir: skuba
+        script-path: skuba/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+
+- job-template:
+    name: '{name}-test_remove_worker'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    branch: master
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
+    triggers:
+        - timed: 'H H(3-5) * * *'
+    parameters:
+        - string:
+            name: BRANCH
+            default: '{branch}'
+            description: The branch to checkout
+        - string:
+              name: PLATFORM
+              default: '{platform}'
+              description: The platform to perform the tests on
+        - string:
+            name: E2E_MAKE_TARGET_NAME
+            default: 'test_remove_worker'
+            description: The make target to run (only e2e tests)
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://github.com/{repo-owner}/{repo-name}.git'
+                credentials-id: '{repo-credentials}'
+                branches:
+                    - '{branch}'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+                basedir: skuba
+        script-path: skuba/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+


### PR DESCRIPTION
## Why is this PR needed?

We want to test removing a node from a cluster to make sure it doesn't break anything.

Fixes https://github.com/SUSE/avant-garde/issues/967
## What does this PR do?

Adds tests for removing workers and masters
Waits for Nodes to be ready before checking pod status
Ignores completed pods when checking pod status
Adds jobs for running the tests nightly

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
