### PR TITLE
Wait for kube-system pods to be ready

### DIFF
--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -45,11 +45,11 @@ def bootstrap(request, provision, skuba):
 
 
 @pytest.fixture
-def deployment(request, bootstrap, skuba):
-    if request.config.getoption("skip_setup") == 'deployed':
-        return
+def deployment(request, bootstrap, skuba, kubectl):
+    if request.config.getoption("skip_setup") != 'deployed':
+        skuba.join_nodes()
 
-    skuba.join_nodes()
+    kubectl.run_kubectl('wait --timeout=3m --for=condition=Ready pods --all --namespace=kube-system')
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why is this PR needed?

We want to check that all the system pods are running after deployment

Fixes https://github.com/SUSE/avant-garde/issues/706

## What does this PR do?

Uses kubectl to wait for the pods to be ready

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
