### PR TITLE
[VMware] Use only one userdata/metadata for LB

### DIFF
--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -83,7 +83,6 @@ data "template_file" "haproxy_dex_backends_master" {
 }
 
 data "template_file" "lb_cloud_init_metadata" {
-  count    = "${var.lbs}"
   template = "${file("cloud-init/metadata.tpl")}"
 
   vars {
@@ -93,7 +92,6 @@ data "template_file" "lb_cloud_init_metadata" {
 }
 
 data "template_file" "lb_cloud_init_userdata" {
-  count    = "${var.lbs}"
   template = "${file("cloud-init/lb.tpl")}"
 
   vars {


### PR DESCRIPTION
## Why is this PR needed?

The counts currently block the deployment
of several LBs, since the LBs share the same
userdata/metada, there is no need to create
several based on the number of LBs.

Deploying several LBs is required to test
the Linux-HA stack Load Balancing with CaaSP.

Signed-off-by: lcavajani <lcavajani@suse.com>

## Info for QA

We can now use `lbs = 2` 

It was failing with:

```
Error: Error running plan: 1 error occurred:
	* vsphere_virtual_machine.lb: 2 errors occurred:
	* vsphere_virtual_machine.lb[1]: Resource 'data.template_file.lb_cloud_init_metadata' not found for variable 'data.template_file.lb_cloud_init_metadata.rendered'
	* vsphere_virtual_machine.lb[0]: Resource 'data.template_file.lb_cloud_init_userdata' not found for variable 'data.template_file.lb_cloud_init_userdata.rendered'
```


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
