### PR TITLE
Do not redirect pip3 install output to `/dev/null`

### DIFF
--- a/ci/infra/testrunner/testrunner
+++ b/ci/infra/testrunner/testrunner
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -eo pipefail
+
 echo "Starting $0 script"
 
 SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/ci/infra/testrunner/testrunner
+++ b/ci/infra/testrunner/testrunner
@@ -14,7 +14,7 @@ setup_python_env() {
         python3 -m venv $VENVDIR
     fi
     source ${VENVDIR}/bin/activate
-    pip3 install -r "${SDIR}/requirements.txt"&>/dev/null
+    pip3 install -r "${SDIR}/requirements.txt"
     deactivate
 }
 


### PR DESCRIPTION
## Why is this PR needed?

Do not redirect pip3 install output to `/dev/null`

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
