### PR TITLE
runshellcommand return command result

### DIFF
--- a/ci/infra/testrunner/tests/test_node_reboot.py
+++ b/ci/infra/testrunner/tests/test_node_reboot.py
@@ -38,7 +38,7 @@ def check_nodes_ready(kubectl):
 def check_pods_ready(kubectl):
     while True:
         try:
-            pods = json.loads(kubectl.run_kubectl('get pods --all-namespaces -o json'))['items']
+            pods = json.loads(kubectl.run_kubectl('get pods --all-namespaces -o json').stdout)['items']
 
             for pod in pods:
                 pod_status = pod['status']['phase']

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -98,7 +98,7 @@ def test_upgrade_plan_from_previous(setup, skuba, kubectl, platform):
     for n in range(0, workers):
         worker = skuba.node_upgrade("plan", "worker", n, ignore_errors=True)
         # If the control plane nodes are not upgraded yet, skuba disallows upgrading a worker
-        assert worker.find("Unable to plan node upgrade: my-worker-{} is not upgradeable until all control plane nodes are upgraded".format(n))
+        assert worker.stderr.find("Unable to plan node upgrade: my-worker-{} is not upgradeable until all control plane nodes are upgraded".format(n))
 
 
 @pytest.mark.disruptive

--- a/ci/infra/testrunner/utils/command.py
+++ b/ci/infra/testrunner/utils/command.py
@@ -1,0 +1,44 @@
+class CommandResult:
+    """
+    Embeds the result of running a command for easier testing of different
+    output channels (stdout, stderr) and the return code of the execution.
+
+    Delegates iterators, direct comparisons and unknown attribute retrieval
+    (including function calls) to the `stdout` attribute for better testing
+    ergonomics.
+    """
+    def __init__(self, retcode, stdout, stderr):
+        self.retcode = retcode
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.stdout == other
+        elif isinstance(other, self.__class__):
+            return self.retcode == other.retcode and self.stdout == other.stdout and self.stderr == other.stderr
+        return False
+
+    def __contains__(self, other):
+        if isinstance(other, str):
+            return self.stdout.__contains__(other)
+        elif isinstance(other, self.__class__):
+            return self.retcode == other.retcode and self.stdout.__contains__(other.stdout) and self.stderr.__contains__(other.stderr)
+        return False
+
+    def __iter__(self):
+        return self.stdout.__iter__()
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}({self.retcode!r}, {self.stdout!r}, {self.stderr!r})'
+
+    def __str__(self):
+        return self.stdout
+
+    def __int__(self):
+        return int(self.__str__())
+
+    def __getattr__(self, name):
+        def forward_method(*args, **kwargs):
+            return getattr(self.stdout, name)(*args, **kwargs)
+        return forward_method

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -11,6 +11,7 @@ from threading import Thread
 import requests
 from timeout_decorator import timeout
 
+from utils.command import CommandResult
 from utils.constants import Constant
 from utils.format import Format
 
@@ -207,12 +208,10 @@ class Utils:
         p.wait()
         stdout, stderr = "".join(stdout), "".join(stderr)
 
-        if p.returncode != 0:
-            if not ignore_errors:
-                raise RuntimeError("Error executing command {}".format(cmd))
-            else:
-                return stderr
-        return stdout
+        if p.returncode != 0 and not ignore_errors:
+            raise RuntimeError("Error executing command {}; retcode: {}; stdout: {}; stderr: {}".format(cmd, p.returncode, stdout, stderr))
+
+        return CommandResult(p.returncode, stdout, stderr)
 
     def ssh_sock_fn(self):
         """generate path to ssh socket
@@ -282,9 +281,9 @@ class Utils:
     def info(self):
         """Node info"""
         info_lines = "Env vars: {}\n".format(sorted(os.environ))
-        info_lines += self.runshellcommand('ip a')
-        info_lines += self.runshellcommand('ip r')
-        info_lines += self.runshellcommand('cat /etc/resolv.conf')
+        info_lines += self.runshellcommand('ip a').stdout
+        info_lines += self.runshellcommand('ip r').stdout
+        info_lines += self.runshellcommand('cat /etc/resolv.conf').stdout
 
         # TODO: the logic for retrieving external is platform depedant and should be
         # moved to the corresponding platform


### PR DESCRIPTION
## Why is this PR needed?

Make `runshellcommand` return a result object
    
`runshellcommand` now returns a `CommandResult` object that contains
all attributes regarding the execution of the command: `retcode`,
`stdout` and `stderr`.
    
Tests are then free to retrieve the information they need to perform
their checks.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
