### PR TITLE
node upgrade plan e2e test fixes and enhancements

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -73,6 +73,10 @@ test_upgrade_plan_all_fine:
 test_upgrade_plan_from_previous:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_plan_from_previous
 
+.PHONY: test_upgrade_plan_from_previous_with_upgraded_control_plane
+test_upgrade_plan_from_previous_with_upgraded_control_plane:
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_plan_from_previous_with_upgraded_control_plane
+
 .PHONY: test_upgrade_apply_all_fine
 test_upgrade_apply_all_fine:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_skuba_upgrade.py --test test_upgrade_apply_all_fine

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -126,7 +126,7 @@ class Skuba:
             raise Exception("Error executing cmd {}".format(cmd)) from ex
 
     @step
-    def node_upgrade(self, action, role, nr):
+    def node_upgrade(self, action, role, nr, ignore_errors=False):
         self._verify_bootstrap_dependency()
 
         if role not in ("master", "worker"):
@@ -145,7 +145,7 @@ class Skuba:
         else:
             raise ValueError("Invalid action '{}'".format(action))
 
-        return self._run_skuba(cmd)
+        return self._run_skuba(cmd, ignore_errors=ignore_errors)
 
     @step
     def cluster_upgrade_plan(self):
@@ -173,7 +173,7 @@ class Skuba:
         path = "{cwd}/test-cluster/admin.conf".format(cwd=self.conf.workspace)
         return path
 
-    def _run_skuba(self, cmd, cwd=None, verbosity=None):
+    def _run_skuba(self, cmd, cwd=None, verbosity=None, ignore_errors=False):
         """Running skuba command in cwd.
         The cwd defautls to {workspace}/test-cluster but can be overrided
         for example, for the init command that must run in {workspace}
@@ -201,4 +201,5 @@ class Skuba:
           f"{self.binpath} -v {verbosity} {cmd}",
           cwd=cwd,
           env=env,
+          ignore_errors=ignore_errors,
           )

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -101,6 +101,33 @@ def test_upgrade_plan_from_previous(setup, skuba, kubectl, platform):
 
 
 @pytest.mark.disruptive
+def test_upgrade_plan_from_previous_with_upgraded_control_plane(setup, skuba, kubectl, platform):
+    """
+    Starting from an updated control plane, check what cluster/node plan report.
+    """
+
+    setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
+
+    masters = platform.get_num_nodes("master")
+    for n in range (0, masters):
+        node = "my-master-{}".format(n)
+        assert node_is_ready(kubectl, node)
+        master = skuba.node_upgrade("apply", "master", n)
+        assert master.find("successfully upgraded") != -1
+        assert node_is_upgraded(kubectl, platform, node)
+
+    workers = platform.get_num_nodes("worker")
+    for n in range (0, workers):
+        worker = skuba.node_upgrade("plan", "worker", n)
+        assert worker.find(
+            "Current Kubernetes cluster version: {pv}".format(pv=PREVIOUS_VERSION))
+        assert worker.find("Latest Kubernetes version: {cv}".format(
+            cv=CURRENT_VERSION)) != -1
+        assert worker.find(" - kubelet: {pv} -> {cv}".format(
+            pv=PREVIOUS_VERSION, cv=CURRENT_VERSION)) != -1
+
+
+@pytest.mark.disruptive
 def test_upgrade_apply_all_fine(setup, platform, skuba, kubectl):
     """
     Starting from a up-to-date cluster, check what node upgrade apply reports.

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -24,13 +24,7 @@ def setup_kubernetes_version(platform, skuba, kubectl, kubernetes_version=None):
     skuba.cluster_init(kubernetes_version)
     skuba.node_bootstrap()
 
-    masters = platform.get_num_nodes("master")
-    for n in range (1, masters):
-        skuba.node_join("master", n)
-
-    workers = platform.get_num_nodes("worker")
-    for n in range (0, workers):
-        skuba.node_join("worker", n)
+    skuba.join_nodes()
 
     kubectl.run_kubectl("wait --for=condition=ready nodes --all --timeout=5m")
 

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -95,13 +95,9 @@ def test_upgrade_plan_from_previous(setup, skuba, kubectl, platform):
 
     workers = platform.get_num_nodes("worker")
     for n in range (0, workers):
