### PR TITLE
Fix changelog generator

### DIFF
--- a/ci/packaging/suse/changelog_maker.sh
+++ b/ci/packaging/suse/changelog_maker.sh
@@ -7,7 +7,7 @@ changes=${1:-skuba.changes.append}
 
 [ -f "${changes}" ] && rm "${changes}"
 
-mapfile -t tags < <( git tag --merged | sort -r | head -n2 )
+mapfile -t tags < <( git tag --merged | sort -rV | head -n2 )
 scope="${tags[1]}..${tags[0]}"
 
 {


### PR DESCRIPTION
## Why is this PR needed?

The current changelog generation under some circumstances could lead to wrong entries becuase of sorting tags (that represent software versions) in alphabetical order. This could happen comparing versions like `0.10.x` and `0.9.x`.

## What does this PR do?

This commit ensures that the changelog generator uses the highest
couple of tags of the current branch. Tags are sorted assuming they
represent software versions (MAJOR.MINOR.PATCH).

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.


## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
