### PR TITLE
Fix typo (bsc#1149637)

### DIFF
--- a/cmd/skuba/node/bootstrap.go
+++ b/cmd/skuba/node/bootstrap.go
@@ -51,7 +51,7 @@ func NewBootstrapCmd() *cobra.Command {
 
 			d := target.GetDeployment(nodenames[0])
 			if err := node.Bootstrap(bootstrapConfiguration, d); err != nil {
-				klog.Fatalf("error bootstraping node: %s", err)
+				klog.Fatalf("error bootstrapping node: %s", err)
 			}
 		},
 		Args: cobra.ExactArgs(1),


### PR DESCRIPTION
#Why is this PR needed?

Fix a typo inside of one of our logging messages. See [bsc#1149637](https://bugzilla.suse.com/show_bug.cgi?id=1149637)

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.