### PR TITLE
Make sure pause-image is configured by skuba (bsc#1144905)

### DIFF
--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
-	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 type InitConfiguration struct {
@@ -71,10 +70,6 @@ func Init(initConfiguration InitConfiguration) error {
 		return errors.Wrapf(err, "could not change to cluster directory %q", initConfiguration.ClusterName)
 	}
 	for _, file := range scaffoldFilesToWrite {
-		// If '--strict-capability-defaults' is used, then don't modify the /etc/sysconfig/crio
-		if initConfiguration.StrictCapDefaults && file.Location == skuba.CriDockerDefaultsConfFile() {
-			continue
-		}
 		filePath, _ := filepath.Split(file.Location)
 		if filePath != "" {
 			if err := os.MkdirAll(filePath, 0700); err != nil {

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -58,8 +58,8 @@ useHyperKubeImage: true
 ## Default        : ""
 ## ServiceRestart : crio
 #
-CRIO_OPTIONS=--pause-image={{.PauseImage}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
-  `
+CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"{{end}}
+`
 
 	masterConfTemplate = `apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration


### PR DESCRIPTION
## Why is this PR needed?

This PR makes sure the crio configuration is always applied regardless of the usage of `--strict-capability-defaults` flag or not. This is needed to ensure that dropping caasp-config package won't have any effect. All configurations are managed by skuba, caasp-config was only configuring crio, but this not the case any more. 

This PR just fills the gap for the corner case in which skuba was not providing the crio configuration for the pause image.

Required for SUSE/avant-garde#724

## What does this PR do?

The crio configuration template now is always applied and including
the pause image configuration and the container capabilities are only
configured in case the --strict-capability-defaults is applied.

This commit enables to completely drop the caasp-config package, this
is related to bsc#1144905

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

Initiate a cluster with --strict-capability-defaults flag and check the pause image is being properly configured in `/etc/sysconfig/crio` and without the flag is also being configured properly including some container capabilities configurations.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.


## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
