### PR TITLE
skuba-update: fix RPM requirements

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -58,6 +58,7 @@ Summary:        Utility to automatically refresh and update a skuba cluster
 Group:          System/Management
 Requires:       python3-setuptools
 Requires:       zypper >= 1.14.15
+Requires:       kubernetes-client
 Requires:       lsof
 BuildArch:      noarch
 %{?systemd_requires}


### PR DESCRIPTION
## Why is this PR needed?

he skuba-update binary requires the kubectl binary to be available. This dependency is usually satisfied when skuba-update is installed via skuba because quite some packages are installed on the node at the same time.

However this dependency is not made explicit at the package level.

As a result of that, installing skuba-update manually doesn't pull this required dependency.

This commit just makes the dependency explicit.

Fixes #

I haven't filed a bugzilla entry yet. Should I?

## What does this PR do?

This PR makes the RPM dependency between skuba-update and kubectl explicit.

## Anything else a reviewer needs to know?

Nothing special.

## Info for QA

Just do a `zypper in skuba-update` on a node where the `kubernetes-client` is not installed. The package with this new runtime requirement will pull the missing package.

### Status **BEFORE** applying the patch

kubectl can be missing even though skuba-update is installed on the machine.

### Status **AFTER** applying the patch

kubectl is always available on the machine when skuba-update is installed.

## Docs

Nothing to be done.