### PR TITLE
Shorten TERRAFORM_STACK_NAME for e2e tests

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${E2E_MAKE_TARGET_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
    }
 
    stages {


### PR DESCRIPTION
On VMWare there's a hardcoded limit of chars which cannot
be reconfigured.

## Why is this PR needed?

```
ERROR    testrunner:utils.py:245 Error: vsphere_virtual_machine.lb: expected length of name to be in the range (1 - 80), got caasp-jobs/e2e/caasp-v4-vmware-test_upgrade_plan_from_previous_with_upgraded_control_plane-nightly-test_upgrade_plan_from_previous_with_upgraded_control_plane-10-lb-0
```

## What does this PR do?

shorten the TERRAFORM_STACK_NAME which will be used for most resources in the terraform state
