### PR TITLE
Crio configuration airgap

### DIFF
--- a/cmd/skuba/cluster/init.go
+++ b/cmd/skuba/cluster/init.go
@@ -41,17 +41,17 @@ type initOptions struct {
 	RegistryMirror    string
 }
 
-func ParseCrioRegistryConfiguration(config string) cluster.CrioMirrorConfiguration {
+func ParseCrioRegistryConfiguration(config string) *cluster.CrioMirrorConfiguration {
 	values := strings.Split(config, ":")
 	if len(values) != 3 {
-		return cluster.CrioMirrorConfiguration{}
+		return nil
 	}
 	insecure, err := strconv.ParseBool(values[2])
 	// Default to secure registry
 	if err != nil {
 		insecure = false
 	}
-	return cluster.CrioMirrorConfiguration{
+	return &cluster.CrioMirrorConfiguration{
 		SourceRegistry: values[0],
 		MirrorRegistry: values[1],
 		Insecure:       insecure,

--- a/cmd/skuba/cluster/init_test.go
+++ b/cmd/skuba/cluster/init_test.go
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package cluster
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+
+	cluster "github.com/SUSE/skuba/pkg/skuba/actions/cluster/init"
+)
+
+func TestParseCrioRegistryConfiguration(t *testing.T) {
+	type args struct {
+		config string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *cluster.CrioMirrorConfiguration
+	}{
+		{"Parse a valid registry configuration", args{config: "registry.suse.com:test.registry.com:true"}, &cluster.CrioMirrorConfiguration{SourceRegistry: "registry.suse.com", MirrorRegistry: "test.registry.com", Insecure: true}},
+		{"Parse an invalid registry configuration", args{config: "::"}, &cluster.CrioMirrorConfiguration{SourceRegistry: "", MirrorRegistry: "", Insecure: false}},
+		{"Parse an registry configuration with security part", args{config: "registry.suse.com:test.registry.com:"}, &cluster.CrioMirrorConfiguration{SourceRegistry: "registry.suse.com", MirrorRegistry: "test.registry.com", Insecure: false}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseCrioRegistryConfiguration(tt.args.config); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseCrioRegistryConfiguration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type FileCheck struct {
+	RelativePath string
+	Contents     string
+	Exists       bool
+}
+
+func (fc FileCheck) FileState(e error) bool {
+	if fc.Exists {
+		return os.IsNotExist(e)
+	} else {
+		return e == nil
+	}
+}
+
+func TestInitCmdCreatesRegistryMirrorFiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		args  []string
+		files []FileCheck
+	}{
+		{
+			"Run init with mirror setup",
+			[]string{"cluster", "--control-plane", "1.2.3.4", "--registry-mirror", "registry.suse.com:my.registry.com:false"},
+			[]FileCheck{FileCheck{"addons/containers/registries.conf", "", true}},
+		},
+		{
+			"Run init without mirror setup",
+			[]string{"cluster", "--control-plane", "1.2.3.4"},
+			[]FileCheck{FileCheck{"addons/containers/registries.conf", "", false}},
+		},
+	}
+	for _, tt := range tests {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		clusterName := tt.args[0]
+		os.Args = tt.args
+		dir, err := ioutil.TempDir("/tmp", "skuba-init-test")
+		if err != nil {
+			t.Fail()
+		}
+		os.Chdir(dir)
+		command := NewInitCmd()
+		command.Run(command, tt.args)
+		for _, relPath := range tt.files {
+			fullPath := path.Join(dir, clusterName, relPath.RelativePath)
+			if _, err := os.Stat(fullPath); relPath.FileState(err) {
+				t.Errorf("%s incorrect state - expected: %v got %v.", fullPath, relPath.Exists, relPath.FileState(err))
+			}
+		}
+
+	}
+}

--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -47,6 +47,17 @@ func criConfigure(t *Target, data interface{}) error {
 		return err
 	}
 	_, _, err = t.ssh("mv -f /tmp/cri.d/default_flags /etc/sysconfig/crio")
+
+	containersFiles, err := ioutil.ReadDir(skuba.ContainersDir())
+	if err != nil {
+		return errors.Wrap(err, "Could not read local containers directory: "+skuba.ContainersDir())
+	}
+	for _, f := range containersFiles {
+		if err := t.target.UploadFile(filepath.Join(skuba.ContainersDir(), f.Name()), filepath.Join("/tmp/containers", f.Name())); err != nil {
+			return err
+		}
+	}
+	_, _, err = t.ssh("mv -f /tmp/containers/* /etc/containers/")
 	return err
 }
 

--- a/pkg/skuba/actions/cluster/init/constants.go
+++ b/pkg/skuba/actions/cluster/init/constants.go
@@ -45,6 +45,9 @@ var (
 			Location: skuba.CriDockerDefaultsConfFile(),
 			Content:  criDockerDefaultsConf,
 		},
+	}
+
+	registriesScaffoldFiles = []ScaffoldFile{
 		{
 			Location: skuba.CriRegistriesV2ConfFile(),
 			Content:  criRegistriesV2Template,

--- a/pkg/skuba/actions/cluster/init/constants.go
+++ b/pkg/skuba/actions/cluster/init/constants.go
@@ -45,6 +45,10 @@ var (
 			Location: skuba.CriDockerDefaultsConfFile(),
 			Content:  criDockerDefaultsConf,
 		},
+		{
+			Location: skuba.CriRegistriesV2ConfFile(),
+			Content:  criRegistriesV2Template,
+		},
 	}
 
 	cloudScaffoldFiles = map[string][]ScaffoldFile{

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -31,6 +31,15 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
 )
 
+// This type is used to render a v2 registries.conf file for crio.
+// It will setup a mirror from SourceRegistry -> MirrorRegistry.
+// It will also be used to configure the MirrorRegistry as Insecure if needed.
+type CrioMirrorConfiguration struct {
+	SourceRegistry string
+	MirrorRegistry string
+	Insecure       bool
+}
+
 type InitConfiguration struct {
 	ClusterName       string
 	ControlPlane      string
@@ -41,6 +50,7 @@ type InitConfiguration struct {
 	CoreDNSImageTag   string
 	CloudProvider     string
 	StrictCapDefaults bool
+	RegistryMirror    CrioMirrorConfiguration
 }
 
 // Init creates a cluster definition scaffold in the local machine, in the current

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -50,7 +50,7 @@ type InitConfiguration struct {
 	CoreDNSImageTag   string
 	CloudProvider     string
 	StrictCapDefaults bool
-	RegistryMirror    CrioMirrorConfiguration
+	RegistryMirror    *CrioMirrorConfiguration
 }
 
 // Init creates a cluster definition scaffold in the local machine, in the current
@@ -71,6 +71,10 @@ func Init(initConfiguration InitConfiguration) error {
 		} else {
 			klog.Fatalf("unknown cloud provider integration provided: %s", initConfiguration.CloudProvider)
 		}
+	}
+	// TODO: Nicer checking to see if a regitrymirror is configured
+	if initConfiguration.RegistryMirror != nil {
+		scaffoldFilesToWrite = append(scaffoldFilesToWrite, registriesScaffoldFiles...)
 	}
 
 	if err := os.MkdirAll(initConfiguration.ClusterName, 0700); err != nil {

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -61,6 +61,28 @@ useHyperKubeImage: true
 CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"{{end}}
 `
 
+	// TODO: This needs to handle `insecure = true` somehow as well - might
+	// need an additional flag
+	criRegistriesV2Template = `# For more information on this configuration file, see containers-registries.conf(5).
+#
+# Registries to search for images that are not fully-qualified.
+# i.e. foobar.com/my_image:latest vs my_image:latest
+unqualified-search-registries = ["docker.io"]
+
+{{ if (ne .RegistryMirror.SourceRegistry "") }}
+[[registry]]
+location = "{{ .RegistryMirror.SourceRegistry }}"
+mirror = [
+  { location = "{{ .RegistryMirror.MirrorRegistry }}", insecure = {{ .RegistryMirror.Insecure }} }
+]
+{{ end }}
+{{ if (eq .RegistryMirror.Insecure true) }}
+[[registry]]
+location = "{{ .RegistryMirror.MirrorRegistry }}"
+insecure = {{ .RegistryMirror.Insecure }}
+{{ end }}
+`
+
 	masterConfTemplate = `apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
 discovery:

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -74,8 +74,16 @@ func CriDir() string {
 	return filepath.Join(AddonsDir(), "cri")
 }
 
+func ContainersDir() string {
+	return filepath.Join(AddonsDir(), "containers")
+}
+
 func CriDockerDefaultsConfFile() string {
 	return filepath.Join(CriDir(), "default_flags")
+}
+
+func CriRegistriesV2ConfFile() string {
+	return filepath.Join(ContainersDir(), "registries.conf")
 }
 
 func KubeConfigAdminFile() string {


### PR DESCRIPTION
## Why is this PR needed?

It allows the customer to specify a registry mirror during cluster initialization.

This way it is possible to redirect images that would be pulled from one registry to pull the from another - by redirecting `registry.suse.com` to an internally hosted registry this allows airgapped installation.

The PR will generate a `registries.conf` file with the `v2` format for crio (https://github.com/containers/image/blob/master/docs/containers-registries.conf.5.md).

## Anything else a reviewer needs to know?

Right now the included test cases onl

### Related info

Part of the epic: https://github.com/SUSE/avant-garde/issues/567

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
