### PR TITLE
Increase unit-test code coverage for node remove

### DIFF
--- a/internal/pkg/skuba/etcd/member.go
+++ b/internal/pkg/skuba/etcd/member.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 )
 
-func RemoveMember(node *v1.Node) error {
+func RemoveMember(client clientset.Interface, node *v1.Node) error {
 	controlPlaneNodes, err := kubernetes.GetControlPlaneNodes()
 	if err != nil {
 		return errors.Wrap(err, "could not get the list of control plane nodes, aborting")
@@ -38,7 +39,7 @@ func RemoveMember(node *v1.Node) error {
 	klog.V(1).Info("removing etcd member from the etcd cluster")
 	for _, controlPlaneNode := range controlPlaneNodes.Items {
 		klog.V(1).Infof("trying to remove etcd member from control plane node %s", controlPlaneNode.ObjectMeta.Name)
-		if err := RemoveMemberFrom(node, &controlPlaneNode); err == nil {
+		if err := RemoveMemberFrom(client, node, &controlPlaneNode); err == nil {
 			klog.V(1).Infof("etcd member for node %s removed from control plane node %s", node.ObjectMeta.Name, controlPlaneNode.ObjectMeta.Name)
 			break
 		} else {
@@ -49,8 +50,9 @@ func RemoveMember(node *v1.Node) error {
 	return nil
 }
 
-func RemoveMemberFrom(node, executorNode *v1.Node) error {
+func RemoveMemberFrom(client clientset.Interface, node, executorNode *v1.Node) error {
 	return kubernetes.CreateAndWaitForJob(
+		client,
 		removeMemberFromJobName(node, executorNode),
 		removeMemberFromJobSpec(node, executorNode),
 	)

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -25,13 +25,15 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func DisarmKubelet(node *v1.Node, clusterVersion *version.Version) error {
+func DisarmKubelet(client clientset.Interface, node *v1.Node, clusterVersion *version.Version) error {
 	return CreateAndWaitForJob(
+		client,
 		disarmKubeletJobName(node),
 		disarmKubeletJobSpec(node, clusterVersion),
 	)

--- a/internal/pkg/skuba/upgrade/cluster/drift.go
+++ b/internal/pkg/skuba/upgrade/cluster/drift.go
@@ -43,7 +43,11 @@ func driftedNodesWithVersions(currentClusterVersion *version.Version, nodesVersi
 // the node version with regards to the current cluster version is only the patch level
 // version, the node won't be included in the list.
 func DriftedNodes() ([]kubernetes.NodeVersionInfo, error) {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return nil, err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return []kubernetes.NodeVersionInfo{}, err
 	}

--- a/internal/pkg/skuba/upgrade/cluster/versions.go
+++ b/internal/pkg/skuba/upgrade/cluster/versions.go
@@ -55,7 +55,11 @@ func nextAvailableVersionsForVersion(currentClusterVersion *version.Version, ava
 // the current minor version, the next minor version (if any) for the current
 // major version, and the next major version (if any)
 func NextAvailableVersions() (nextPatch *version.Version, nextMinor *version.Version, nextMajor *version.Version, err error) {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -102,7 +106,11 @@ func UpgradePathWithAvailableVersions(currentClusterVersion *version.Version, av
 // UpgradePath returns the list of versions the cluster needs to go through
 // in order to upgrade to the latest available version
 func UpgradePath() ([]*version.Version, error) {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return nil, err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return []*version.Version{}, err
 	}

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -67,7 +67,8 @@ func (nviu NodeVersionInfoUpdate) IsUpdated() bool {
 
 func (nviu NodeVersionInfoUpdate) IsFirstControlPlaneNodeToBeUpgraded() bool {
 	isControlPlane := nviu.Current.IsControlPlane()
-	currentClusterVersion, _ := kubeadm.GetCurrentClusterVersion()
+	client, _ := kubernetes.GetAdminClientSet()
+	currentClusterVersion, _ := kubeadm.GetCurrentClusterVersion(client)
 	allControlPlanesMatchVersion, _ := kubernetes.AllControlPlanesMatchVersion(currentClusterVersion)
 	matchesClusterVersion := (currentClusterVersion.String() == nviu.Current.KubeletVersion.String())
 
@@ -75,11 +76,11 @@ func (nviu NodeVersionInfoUpdate) IsFirstControlPlaneNodeToBeUpgraded() bool {
 }
 
 func UpdateStatus(nodeName string) (NodeVersionInfoUpdate, error) {
-	clientSet, err := kubernetes.GetAdminClientSet()
+	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return NodeVersionInfoUpdate{}, errors.Wrap(err, "unable to get admin client set")
 	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return NodeVersionInfoUpdate{}, err
 	}
@@ -87,7 +88,7 @@ func UpdateStatus(nodeName string) (NodeVersionInfoUpdate, error) {
 	if err != nil {
 		return NodeVersionInfoUpdate{}, err
 	}
-	node, err := clientSet.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	node, err := client.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	if err != nil {
 		return NodeVersionInfoUpdate{}, errors.Wrapf(err, "could not find node %s", nodeName)
 	}

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -31,7 +31,11 @@ import (
 func Plan() error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return err
 	}

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -49,7 +49,12 @@ import (
 // FIXME: being this a part of the go API accept the toplevel directory instead of
 //        using the PWD
 func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.Target) error {
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		fmt.Print("[join] failed to get admin client set\n")
+		return err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return err
 	}
@@ -76,12 +81,6 @@ func Join(joinConfiguration deployments.JoinConfiguration, target *deployments.T
 		"kubelet.enable",
 		"kubeadm.join",
 		"skuba-update.start",
-	}
-
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		fmt.Print("[join] failed to get admin client set\n")
-		return err
 	}
 
 	_, err = client.CoreV1().Nodes().Get(target.Nodename, metav1.GetOptions{})
@@ -124,7 +123,11 @@ func ConfigPath(role deployments.Role, target *deployments.Target) (string, erro
 		configPath = skuba.TemplatePathForRole(role)
 	}
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get admin client set")
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return "", errors.Wrap(err, "could not get current cluster version")
 	}

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -53,7 +53,7 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 		}
 	}
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve the current cluster version")
 	}
@@ -71,15 +71,15 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 
 	if isControlPlane {
 		fmt.Printf("[remove-node] removing etcd from node %s\n", targetName)
-		etcd.RemoveMember(node)
+		etcd.RemoveMember(client, node)
 	}
 
-	if err := kubernetes.DisarmKubelet(node, currentClusterVersion); err != nil {
+	if err := kubernetes.DisarmKubelet(client, node, currentClusterVersion); err != nil {
 		fmt.Printf("[remove-node] failed disarming kubelet: %v; node could be down, continuing with node removal...\n", err)
 	}
 
 	if isControlPlane {
-		if err := kubeadm.RemoveAPIEndpointFromConfigMap(node); err != nil {
+		if err := kubeadm.RemoveAPIEndpointFromConfigMap(client, node); err != nil {
 			return errors.Wrapf(err, "[remove-node] could not remove the APIEndpoint for %s from the kubeadm-config configmap", targetName)
 		}
 

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -18,42 +18,132 @@
 package remove
 
 import (
+	"crypto/sha1"
+	"fmt"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_RemoveMasterNode(t *testing.T) {
-	node1 := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "master-1", Labels: map[string]string{"node-role.kubernetes.io/master": ""}}}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kubeadm-config",
+			Namespace: metav1.NamespaceSystem,
+		},
+		Data: map[string]string{"ClusterConfiguration": `
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+kubernetesVersion: "v1.2.3"
+apiServer:
+  extraArgs:
+    advertiseAddress: 1.2.3.4
+`},
+	}
+
+	jobSpec := batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "fake",
+						Image: "fake",
+						Command: []string{"/bin/bash"},
+					},
+				},
+				RestartPolicy: corev1.RestartPolicyNever,
+				Volumes: []corev1.Volume{},
+				NodeSelector: map[string]string{
+					"kubernetes.io/hostname": "fake",
+				},
+				Tolerations: []corev1.Toleration{
+					{
+						Operator: corev1.TolerationOpExists,
+					},
+				},
+			},
+		},
+	}
+
+	master1 := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-1", 
+			Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+		},
+	}
+
+	master2 := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "master-2", 
+			Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+		},
+	}
+
+	worker1 := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-1", 
+		},
+	}
+
+	worker2 := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-2", 
+		},
+	}
 
 	test := []struct {
 		name          string
 		target        string
+		job	  		  string
 		clientset     *fake.Clientset
 		errorExpected bool
 		errorMessage  string
 	}{
 		{
-			name:          "remove last master from cluster",
+			name:          "should remove master from cluster",
 			target:        "master-1",
-			clientset:     fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
+			clientset:     fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{master1, master2}}),
+			job:	   	   fmt.Sprintf("caasp-kubelet-disarm-%x", sha1.Sum([]byte(master1.ObjectMeta.Name))),
+			errorExpected: false,
+		},
+		{
+			name:          "should fail when remove last master from cluster",
+			target:        "master-1",
+			clientset:     fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{master1}}),
 			errorExpected: true,
 			errorMessage:  "could not remove last master of the cluster",
 		},
 		{
-			name:          "cannot get node",
-			target:        "master-2",
-			clientset:     fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1}}),
+			name:          "should fail when remove node does not exist",
+			target:        "not-exist",
+			clientset:     fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{master1}}),
 			errorExpected: true,
