### PR TITLE
Redirect pip3 install output to /dev/null

### DIFF
--- a/ci/infra/testrunner/testrunner
+++ b/ci/infra/testrunner/testrunner
@@ -18,7 +18,7 @@ setup_python_env() {
   source ${VENVDIR}/bin/activate
   # Not calling to `pip3` directly because its shebang can exceed 128 characters
   # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
-  python -m pip install -r "${SDIR}/requirements.txt"
+  python -m pip install -r "${SDIR}/requirements.txt" &>/dev/null
 }
 
 setup_python_env


### PR DESCRIPTION
## Why is this PR needed?

While running testrunner locally sending pip output to
stdout makes execution noisy.

This commit reverts 6a395d7e which was introduced to make
debugging in CI easier.

## What does this PR do?

Redirects pip output to /dev/null

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