-        worker = skuba.node_upgrade("plan", "worker", n)
-        assert worker.find(
-            "Current Kubernetes cluster version: {pv}".format(pv=PREVIOUS_VERSION))
-        assert worker.find("Latest Kubernetes version: {cv}".format(
-            cv=CURRENT_VERSION)) != -1
+        worker = skuba.node_upgrade("plan", "worker", n, ignore_errors=True)
         # If the control plane nodes are not upgraded yet, skuba disallows upgrading a worker
-        assert worker.find("Node my-worker-{} is up to date".format(n))
+        assert worker.find("Unable to plan node upgrade: my-worker-{} is not upgradeable until all control plane nodes are upgraded".format(n))
 
 
 @pytest.mark.disruptive

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -199,6 +199,8 @@ class Utils:
         if p.returncode != 0:
             if not ignore_errors:
                 raise RuntimeError("Error executing command {}".format(cmd))
+            else:
+                return p.stderr.decode()
         return p.stdout.decode()
 
     def ssh_sock_fn(self):

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -45,6 +45,7 @@
     jobs:
         - '{name}-test_upgrade_plan_all_fine-nightly'
         - '{name}-test_upgrade_plan_from_previous-nightly'
+        - '{name}-test_upgrade_plan_from_previous_with_upgraded_control_plane-nightly'
         - '{name}-test_upgrade_apply_all_fine-nightly'
         - '{name}-test_upgrade_apply_from_previous-nightly'
         - '{name}-test_upgrade_apply_user_lock-nightly'
@@ -61,6 +62,7 @@
     jobs:
         - '{name}-test_upgrade_plan_all_fine-nightly'
         - '{name}-test_upgrade_plan_from_previous-nightly'
+        - '{name}-test_upgrade_plan_from_previous_with_upgraded_control_plane-nightly'
         - '{name}-test_upgrade_apply_all_fine-nightly'
         - '{name}-test_upgrade_apply_from_previous-nightly'
         - '{name}-test_upgrade_apply_user_lock-nightly'

--- a/ci/jenkins/templates/e2e-nightly-template.yaml
+++ b/ci/jenkins/templates/e2e-nightly-template.yaml
@@ -73,6 +73,43 @@
         script-path: skuba/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
 
 - job-template:
+    name: '{name}-test_upgrade_plan_from_previous_with_upgraded_control_plane-nightly'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    branch: master
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
+    triggers:
+        - timed: 'H H(3-5) * * *'
+    parameters:
+        - string:
+            name: BRANCH
+            default: '{branch}'
+            description: The branch to checkout
+        - string:
+              name: PLATFORM
+              default: '{platform}'
+              description: The platform to perform the tests on
+        - string:
+            name: E2E_MAKE_TARGET_NAME
+            default: 'test_upgrade_plan_from_previous_with_upgraded_control_plane'
+            description: The make target to run (only e2e tests)
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://github.com/{repo-owner}/{repo-name}.git'
+                credentials-id: '{repo-credentials}'
+                branches:
+                    - '{branch}'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+                basedir: skuba
+        script-path: skuba/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+
+- job-template:
     name: '{name}-test_upgrade_apply_all_fine-nightly'
     project-type: pipeline
     number-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

Currently https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/e2e/job/caasp-v4-openstack-test_upgrade_plan_from_previous-nightly/ is broken as we changed the logic in skuba, see https://github.com/SUSE/skuba/pull/560

## What does this PR do?

* Fixes the existing node upgrade plan testcase, by ignoring the error that skuba throws, and parsing skuba's message on stderr
* Adding a new testcase for a different node upgrade plan scenario, where a control plane has been upgraded already
* using a new helper function `join_nodes` from testrunner introduced in https://github.com/SUSE/skuba/pull/639