### PR TITLE
Reference ssh key by path

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -109,9 +109,7 @@ There are some arguments that are currently at the top level of the configuratio
 
 - log_dir: path to the directory where platform logs are collected. Defaults to `<workspace>/testrunner_logs` 
 - nodeuser: the user name used to login into the platform nodes. Optional. 
-- ssh_option: specifies the location of the key used to access nodes. Can have two possible values:
-  - "id_shared": uses the key located at `<skuba src directory>/ci/infra/id_shared` (default)
-  - "id_rsa": uses the user's key located at `$HOME/.ssh/id_rsa`
+- ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
 
 #### Terraform
 
@@ -156,7 +154,7 @@ vmware:
 The Skuba section defines the location and execution options for the `skuba` command. As `testrunner` can be used either from a local development or testing environment or a CI pipeline, the configuration allows to define the location of both the source and the binary. Please notice that the source location is used as default location for other configuration elements, such as terraform files, even if the `skuba` binary is specified. 
 
 * binpath: path to skuba binary
-* srcpath: path to skuba source. Used to locate other resources, like terraform configuration, and ssh keys.
+* srcpath: path to skuba source. Used to locate other resources, like terraform configuration.
 * verbosity: verbosity level for skuba command execution
 
 ```
@@ -234,7 +232,7 @@ Be sure you don't specify the `terraform.tfdir` directory, so terraform configur
 You use your `id_rsa` keys to connect to the cluster nodes, as the `shared_id` is not available.
 
 ```
-ssh_option: "id_rsa"
+ssh_key: "path/to/id_rsa"
 ```
 
 #### Open Stack

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -19,7 +19,7 @@ class BaseConfig:
         obj.yaml_path = yaml_path
         obj.workspace = None
         obj.terraform_json_path = None
-        obj.ssh_key_option = None
+        obj.ssh_key = None
         obj.username = None
         obj.nodeuser = None
         obj.log_dir = None
@@ -166,11 +166,10 @@ class BaseConfig:
         if not conf.terraform.internal_net:
             conf.terraform.internal_net = conf.terraform.stack_name
 
-        # TODO: add the path to shared ssh credentials as a configuration parameter
-        if conf.ssh_key_option == "id_shared":
-            conf.ssh_key_option = os.path.join(conf.skuba.srcpath, "ci/infra/id_shared")
-        elif conf.ssh_key_option == "id_rsa":
-            conf.ssh_key_option = os.path.join(os.path.expanduser("~"), ".ssh/id_rsa")
+        if not conf.ssh_key:
+            conf.ssh_key = os.path.join(os.path.expanduser("~"), ".ssh/id_rsa")
+        else:
+            conf.ssh_key = os.path.expandvars(conf.ssh_key)
 
         return conf
 

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -128,15 +128,15 @@ class Utils:
         return logging_errors
 
     def authorized_keys(self):
-        public_key_path = self.conf.ssh_key_option + ".pub"
-        os.chmod(self.conf.ssh_key_option, 0o400)
+        public_key_path = self.conf.ssh_key + ".pub"
+        os.chmod(self.conf.ssh_key, 0o400)
 
         with open(public_key_path) as f:
             pubkey = f.read().strip()
         return pubkey
 
     def ssh_run(self, ipaddr, cmd):
-        key_fn = self.conf.ssh_key_option
+        key_fn = self.conf.ssh_key
         cmd = "ssh " + Constant.SSH_OPTS + " -i {key_fn} {username}@{ip} -- '{cmd}'".format(
             key_fn=key_fn, ip=ipaddr, cmd=cmd, username=self.conf.nodeuser)
         return self.runshellcommand(cmd)
@@ -149,7 +149,7 @@ class Utils:
         :param local_file_path: (str) Path where to store the log
         :return:
         """
-        cmd = (f"scp {Constant.SSH_OPTS} -i {self.conf.ssh_key_option}"
+        cmd = (f"scp {Constant.SSH_OPTS} -i {self.conf.ssh_key}"
                f" {self.conf.nodeuser}@{ip_address}:{remote_file_path} {local_file_path}")
         self.runshellcommand(cmd)
 
@@ -161,7 +161,7 @@ class Utils:
         :param local_dir_path: (str) Path where to store the dir
         :return:
         """
-        cmd = (f'rsync -avz --no-owner --no-perms -e "ssh {Constant.SSH_OPTS} -i {self.conf.ssh_key_option}"  '
+        cmd = (f'rsync -avz --no-owner --no-perms -e "ssh {Constant.SSH_OPTS} -i {self.conf.ssh_key}"  '
                f'--rsync-path="sudo rsync" --ignore-missing-args {self.conf.nodeuser}@{ip_address}:{remote_dir_path} '
                f'{local_dir_path}')
         self.runshellcommand(cmd)
@@ -247,7 +247,7 @@ class Utils:
     @timeout(60)
     @step
     def setup_ssh(self):
-        os.chmod(self.conf.ssh_key_option, 0o400)
+        os.chmod(self.conf.ssh_key, 0o400)
 
         # use a dedicated agent to minimize stateful components
         sock_fn = self.ssh_sock_fn()
@@ -275,7 +275,7 @@ class Utils:
             pass
         self.runshellcommand("ssh-agent -a {}".format(sock_fn))
         self.runshellcommand(
-            "ssh-add " + self.conf.ssh_key_option, env={"SSH_AUTH_SOCK": sock_fn})
+            "ssh-add " + self.conf.ssh_key, env={"SSH_AUTH_SOCK": sock_fn})
 
     @timeout(30)
     @step

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -1,6 +1,6 @@
 # Infra deployment engine
 workspace: "" # Working directory for testrunner
-ssh_key_option: "id_shared" # "id_shared" or "id_rsa" for your local public key
+ssh_key: "$WORKSPACE/skuba/ci/infra/id_shared" # path to ssh keys
 username: ""  # Fill your username
 nodeuser: "sles"  # Default node username
 


### PR DESCRIPTION
# Why is this PR needed?

Presently, the location for the ssh keys used by testrunner is defined indirectly by the `ssh_key_option` parameter which has two possible values:
* id_shared: the key at `<skuba.srcpath>/ci/infra/id_shared` is used
* id_rsa: the key at `<user home>/.ssh/id_rsa` is used

This has several inconvenientes and limitations:
* It is non intuitive
* Assumes the user uses `id_rsa`
* Assumes the skuba source is locally available and the skuba srcpath is specified
* Doesn't allow a team to share they own keys

Fixes https://github.com/SUSE/avant-garde/issues/688
Supersedes: https://github.com/SUSE/skuba/pull/593 

## What does this PR do?

Replace the `ssh_key_option` configuration parameter by the `ssh_key` parameter, which
points to to ssh key to be used. It defaults to the `id_rsa` key at the `~/.ssh` for the current user.

Additionally, make `vars.yaml` to point to the `shared_id` keys in the  `skuba/ci/
directory` to make it compatible with the CI setup.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
