### PR TITLE
Add testrunner with cloud-provider option

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -112,3 +112,7 @@ test_post_bootstrap:
 .PHONY: test_e2e
 test_e2e:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --junit e2e --filter "not disruptive and not flaky" --skip-setup deployed
+
+.PHONY: test_cpi_openstack
+test_cpi_openstack:
+	${TEST_RUNNER} -v vars.yaml -p openstack test --verbose --suite test_cpi_openstack.py

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -336,8 +336,19 @@ optional arguments:
   -w WORKER_COUNT, --worker-count WORKER_COUNT
                         number of workers nodes to be deployed. eg: -w 2
 ```
+### Bootstrap
+
+ ```
+optional arguments:
+  -h, --help            show this help message and exit
+  -k KUBERNETES_VERSION, --kubernetes-version KUBERNETES_VERSION
+                        kubernetes version
+  -c, --cloud-provider
+                        The cloud provider will be offered
+```
 
 ### Node commands
+
 ```
   -h, --help            show this help message and exit
   -r {master,worker}, --role {master,worker}

--- a/ci/infra/testrunner/platforms/openstack.py
+++ b/ci/infra/testrunner/platforms/openstack.py
@@ -1,7 +1,7 @@
 import os
+import stat
 
 from timeout_decorator import timeout
-
 from platforms.terraform import Terraform
 from utils import Format
 
@@ -22,3 +22,49 @@ class Openstack(Terraform):
                      f"stack_name={self.conf.terraform.stack_name}"]
 
         self.destroy(variables)
+
+    def setup_cloud_provider(self):
+        openstack_conf_template = ""
+        for root, dirs, files in os.walk(self.conf.workspace):
+            for f in files:
+                if f == "openstack.conf.template":
+                    openstack_conf_template = os.path.join(root, f)
+
+        if not openstack_conf_template:
+            raise ValueError("openstack.conf.template file is not found")
+
+        openstack_conf = os.path.join(os.path.dirname(openstack_conf_template), "openstack.conf")
+        openrc_vars = {}
+        openrc_vars["PRIVATE_SUBNET_ID"] = ""
+        openrc_vars["PUBLIC_NET_ID"] = ""
+        with open(self.conf.openstack.openrc, mode="rt") as openrc:
+            for line in openrc:
+                try:
+                    name, _, var = line.split()[1].partition("=")
+                    if var:
+                        openrc_vars[name] = var.strip('"').strip("'")
+                except:
+                    pass
+
+        with open(openstack_conf_template, mode="rt") as tmp_conf:
+            with open(openstack_conf, mode="wt") as conf:
+                for line in tmp_conf:
+                    line = self._replace_env_vars(line, openrc_vars)
+                    conf.write(line)
+        os.chmod(openstack_conf, stat.S_IRUSR | stat.S_IWUSR)
+
+
+    def _replace_env_vars(self, line, openrc_vars):
+        """
+        openstack.conf.template provides auth-url=<OS_AUTH_URL>.  This method will replace <OS_AUTH_URL> to
+        OS_AUTH_URL from openrc file from users
+         :param line:
+        :param openrc:
+        :return:
+        """
+        name, _, var = line.strip().partition("=")
+        var = var.strip().strip("<").strip(">")
+        re_line = ""
+        if var in openrc_vars:
+            line = "=".join((name, openrc_vars[var])) + os.linesep
+        return line

--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -155,3 +155,6 @@ class Platform:
             if response.status_code != 200:
                 return False
         return True
+
+    def setup_cloud_provider(self):
+        raise ValueError("Cloud provider is not supported for this platform")

--- a/ci/infra/testrunner/requirements.txt
+++ b/ci/infra/testrunner/requirements.txt
@@ -1,5 +1,6 @@
 timeout-decorator
 requests
 pyhcl
-pytest
+pytest==5.1.0
 pyyaml
+pytest-ordering

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -36,8 +36,8 @@ def provision(options):
 
 def bootstrap(options):
     skuba = Skuba(options.conf, options.platform)
