### PR TITLE
CODEOWNERS: Clean up file before turning mandatory reviews on

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,16 +12,8 @@
 # Order is important; the last matching pattern takes the most
 # precedence.
 
-# Instead of maching the individual skuba directories,
-# we can look for *.go files instead.
-*.go @ereslibre @nirmoy @klaven
+# The codeowners of this file are the repository admins
+.github/CODEOWNERS @ereslibre @flavio @innobead @jordimassaguerpla @stefsuse
 
-/skuba-update/ @davidcassany @mssola
-
-/ci/ @tdaines42
-/ci/infra/testrunner/ @pablochacin @tdaines42
-/ci/packaging/ @davidcassany @MaximilianMeister
-
-/test/ @pablochacin
-
-/tools/ @ereslibre
+# A file/directory pattern or domain MUST have at least 3 codeowners before
+# it is added to this file.


### PR DESCRIPTION
The CODEOWNERS file was being used as a notification method for those
who were interested in specific domains. However, it was decided to
repurpose it and make reviews from CODEOWNERS mandatory. As a result of
which, we need to clean it up in order to prevent dragging people into
reviews before they sign up for it.