-			errorMessage:  "[remove-node] could not get node master-2: nodes \"master-2\" not found",
+			errorMessage:  "[remove-node] could not get node not-exist: nodes \"not-exist\" not found",
+		},
+		{
+			name:          "should remove worker from cluster",
+			target:        "worker-2",
+			clientset:     fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{worker1, worker2}}),
+			job:	   	   fmt.Sprintf("caasp-kubelet-disarm-%x", sha1.Sum([]byte(worker2.ObjectMeta.Name))),
+			errorExpected: false,
 		},
 	}
 
 	for _, tt := range test {
 		tt := tt // Parallel testing
 		t.Run(tt.name, func(t *testing.T) {
+			tt.clientset.CoreV1().ConfigMaps(metav1.NamespaceSystem).Create(cm)
+			tt.clientset.BatchV1().Jobs(metav1.NamespaceSystem).Create(&batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:		tt.job,
+					Namespace: 	metav1.NamespaceSystem,
+				},
+				Spec: jobSpec,
+			})
+
 			err := Remove(tt.clientset, tt.target, 0)
 			if tt.errorExpected && err == nil {
 				t.Errorf("error expected on %s, but no error reported", tt.name)

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -47,7 +47,7 @@ func Apply(target *deployments.Target) error {
 		return err
 	}
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func Apply(target *deployments.Target) error {
 		if upgradeable {
 			fmt.Println("Fetching the cluster configuration...")
 
-			initCfg, err := kubeadm.GetClusterConfiguration()
+			initCfg, err := kubeadm.GetClusterConfiguration(client)
 			if err != nil {
 				return err
 			}

--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -29,7 +29,11 @@ import (
 func Plan(nodeName string) error {
 	fmt.Printf("%s\n", skuba.CurrentVersion().String())
 
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion()
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why is this PR needed?

The current code coverage for remove node is low (25.0%). Increase unit-test code coverage helps to enhance feature hardening.

## What does this PR do?

Added new unit tests for remove node.

Test Includes:
    * should remove master from cluster
    * should remove worker from cluster
    
    Other Changes:
    * rewording of existing tests

## Anything else a reviewer needs to know?

Minor refactor to suit unit-test

## Info for QA

This adds unit-test for remove node

### Related info

https://github.com/SUSE/avant-garde/issues/823

### Status **BEFORE** applying the patch

Unit test code coverage: 25.0%

### Status **AFTER** applying the patch

Unit test code coverage: 84.4%

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
