### PR TITLE
Make collab check part of jenkinsfile

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
@@ -13,9 +13,27 @@ pipeline {
     }
 
     stages {
-        stage('Collaborator Check') { steps {
-            sh(script: "${PR_MANAGER} check-pr --collab-check", label: "Checking if collaborator")
-        }}
+        stage('Collaborator Check') { steps { script {
+            def membersResponse = httpRequest(
+                url: "https://api.github.com/repos/SUSE/skuba/collaborators/${CHANGE_AUTHOR}",
+                authentication: 'github-token',
+                validResponseCodes: "204:404")
+
+            if (membersResponse.status == 204) {
+                echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
+
+            } else {
+                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                ])
+
+                if (!allowExecution) {
+                    echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"
+                    error(message: "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed")
+                    return;
+                }
+            }
+        } } }
 
         stage('Setting GitHub in-progress status') { steps {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -21,9 +21,27 @@ pipeline {
     }
 
     stages {
-        stage('Collaborator Check') { steps {
-            sh(script: "${PR_MANAGER} check-pr --collab-check", label: "Checking if collaborator")
-        }}
+        stage('Collaborator Check') { steps { script {
+            def membersResponse = httpRequest(
+                url: "https://api.github.com/repos/SUSE/skuba/collaborators/${CHANGE_AUTHOR}",
+                authentication: 'github-token',
+                validResponseCodes: "204:404")
+
+            if (membersResponse.status == 204) {
+                echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
+
+            } else {
+                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                ])
+
+                if (!allowExecution) {
+                    echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"
+                    error(message: "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed")
+                    return;
+                }
+            }
+        } } }
 
         stage('Setting GitHub in-progress status') { steps {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")

--- a/ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile
@@ -11,9 +11,27 @@ pipeline {
         FILTER_SUBDIRECTORY = 'skuba-update'
     }
     stages {
-        stage('Collaborator Check') { steps {
-            sh(script: "${PR_MANAGER} check-pr --collab-check", label: "Checking if collaborator")
-        }}
+        stage('Collaborator Check') { steps { script {
+            def membersResponse = httpRequest(
+                url: "https://api.github.com/repos/SUSE/skuba/collaborators/${CHANGE_AUTHOR}",
+                authentication: 'github-token',
+                validResponseCodes: "204:404")
+
+            if (membersResponse.status == 204) {
+                echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
+
+            } else {
+                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                ])
+
+                if (!allowExecution) {
+                    echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"
+                    error(message: "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed")
+                    return;
+                }
+            }
+        } } }
 
         stage('Setting GitHub in-progress status') { steps {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")

--- a/ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile
@@ -12,9 +12,27 @@ pipeline {
         DOCKERIZED_UNIT_TESTS = '1'
     }
     stages {
-        stage('Collaborator Check') { steps {
-            sh(script: "${PR_MANAGER} check-pr --collab-check", label: "Checking if collaborator")
-        }}
+        stage('Collaborator Check') { steps { script {
+            def membersResponse = httpRequest(
+                url: "https://api.github.com/repos/SUSE/skuba/collaborators/${CHANGE_AUTHOR}",
+                authentication: 'github-token',
+                validResponseCodes: "204:404")
+
+            if (membersResponse.status == 204) {
+                echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
+
+            } else {
+                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                ])
+
+                if (!allowExecution) {
+                    echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"
+                    error(message: "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed")
+                    return;
+                }
+            }
+        } } }
 
         stage('Setting GitHub in-progress status') { steps {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")

--- a/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
@@ -12,9 +12,27 @@ pipeline {
     }
 
     stages {
-        stage('Collaborator Check') { steps {
-            sh(script: "${PR_MANAGER} check-pr --collab-check", label: "Checking if collaborator")
-        }}
+        stage('Collaborator Check') { steps { script {
+            def membersResponse = httpRequest(
+                url: "https://api.github.com/repos/SUSE/skuba/collaborators/${CHANGE_AUTHOR}",
+                authentication: 'github-token',
+                validResponseCodes: "204:404")
+
+            if (membersResponse.status == 204) {
+                echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
+
+            } else {
+                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                ])
+
+                if (!allowExecution) {
+                    echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"
+                    error(message: "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed")
+                    return;
+                }
+            }
+        } } }
 
         stage('Setting GitHub in-progress status') { steps {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")


### PR DESCRIPTION
## Why is this PR needed?

We should check if someone is a collaborator before testing their pr

## What does this PR do?

Makes the collab check part of the jenkinsfile instead of pr manager

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
