### PR TITLE
testrunner: do not rely on shebang when running `pip3`

### DIFF
--- a/ci/infra/testrunner/testrunner
+++ b/ci/infra/testrunner/testrunner
@@ -16,7 +16,9 @@ setup_python_env() {
     python3 -m venv $VENVDIR
   fi
   source ${VENVDIR}/bin/activate
-  pip3 install -r "${SDIR}/requirements.txt"
+  # Not calling to `pip3` directly because its shebang can exceed 128 characters
+  # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
+  python -m pip install -r "${SDIR}/requirements.txt"
   deactivate
 }
 

--- a/ci/infra/testrunner/testrunner
+++ b/ci/infra/testrunner/testrunner
@@ -19,9 +19,9 @@ setup_python_env() {
   # Not calling to `pip3` directly because its shebang can exceed 128 characters
   # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
   python -m pip install -r "${SDIR}/requirements.txt"
-  deactivate
 }
 
 setup_python_env
 # use unbuffered output
-stdbuf -i0 -o0 -e0 ${VENVDIR}/bin/python3 -u ${SDIR}/testrunner.py "$@"
+stdbuf -i0 -o0 -e0 python -u ${SDIR}/testrunner.py "$@"
+deactivate

--- a/ci/jenkins/pipelines/prs/helpers/pr-manager
+++ b/ci/jenkins/pipelines/prs/helpers/pr-manager
@@ -19,9 +19,9 @@ setup_python_env() {
     # Not calling to `pip3` directly because its shebang can exceed 128 characters
     # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
     python -m pip install -r "${SDIR}/pr_manager/requirements.txt"
-    deactivate
 }
 
 setup_python_env
 # use unbuffered output
-stdbuf -i0 -o0 -e0  ${VENVDIR}/bin/python3 -u ${SDIR}/pr_manager/pr_manager.py $@
+stdbuf -i0 -o0 -e0 python -u ${SDIR}/pr_manager/pr_manager.py "$@"
+deactivate

--- a/ci/jenkins/pipelines/prs/helpers/pr-manager
+++ b/ci/jenkins/pipelines/prs/helpers/pr-manager
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 echo "Starting $0 script"
 
-SDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 VENVDIR=${WORKSPACE:-~}/py3venv
 export VENVDIR=${VENVDIR}
 
@@ -14,8 +16,9 @@ setup_python_env() {
         python3 -m venv $VENVDIR
     fi
     source ${VENVDIR}/bin/activate
-    REQ_PATH="${SDIR}/pr_manager/requirements.txt"
-    pip3 install -r "${REQ_PATH}" &>/dev/null
+    # Not calling to `pip3` directly because its shebang can exceed 128 characters
+    # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
+    python -m pip install -r "${SDIR}/pr_manager/requirements.txt"
     deactivate
 }
 


### PR DESCRIPTION
## Why is this PR needed?

When running `pip3` directly, the shebang command can exceed the 128
limit very easily depending on the job name that is being run on CI.

To avoid this limit, call to `python3` directly, that will run the
`pip3` command, instead of relying on the `pip3` venv script, that
contains the shebang that can exceed 128 characters.

More information: https://github.com/pypa/pip/issues/1773

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
