### PR TITLE
Fix make clean/distclean failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,12 @@ install: go-version-check
 
 .PHONY: clean
 clean:
-	$(GO) clean -i
+	$(GO) clean -i ./...
 	$(RM) -f ./skuba
 
 .PHONY: distclean
 distclean: clean
-	$(GO) clean -i -cache -testcache -modcache
+	$(GO) clean -i -cache -testcache -modcache ./...
 
 .PHONY: staging
 staging:


### PR DESCRIPTION
## Why is this PR needed?

Run `make clean` or `make distclean`, error message bumps out
```
can't load package: package github.com/SUSE/skuba: unknown import path "github.com/SUSE/skuba": cannot find module providing package github.com/SUSE/skuba
```

## What does this PR do?

Not use `-mod=vendor` flag when clean/disclean.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

Run `make clean` or `make distclean`, error message bumps out

### Status **AFTER** applying the patch

Run `make clean` or `make distclean`, error message bump out, no error message bumps out

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
