### PR TITLE
Increased wait time for pods to be ready

### DIFF
--- a/ci/infra/testrunner/tests/test_node_reboot.py
+++ b/ci/infra/testrunner/tests/test_node_reboot.py
@@ -34,7 +34,7 @@ def check_nodes_ready(kubectl):
         time.sleep(5)
 
 
-@timeout(120)
+@timeout(300)
 def check_pods_ready(kubectl):
     while True:
         try:


### PR DESCRIPTION
## Why is this PR needed?

The timeout didn't seem to be long enough for a pr that passed on a rerun 

Fixes #


## What does this PR do?

Increases the timeout from 2 min to 5

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
