### PR TITLE
Fix cleanup verbosity

### DIFF
--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -48,12 +48,12 @@ class Utils:
             try:
                 os.chmod(file, permissions)
             except Exception as ex:
-                logger.exception(ex)
+                logger.debug(ex)
 
     @staticmethod
     def cleanup_file(file):
         if os.path.exists(file):
-            logger.info(f"Cleaning up {file}")
+            logger.debug(f"Cleaning up {file}")
             try:
                 try:
                     # Attempt to remove the file first, because a socket (e.g.
@@ -62,9 +62,9 @@ class Utils:
                 except IsADirectoryError:
                     shutil.rmtree(file)
             except Exception as ex:
-                logger.exception(ex)
+                logger.debug(ex)
         else:
-            logger.warning(f"Nothing to clean up for {file}")
+            logger.debug(f"Nothing to clean up for {file}")
 
     @staticmethod
     def cleanup_files(files):
@@ -87,7 +87,7 @@ class Utils:
         except FileNotFoundError:
             pass
         except OSError as ex:
-            logger.exception(ex)
+            logger.debug(ex)
 
     def collect_remote_logs(self, ip_address, logs, store_path):
         """


### PR DESCRIPTION
## Why is this PR needed?

During cleanup, many exceptions are expected when deleting files,
as some files may not exist. However, these exceptions are reported
as errors, generating noise in the output.

Fixes https://github.com/SUSE/avant-garde/issues/892

## What does this PR do?

To lower the verbosity, such exceptions are reported as debug
info.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
