### PR TITLE
removed force from options in node install

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -77,7 +77,7 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 		updatedVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.UpdatedVersion))
 		patternName = fmt.Sprintf("patterns-caasp-Node-%s-%s", currentVersion, updatedVersion)
 	}
-	_, _, err = t.ssh("zypper", "--non-interactive", "install", "--recommends", "--force", patternName)
+	_, _, err = t.ssh("zypper", "--non-interactive", "install", "--recommends", patternName)
 	return err
 }
 


### PR DESCRIPTION
no longer force package install for the node package

## Why is this PR needed?

Per our discussions here https://github.com/SUSE/skuba/pull/665 and elsewhere, is not needed or wanted anymore to use the flag force.
Fixes #

## What does this PR do?

it removes the `--force` flag from the node install.

## Anything else a reviewer needs to know?
no.


## Info for QA
I thought about making a test where it would fail without force? but that seemed convoluted at best and prone to breaking. if anyone wants to hit me up with an idea awesome.
### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.
you would need to make the node package pattern install fail if it does not use the --force flag. 

## Docs

NONE

# Merge restrictions

(Please do not edit this) then why is it in the PR template?!

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
