### PR TITLE
Provide function for waiting actions in tests

### DIFF
--- a/ci/infra/testrunner/tests/README.md
+++ b/ci/infra/testrunner/tests/README.md
@@ -132,3 +132,30 @@ Testrunner provides a library of functions that wraps `skuba` and `terraform` fo
 - `node_join(role, nr)`: adds a new node to the cluster with the given role. The node is identified by its index in the provisioned nodes for that role.
 - `node_remove(role, nr)` removes a node currently part of the cluster. The node is identified by its role an its id in the list of provisioned nodes for that role.
 - `num_of_nodes(role)`: returns the number of nodes in cluster for the given role.
+
+## Handling timeouts and retries
+
+Sometimes tests involve operations that require waiting for some time until they are completed (e.g. deploying a component) and eventually retrying them. In order to facilitate implementing this kind of logic, the testrunner test library offers the function `wait` which can be used to wrap another function call and specify how to handle timeouts and retries:
+
+```
+wait(func, *args, **kwargs)
+```
+
+The `wait` function receives the name of a function to invoke, a list of arguments, and a list of key-value pairs, which are passed to the function. Additionally, some key-value parameters can be passed to the wait function itself:
+* wait_delay: time before first try in seconds (default 0)
+* wait_timeout: timeout in seconds for waiting each try to complete (default, 5)
+* wait_allow: a tuple of exceptions that are expected and must be retried (default, none)
+* wait_retries: number of retries in case of failed invication (default, 3)
+* wait_backoff: delay in seconds between retries (default, 1 second)
+
+For example, the following code reboots a node and waits until a command can be executed sucessfully, with an initial 30 seconds delay to give time for the node to reboot. The exception `RuntimeError` is allow and retried because `ssh_run` raises it in case it cannot stablish a connection.
+```
+from test.testconf import platform
+from test.utils import wait
+
+test_reboot(provision, platform):
+    
+    platform.ssh_run("master", "0", "sudo reboot &")
+
+    wait(platform.ssh, "master", "0", "/bin/true", wait_delay=30, wait_timeout=10, wait_retries=3, wait_bakoff=30, wait_allow=(RuntimeError))
+``` 

--- a/ci/infra/testrunner/tests/README.md
+++ b/ci/infra/testrunner/tests/README.md
@@ -158,4 +158,13 @@ test_reboot(provision, platform):
     platform.ssh_run("master", "0", "sudo reboot &")
 
     wait(platform.ssh, "master", "0", "/bin/true", wait_delay=30, wait_timeout=10, wait_retries=3, wait_bakoff=30, wait_allow=(RuntimeError))
-``` 
+```
+
+**Note**: current implementation does not allow nesting calls to the `wait` function. Therefore the code shown below will not work:
+```
+def waiting_function():
+    wait( ....)
+
+test_waiting():
+    wait(waiting_function, ...)
+```

--- a/ci/infra/testrunner/tests/test_timeout.py
+++ b/ci/infra/testrunner/tests/test_timeout.py
@@ -1,0 +1,11 @@
+import pytest
+from tests.utils import wait
+
+def test_reboot(deployment, platform):
+
+    try:
+        platform.ssh_run("worker", 0, "sudo reboot &")
+    except Exception:
+        pass
+
+    wait(platform.ssh_run, "worker", 0, "/bin/true", wait_delay=30,  wait_timeout=10, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))

--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -1,0 +1,34 @@
+import signal
+import time
+
+def wait(func, *args, **kwargs):
+
+    class TimeoutError(Exception):
+        pass
+
+    timeout = kwargs.pop("wait_timeout", 5)
+    delay   = kwargs.pop("wait_delay", 0)
+    backoff = kwargs.pop("wait_backoff", 1)
+    retries = kwargs.pop("wait_retries", 3)
+    allow   = kwargs.pop("wait_allow", ())
+    def _handle_timeout(signum, frame):
+        raise TimeoutError()
+
+    time.sleep(delay)
+    reason=""
+    for i in range(0, retries):
+        signal.signal(signal.SIGALRM, _handle_timeout)
+        signal.alarm(timeout)
+        try:
+            return func(*args, **kwargs)
+        except TimeoutError:
+            reason = "timeout {}s exceded".format(timeout)
+        except allow as ex:
+            reason = "{}: '{}'".format(ex.__class__.__name__, ex)
+        finally:
+            signal.alarm(0)
+
+        time.sleep(backoff)
+
+    raise Exception("Failed waiting for function {} due to {} after {} retries".format(func.__name__, reason, retries))
+


### PR DESCRIPTION
## Why is this PR needed?

Sometimes tests include actions such as executing commands in the nodes which must wait for a bounded time, and retried in case of failure. It would be convenient to implement this logic as part of the test library to be reused by tests.

Fixes https://github.com/SUSE/avant-garde/issues/871

## What does this PR do?

Implements the `wait` function which allows waiting actions in tests
to complete and retry in case of timeout or selected exceptions occurs.

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
