### PR TITLE
Fix ssh setup sequence

### DIFF
--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -13,6 +13,7 @@ class Platform:
     def __init__(self, conf):
         self.conf = conf
         self.utils = Utils(conf)
+        self.utils.setup_ssh()
 
         # Which logs will be collected from the nodes
         self.logs = {

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -38,8 +38,6 @@ class Terraform(Platform):
         exception = None
         self._check_tf_deployed()
 
-        self.utils.setup_ssh()
-
         init_cmd = "init"
         if self.conf.terraform.plugin_dir:
             logger.info(f"Installing plugins from {self.conf.terraform.plugin_dir}")

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -17,6 +17,7 @@ class Skuba:
         self.utils = Utils(self.conf)
         self.platform = platforms.get_platform(conf, platform)
         self.cwd = "{}/test-cluster".format(self.conf.workspace)
+        self.utils.setup_ssh()
 
     def _verify_skuba_bin_dependency(self):
         if not os.path.isfile(self.binpath):


### PR DESCRIPTION
## Why is this PR needed?
ssh setup routine ensures the ssh-agent is running and sets the socket to communicate with it. This setup is required before running terraform and skuba.

However, presently it is only been setup before provisioning the cluster. If the agent is killed and a skuba command is run, it fails.

Fixes: https://github.com/SUSE/avant-garde/issues/862

## What does this PR do?

Ensure ssh is properly setup before any platform or skuba commands are executed.



## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
