### PR TITLE
Dex/gangway HA deployments (#bsc1143232)

### DIFF
--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -159,7 +159,7 @@ metadata:
   name: oidc-dex
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: oidc-dex

--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -122,7 +122,7 @@ metadata:
   labels:
     app: oidc-gangway
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: oidc-gangway

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -91,8 +91,8 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 0},
 				Kured:   &AddonVersion{"1.2.0", 0},
-				Dex:     &AddonVersion{"2.16.0", 0},
-				Gangway: &AddonVersion{"3.1.0", 0},
+				Dex:     &AddonVersion{"2.16.0", 1},
+				Gangway: &AddonVersion{"3.1.0", 1},
 				PSP:     &AddonVersion{"1.0.0", 0},
 			},
 		},
@@ -111,8 +111,8 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 0},
 				Kured:   &AddonVersion{"1.2.0", 0},
-				Dex:     &AddonVersion{"2.16.0", 0},
-				Gangway: &AddonVersion{"3.1.0", 0},
+				Dex:     &AddonVersion{"2.16.0", 1},
+				Gangway: &AddonVersion{"3.1.0", 1},
 				PSP:     &AddonVersion{"1.0.0", 0},
 			},
 		},
@@ -131,8 +131,8 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 0},
 				Kured:   &AddonVersion{"1.2.0", 0},
-				Dex:     &AddonVersion{"2.16.0", 0},
-				Gangway: &AddonVersion{"3.1.0", 0},
+				Dex:     &AddonVersion{"2.16.0", 1},
+				Gangway: &AddonVersion{"3.1.0", 1},
 				PSP:     &AddonVersion{"1.0.0", 0},
 			},
 		},


### PR DESCRIPTION
Align with v3, replicas set to 3.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>

## Why is this PR needed?

At v3, the number of dex replicas is 3 and also for HA requirement.

Fixes #bsc1143232

## What does this PR do?

Change deployment replicas from 1 to 3.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

After cluster deployed, run
```
kubectl get pods -n kube-system
```
1 pod for dex and gangway separately.

### Status **AFTER** applying the patch

After cluster deployed, run
```
kubectl get pods -n kube-system
```
3 pods for dex and gangway separately.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
