### PR TITLE
Further reduce TERRAFORM_STACK_NAME

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
         REQUESTS_CA_BUNDLE = "/var/lib/ca-certificates/ca-bundle.pem"
         PR_CONTEXT = 'jenkins/skuba-jjb-validation'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
     }
     stages {
         stage('Setting GitHub in-progress status') { steps {

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         VMWARE_ENV_FILE = credentials('vmware-env')
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'vmware'
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
         PR_CONTEXT = 'jenkins/skuba-test-vmware'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'openstack'
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
         PR_CONTEXT = 'jenkins/skuba-test'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
         OPENSTACK_OPENRC = credentials('ecp-openrc')
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
     }

--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
         OPENSTACK_OPENRC = credentials('ecp-openrc')
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
    }
 
    stages {

--- a/ci/jenkins/pipelines/skuba-jjb.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-jjb.Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     environment {
         JENKINS_JOB_CONFIG = credentials('jenkins-job-config')
         REQUESTS_CA_BUNDLE = "/var/lib/ca-certificates/ca-bundle.pem"
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
     }
     stages {
         stage('Info') { steps {

--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
    environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
         OPENSTACK_OPENRC = credentials('ecp-openrc')
-        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(80)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
    }


### PR DESCRIPTION
## Why is this PR needed?

Resource names are taking TERRAFORM_STACK_NAME and adding additional
suffixes which exceed the 80 chars again.

Reducing to 70 should leave enough space for that.

## What does this PR do?

Reducing TERRAFORM_STACK_NAME to 70 chars

## Anything else a reviewer needs to know?

Follow up of https://github.com/SUSE/skuba/pull/696

Still failing builds e.g. https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/e2e/job/caasp-v4-vmware-test_upgrade_apply_from_previous-nightly/24/consoleFull
