### PR TITLE
Fix platform provisioning exception reporting

### DIFF
--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -111,7 +111,7 @@ class Platform:
             except Exception as ex:
                 logger.warning(f"Provision attempt {retry}/{retries} failed")
                 if retry == retries:
-                    raise Exception(f"Failed {self.__class__.__name__} deployment") from ex
+                    raise Exception(f"Failed {self.__class__.__name__} provisioning: {ex}") from ex
 
     def ssh_run(self, role, nr, cmd):
         ip_addrs = self.get_nodes_ipaddrs(role)

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -58,9 +58,15 @@ class Terraform(Platform):
         except Exception as ex:
             exception = ex
         finally:
-            self._fetch_terraform_output()
-            if exception:
-                raise exception
+            try:
+                self._fetch_terraform_output()
+            except Exception as inner_ex:
+                # don't override original exception if any
+                if not exception:
+                    exception = inner_ex
+
+        if exception:
+           raise exception
 
     def _load_tfstate(self):
         if self.state is None:


### PR DESCRIPTION
## Why is this PR needed?

Currently exceptions that occurs during platform provisioning
are reported without detail of the cause.

Fixes https://github.com/SUSE/avant-garde/issues/811

## What does this PR do?

Reports the original exception when reporting provisioning failures. 

Also, if an exception occurs while trying to retrieve terraform
state after a provisioning failure, the original exception is still reported.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
