### PR TITLE
node remove: use etcd image for the current cluster version (bsc#1149312)

### DIFF
--- a/internal/pkg/skuba/etcd/member.go
+++ b/internal/pkg/skuba/etcd/member.go
@@ -23,13 +23,16 @@ import (
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func RemoveMember(client clientset.Interface, node *v1.Node) error {
+func RemoveMember(client clientset.Interface, node *v1.Node, clusterVersion *version.Version) error {
 	controlPlaneNodes, err := kubernetes.GetControlPlaneNodes()
 	if err != nil {
 		return errors.Wrap(err, "could not get the list of control plane nodes, aborting")
@@ -39,7 +42,7 @@ func RemoveMember(client clientset.Interface, node *v1.Node) error {
 	klog.V(1).Info("removing etcd member from the etcd cluster")
 	for _, controlPlaneNode := range controlPlaneNodes.Items {
 		klog.V(1).Infof("trying to remove etcd member from control plane node %s", controlPlaneNode.ObjectMeta.Name)
-		if err := RemoveMemberFrom(client, node, &controlPlaneNode); err == nil {
+		if err := RemoveMemberFrom(client, node, &controlPlaneNode, clusterVersion); err == nil {
 			klog.V(1).Infof("etcd member for node %s removed from control plane node %s", node.ObjectMeta.Name, controlPlaneNode.ObjectMeta.Name)
 			break
 		} else {
@@ -50,11 +53,11 @@ func RemoveMember(client clientset.Interface, node *v1.Node) error {
 	return nil
 }
 
-func RemoveMemberFrom(client clientset.Interface, node, executorNode *v1.Node) error {
+func RemoveMemberFrom(client clientset.Interface, node, executorNode *v1.Node, clusterVersion *version.Version) error {
 	return kubernetes.CreateAndWaitForJob(
 		client,
 		removeMemberFromJobName(node, executorNode),
-		removeMemberFromJobSpec(node, executorNode),
+		removeMemberFromJobSpec(node, executorNode, clusterVersion),
 	)
 }
 
@@ -62,16 +65,15 @@ func removeMemberFromJobName(node, executorNode *v1.Node) string {
 	return fmt.Sprintf("caasp-remove-etcd-member-%s-from-%s", node.ObjectMeta.Name, executorNode.ObjectMeta.Name)
 }
 
-func removeMemberFromJobSpec(node, executorNode *v1.Node) batchv1.JobSpec {
+func removeMemberFromJobSpec(node, executorNode *v1.Node, clusterVersion *version.Version) batchv1.JobSpec {
 	return batchv1.JobSpec{
 		Template: v1.PodTemplateSpec{
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
 						Name: removeMemberFromJobName(node, executorNode),
-						// FIXME: fetch etcd image repo and tag from the clusterconfiguration in kubeadm-config configmap
 						// FIXME: check that etcd member is part of the member list already
-						Image: "k8s.gcr.io/etcd:3.3.10",
+						Image: images.GetGenericImage(skuba.ImageRepository, "etcd", kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, clusterVersion)),
 						Command: []string{
 							"/bin/sh", "-c",
 							fmt.Sprintf("etcdctl --endpoints=https://[127.0.0.1]:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key member remove $(etcdctl --endpoints=https://[127.0.0.1]:2379 --cacert=/etc/kubernetes/pki/etcd/ca.crt --cert=/etc/kubernetes/pki/etcd/healthcheck-client.crt --key=/etc/kubernetes/pki/etcd/healthcheck-client.key member list | grep ', %s,' | cut -d',' -f1)", node.ObjectMeta.Name),

--- a/pkg/skuba/actions/node/remove/remove.go
+++ b/pkg/skuba/actions/node/remove/remove.go
@@ -71,7 +71,7 @@ func Remove(client clientset.Interface, target string, drainTimeout time.Duratio
 
 	if isControlPlane {
 		fmt.Printf("[remove-node] removing etcd from node %s\n", targetName)
-		etcd.RemoveMember(client, node)
+		etcd.RemoveMember(client, node, currentClusterVersion)
 	}
 
 	if err := kubernetes.DisarmKubelet(client, node, currentClusterVersion); err != nil {


### PR DESCRIPTION
## Why is this PR needed?

When removing nodes, do not use a hardcoded etcd image, but instead
pull the etcd version that we need for that cluster where we are
removing a node.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
