### PR TITLE
Truncate TERRAFORM_STACK_NAME to 80 chars

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         REQUESTS_CA_BUNDLE = "/var/lib/ca-certificates/ca-bundle.pem"
         PR_CONTEXT = 'jenkins/skuba-jjb-validation'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
     }
     stages {
         stage('Setting GitHub in-progress status') { steps {

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         VMWARE_ENV_FILE = credentials('vmware-env')
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'vmware'
-        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
         PR_CONTEXT = 'jenkins/skuba-test-vmware'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'openstack'
-        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
         PR_CONTEXT = 'jenkins/skuba-test'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
         OPENSTACK_OPENRC = credentials('ecp-openrc')
-        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
     }

--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
-        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
    }
 
    stages {

--- a/ci/jenkins/pipelines/skuba-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-jjb.Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     environment {
         JENKINS_JOB_CONFIG = credentials('jenkins-job-config')
         REQUESTS_CA_BUNDLE = "/var/lib/ca-certificates/ca-bundle.pem"
-        TERRAFORM_STACK_NAME = "${JOB_NAME}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
     }
     stages {
         stage('Info') { steps {

--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
    environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
         OPENSTACK_OPENRC = credentials('ecp-openrc')
-        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}"
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
    }


### PR DESCRIPTION
## Why is this PR needed?

Some jobs have unexpectably long names, and on vmware we can have
a maximum of 80 chars for resource names, so truncate to 80 and
put the build number upfront to minimize chances that another
job will have the same resource name.

## What does this PR do?

Make sure that `TERRAFORM_STACK_NAME` is max. 80 chars

## Anything else a reviewer needs to know?

Follow up of https://github.com/SUSE/skuba/pull/692

Unfortunately some names are still too long https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/e2e/job/caasp-v4-vmware-test_upgrade_apply_from_previous-nightly/18/console
