### PR TITLE
Document skip-setup option in test command

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -17,11 +17,11 @@
   - [CI setup](#ci-setup)
 - [Usage](#usage)
   - [General CLI options](#general-cli-options)
-  - [Provision](#provision)
+  - [Provision](#provision-command)
   - [Node commands](#node-commands)
-    - [Node Upgrade](#node-upgrade)
-  - [Ssh](#ssh)
-  - [Test](#ssh)
+    - [Node Upgrade](#node-upgrade-command)
+  - [Ssh](#ssh-command)
+  - [Test](#test-command)
 - [Examples](#examples)
   - [Create K8s Cluster](#create-k8s-cluster)
   - [Collect logs](#collect-logs)
@@ -326,7 +326,7 @@ optional arguments:
                         log level
 ```
 
-### Provision
+### Provision command
 
 ```
 optional arguments:
@@ -347,7 +347,7 @@ optional arguments:
 
 ```
 
-#### Node Upgrade
+#### Node Upgrade command
 
 ```
   -h, --help            show this help message and exit
@@ -355,7 +355,7 @@ optional arguments:
                         action: plan or apply upgrade
 ```
 
-### Ssh
+### Ssh command
 
 ```
   -h, --help            show this help message and exit
@@ -367,16 +367,28 @@ optional arguments:
                         last argument for ssh command
 ```
 
-### Test
+### Test command
 
 ```
 optional arguments:
   -h, --help            show this help message and exit
+  -f MARK, --filter MARK
+                        Filter the tests based on markers
+  -j JUNIT, --junit JUNIT
+                        Name of the xml file to record the results to.
+  -m MODULE, --module MODULE
+                        folder with the tests
   -s TEST_SUITE, --suite TEST_SUITE
                         test file name
   -t TEST, --test TEST  test to execute
   -l, --list            only list tests to be executed
   -v, --verbose         show all output
+  --skip-setup {provisioned,bootstrapped,deployed}
+                        Skip the given setup step. 'provisioned' For when you
+                        have already provisioned the nodes. 'bootstrapped' For
+                        when you have already bootstrapped the cluster.
+                        'deployed' For when you already have a fully deployed
+                        cluster.
 ```
 
 

--- a/ci/infra/testrunner/tests/README.md
+++ b/ci/infra/testrunner/tests/README.md
@@ -44,7 +44,7 @@ def setup(request, platform, skuba):
     skuba.node_bootstrap()
 ```
 
-Note: pytest also allow a more idiomatic way of defining teardown logic in fixtures by using python's `yield` statement instead of registering a finalizer, as shown in the code below. However, finalizer functions have the advantage that they will always be called regardless if the fixture setup code raises an exception, provided they are registered before the exception occurs. Therefore, testrunner encourages using finalizer functions.
+Note: pytest also allow a more idiomatic way of defining teardown logic in fixtures by using python's `yield` statement instead of registering a finalizer, as shown in the code below. However, finalizer functions have the advantage that they will always be called regardless if the fixture setup code raises an exception, provided they are registered before the exception occurs. Therefore, **testrunner encourages using finalizer functions**.
 
 ```
 @pytest.fixture
@@ -55,6 +55,40 @@ def setup(request, platform, skuba):
     yield               # return from fixture
     platform.cleanup()  # teardown logic
 ```
+
+## Reusing already deployed infrastructure
+
+Sometime, it is convenient to reuse an already deployed infrastructure when executing tests. This is a common case while tests are beeing developed (as they must be tested by the developer and errors need to be fixed), or when multiple tests which have no side effects can share the same infrastructure.
+
+To address these uses cases, `testrunner`'s [`test` command](../README.md#test-command) provides the `--skip-setup` option which allows skipping the execution of one or more setup fixtures that setup, whithout having to modify the test or the fixtures. If a fixuture depends on other fixtures, those are also skipped automatically.
+
+Consider the following fixtures:
+
+```
+@pytest.fixture()
+def provision():
+# provision infrastructure
+
+@pytest.fixture()
+def bootstrap(provision, skuba):
+# bootstrap cluster
+
+@pytest.fixture()
+def deployment(bootstrap, platform, skuba)
+# complete cluster deployment
+# joining all nodes
+
+def test_deployment(deployment, skuba:
+# test fully deployed cluster
+
+```
+
+Running the following command will executed the test without executing the cluster deployment fixture and neither of the fixtures it depends (`bootstrap`, `provision`)
+
+```
+testrunner test --skip-setup deployed -t test_deployment
+```
+
 
 ## Running tests with the Testrunner
 


### PR DESCRIPTION
## Why is this PR needed?

The skip-update option modifies the way setup fixtures are executed. It is intended to be use in some particular uses cases which should be understood by test developers in order to exploit it. 

## What does this PR do?

Update the testrunner usage documentation and the test development guide to explain the usage of this option.

## Anything else a reviewer needs to know?

Nothing

## Info for QA

Nothing

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
