### PR TITLE
Moved archiving terraform files

### DIFF
--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -22,8 +22,6 @@ pipeline {
        stage('Cluster Provisioning') {
            steps {
                sh(script: 'make -f skuba/ci/Makefile create_environment', label: 'Provision')
-               archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
-               archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
            }
        }
 
@@ -58,12 +56,16 @@ pipeline {
    }
    post {
         always {
-            junit('skuba/ci/infra/testrunner/*.xml')
-            sh(script: "make --keep-going -f skuba/ci/Makefile post_run", label: 'Post Run')
-            archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
+            sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
+            archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
+            junit('skuba/ci/infra/testrunner/*.xml')
         }
         cleanup {
+            sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')
             dir("${WORKSPACE}@tmp") {
                 deleteDir()
             }


### PR DESCRIPTION
## Why is this PR needed?

If provisioning failed the tfstate and tfvars weren't being archived.
This makes cleanup later harder.
Also broke up post run steps incase of other failures.

Fixes #

## What does this PR do?

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
