### PR TITLE
etcd member remove: rename job (bsc#1149109)

### DIFF
--- a/internal/pkg/skuba/etcd/member.go
+++ b/internal/pkg/skuba/etcd/member.go
@@ -18,6 +18,7 @@
 package etcd
 
 import (
+	"crypto/sha1"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -59,7 +60,10 @@ func RemoveMemberFrom(client clientset.Interface, node, executorNode *v1.Node) e
 }
 
 func removeMemberFromJobName(node, executorNode *v1.Node) string {
-	return fmt.Sprintf("caasp-remove-etcd-member-%s-from-%s", node.ObjectMeta.Name, executorNode.ObjectMeta.Name)
+	nodeName := fmt.Sprintf("%x", sha1.Sum([]byte(node.ObjectMeta.Name)))
+	executorNodeName := fmt.Sprintf("%x", sha1.Sum([]byte(executorNode.ObjectMeta.Name)))
+
+	return fmt.Sprintf("caasp-remove-etcd-member-%.10s-from-%.10s", nodeName, executorNodeName)
 }
 
 func removeMemberFromJobSpec(node, executorNode *v1.Node) batchv1.JobSpec {


### PR DESCRIPTION
## Why is this PR needed?

The etcd membership removal from other nodes can be longer than the
job limit of 63 characters.

In order to make sure that we never reach this limit, transform the
node names, applying SHA1 hexdigest to them, and write only the 10
first characters of the hexdigest. We are basically breaking the
algorithm, but it should suffice to avoid job name conflicts or
clashes on a given cluster.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
