### PR TITLE
Added timeout to Jenkins user input

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
@@ -21,9 +21,24 @@ pipeline {
                 echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
 
             } else {
-                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
-                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
-                ])
+                def allowExecution = false
+
+                try {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                            booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                        ])
+                    }
+                } catch(err) {
+                    def user = err.getCauses()[0].getUser()
+                    if('SYSTEM' == user.toString()) {
+                        echo "Timeout while waiting for input"
+                    } else {
+                        allowExecution = false
+                        echo "Unhandled error:\n${err}"
+                    }
+                }
+                
 
                 if (!allowExecution) {
                     echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -31,9 +31,24 @@ pipeline {
                 echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
 
             } else {
-                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
-                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
-                ])
+                def allowExecution = false
+
+                try {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                            booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                        ])
+                    }
+                } catch(err) {
+                    def user = err.getCauses()[0].getUser()
+                    if('SYSTEM' == user.toString()) {
+                        echo "Timeout while waiting for input"
+                    } else {
+                        allowExecution = false
+                        echo "Unhandled error:\n${err}"
+                    }
+                }
+                
 
                 if (!allowExecution) {
                     echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -30,9 +30,24 @@ pipeline {
                 echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
 
             } else {
-                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
-                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
-                ])
+                def allowExecution = false
+
+                try {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                            booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                        ])
+                    }
+                } catch(err) {
+                    def user = err.getCauses()[0].getUser()
+                    if('SYSTEM' == user.toString()) {
+                        echo "Timeout while waiting for input"
+                    } else {
+                        allowExecution = false
+                        echo "Unhandled error:\n${err}"
+                    }
+                }
+                
 
                 if (!allowExecution) {
                     echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"

--- a/ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile
@@ -21,9 +21,24 @@ pipeline {
                 echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
 
             } else {
-                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
-                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
-                ])
+                def allowExecution = false
+
+                try {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                            booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                        ])
+                    }
+                } catch(err) {
+                    def user = err.getCauses()[0].getUser()
+                    if('SYSTEM' == user.toString()) {
+                        echo "Timeout while waiting for input"
+                    } else {
+                        allowExecution = false
+                        echo "Unhandled error:\n${err}"
+                    }
+                }
+                
 
                 if (!allowExecution) {
                     echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"

--- a/ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile
@@ -22,9 +22,24 @@ pipeline {
                 echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
 
             } else {
-                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
-                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
-                ])
+                def allowExecution = false
+
+                try {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                            booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                        ])
+                    }
+                } catch(err) {
+                    def user = err.getCauses()[0].getUser()
+                    if('SYSTEM' == user.toString()) {
+                        echo "Timeout while waiting for input"
+                    } else {
+                        allowExecution = false
+                        echo "Unhandled error:\n${err}"
+                    }
+                }
+                
 
                 if (!allowExecution) {
                     echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"

--- a/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
@@ -22,9 +22,24 @@ pipeline {
                 echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
 
             } else {
-                def allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
-                    booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
-                ])
+                def allowExecution = false
+
+                try {
+                    timeout(time: 5, unit: 'MINUTES') {
+                        allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                            booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                        ])
+                    }
+                } catch(err) {
+                    def user = err.getCauses()[0].getUser()
+                    if('SYSTEM' == user.toString()) {
+                        echo "Timeout while waiting for input"
+                    } else {
+                        allowExecution = false
+                        echo "Unhandled error:\n${err}"
+                    }
+                }
+                
 
                 if (!allowExecution) {
                     echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"


### PR DESCRIPTION
Otherwise it will hang until the pipeline timeout

## Why is this PR needed?

If someone who's not a collaborator submits a pull request the pipeline will be paused until it's approved in Jenkins. This will eventually block other runs until the job times out.

Fixes #


## What does this PR do?

Adds a timeout to the input

## Anything else a reviewer needs to know?



# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