-    skuba.cluster_init(kubernetes_version=options.kubernetes_version)
-    skuba.node_bootstrap()
+    skuba.cluster_init(kubernetes_version=options.kubernetes_version, cloud_provider=options.cloud_provider)
+    skuba.node_bootstrap(cloud_provider=options.cloud_provider)
 
 
 def cluster_status(options):
@@ -103,7 +103,7 @@ def main():
                         default="openstack",
                         choices=["openstack", "vmware",
                                  "bare-metal", "libvirt"],
-                        help="The platform you're targeting. Defaults to openstack")
+                        help="The platform you're targeting. Default is openstack")
     parser.add_argument("-l", "--log-level", dest="log_level", default=None, help="log level",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR"])
 
@@ -132,6 +132,8 @@ def main():
                         deployed nodes in your platform")
     cmd_bootstrap.add_argument("-k", "--kubernetes-version", help="kubernetes version",
                                dest="kubernetes_version", default=None)
+    cmd_bootstrap.add_argument("-c", "--cloud-provider", action='store_true',
+                               help="The cloud provider you're targeting. Default is openstack")
     cmd_bootstrap.set_defaults(func=bootstrap)
 
     cmd_status = commands.add_parser("status", help="check K8s cluster status")

--- a/ci/infra/testrunner/tests/pytest.ini
+++ b/ci/infra/testrunner/tests/pytest.ini
@@ -2,5 +2,6 @@
 markers =
     disruptive: mark a test disruptive.
     flaky: mark a test flaky.
-    pre_bootstrap: mark test to run before bootstrap.
-    pre_deployment: mark test to run after bootstrap but before joining additional nodes.
+    pre_bootstrap: mark a test to run before bootstrap.
+    pre_deployment: mark a test to run after bootstrap but before joining additional nodes.
+    openstack: mark a test only for openstack platform

--- a/ci/infra/testrunner/tests/test_cpi_openstack.py
+++ b/ci/infra/testrunner/tests/test_cpi_openstack.py
@@ -1,0 +1,210 @@
+import pytest
+import time
+import os
+import platforms
+from skuba import Skuba
+from utils import BaseConfig
+
+@pytest.fixture(autouse=True, scope='module')
+def conf(request):
+    """Builds a conf object from a yaml file"""
+    path = request.config.getoption("vars")
+    return BaseConfig(path)
+
+@pytest.fixture(autouse=True, scope='module')
+def target(request):
+    """Returns the target platform"""
+    platform = request.config.getoption("platform")
+    return platform
+
+@pytest.fixture(autouse=True, scope='module')
+def platform(conf, target):
+    platform = platforms.get_platform(conf, target)
+    return platform
+
+@pytest.fixture(autouse=True, scope='module')
+def skuba(conf, target):
+    return Skuba(conf, target)
+
+@pytest.fixture(autouse=True, scope='module')
+def setup(request, platform, skuba, conf):
+    def cleanup():
+        platform.cleanup()
+        skuba.cleanup(conf)
+
+    request.addfinalizer(cleanup)
+    platform.provision(num_master=1, num_worker=3)
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=1)
+def test_init_cpi_openstack_cluster(skuba, kubernetes_version=None):
+    """
+    Initialize the cluster with the openstack cpi
+    """
+    try:
+        skuba.cluster_init(kubernetes_version, cloud_provider="openstack")
+    except:
+        pytest.fail("Failure on initializing cpi optionstack init  ...")
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=2)
+def test_bootstrap_cpi_openstack_cluster(skuba):
+    """
+    Bootstrap the cluster with the openstack cpi
+    """
+    try:
+        skuba.node_bootstrap(cloud_provider="openstack")
+    except:
+        pytest.fail("Failure on bootstrapping a cluster with cpi optionstack  ...")
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=3)
+def test_node_join_cpi_openstack_cluster(skuba, kubectl):
+    """
+    Join nodes to the cluster with the openstack cpi enabled
+    """
+    try:
+        skuba.join_nodes(masters=1, workers=3)
+    except:
+        pytest.fail("Failure on joinning nodes to the cluster with cpi optionstack  ...")
+
+    kubectl.run_kubectl("wait --for=condition=ready nodes --all --timeout=5m")
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=4)
+def test_create_cinder_storage(kubectl, skuba):
+    create_yamlfiles(skuba)
+    try:
+        file_path = os.path.join(skuba.cwd, "cinder.yaml")
+        cmd = f" apply -f {file_path}"
+        kubectl.run_kubectl(cmd)
+    except:
+        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=5)
+def test_wrtite_cinder_storage(kubectl, skuba):
+    try:
+        file_path = os.path.join(skuba.cwd, "test_write.yaml")
+        cmd = f" apply -f {file_path}"
+        kubectl.run_kubectl(cmd)
+    except:
+        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
+    time.sleep(60)
+    try:
+        cmd = " get pod | grep write-pod "
+        out = kubectl.run_kubectl(cmd)
+        assert "Completed" in out
+    except:
+        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=6)
+def test_read_cinder_storage(kubectl, skuba):
+    try:
+        file_path = os.path.join(skuba.cwd, "test_read.yaml")
+        cmd = f" apply -f {file_path}"
+        kubectl.run_kubectl(cmd)
+    except:
+        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
+    time.sleep(60)
+    try:
+        cmd = " get pod | grep read-pod"
+        out = kubectl.run_kubectl(cmd)
+        assert "Completed" in out
+    except:
+        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
+
+def create_yamlfiles(skuba):
+    filenames = {"cinder.yaml":get_cinder_yaml,
+                 "test_write.yaml":get_test_write_pod_yaml,
+                 "test_read.yaml":get_test_read_pod_yaml}
+    for filename, _function in filenames.items():
+        contents = _function()
+        with open(os.path.join(skuba.cwd, filename), mode='wt') as yaml_file:
+            for line in contents:
+                yaml_file.write(line)
+
+def get_cinder_yaml():
+    yaml = '''
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gold
+provisioner: kubernetes.io/cinder
+parameters:
+  availability: nova
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cinder-claim
+  annotations:
+    volume.beta.kubernetes.io/storage-class: gold
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: gold
+'''
+    return yaml
+
+def get_test_read_pod_yaml():
+    test_read_pod = '''
+apiVersion: v1
+kind: Pod
+metadata:
+  name: read-pod
+spec:
+  containers:
+  - name: read-pod
+    image: gcr.io/google_containers/busybox:1.24
+    command:
+      - "/bin/sh"
+    args:
+      - "-c"
+      - "test -f /mnt/SUCCESS && exit 0 || exit 1"
+    volumeMounts:
+      - name: cinder
+        mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: cinder
+      persistentVolumeClaim:
+        claimName: cinder-claim
+'''
+    return test_read_pod
+
+def get_test_write_pod_yaml():
+    test_write_pod = '''
+apiVersion: v1
+kind: Pod
+metadata:
+  name: write-pod
+spec:
+  containers:
+  - name: write-pod
+    image: gcr.io/google_containers/busybox:1.24
+    command:
+      - "/bin/sh"
+    args:
+      - "-c"
+      - "touch /mnt/SUCCESS && exit 0 || exit 1"
+    volumeMounts:
+      - name: cinder
+        mountPath: "/mnt"
+  restartPolicy: "Never"
+  volumes:
+    - name: cinder
+      persistentVolumeClaim:
+        claimName: cinder-claim
+'''
+    return test_write_pod


### PR DESCRIPTION
Testrunner can init, bootstrap, join a cluster with cpi option in Openstack.

1. Added the cloud-provider option for testrunner for deployment
`./testrunner bootstrap --cloud-provider openstack`
2. Added a full test for openstack cpi. This will trigger testcases in pytest after cloud-provider cluster is deployed 
`make test_cpi_openstack`

## Why is this PR needed?
https://github.com/SUSE/avant-garde/issues/582

## What does this PR do?
This PR can verify a regression for cloud-provider in Openstack. 

## Docs
Added in testrunner/README.md 