### PR TITLE
Addon upgrade plan command

### DIFF
--- a/cmd/skuba/addon.go
+++ b/cmd/skuba/addon.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+
+	addons "github.com/SUSE/skuba/cmd/skuba/addon"
+)
+
+// NewAddonCmd creates a new `skuba addon` cobra command
+func NewAddonCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "addon",
+		Short: "Commands to handle addons",
+	}
+
+	cmd.AddCommand(
+		addons.NewUpgradeCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/skuba/addon/upgrade.go
+++ b/cmd/skuba/addon/upgrade.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	addons "github.com/SUSE/skuba/pkg/skuba/actions/addon/upgrade"
+)
+
+// NewUpgradeCmd creates a new `skuba addon upgrade` cobra command
+func NewUpgradeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Manages addon upgrade operations",
+	}
+
+	cmd.AddCommand(
+		newUpgradePlanCmd(),
+	)
+
+	return cmd
+}
+
+func newUpgradePlanCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "plan",
+		Short: "Plan addon upgrade",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := addons.Plan(); err != nil {
+				fmt.Printf("Unable to plan addon upgrade: %s\n", err)
+				os.Exit(1)
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+}

--- a/cmd/skuba/main.go
+++ b/cmd/skuba/main.go
@@ -42,6 +42,7 @@ func newRootCmd() *cobra.Command {
 		NewClusterCmd(),
 		NewNodeCmd(),
 		NewAuthCmd(),
+		NewAddonCmd(),
 	)
 
 	register(cmd.PersistentFlags(), "v")

--- a/internal/pkg/skuba/upgrade/addon/version.go
+++ b/internal/pkg/skuba/upgrade/addon/version.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addon
+
+import (
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	skubaconfig "github.com/SUSE/skuba/internal/pkg/skuba/skuba"
+)
+
+type AddonVersionInfoUpdate struct {
+	Current kubernetes.AddonsVersion
+	Updated kubernetes.AddonsVersion
+}
+
+func UpdatedAddons() (AddonVersionInfoUpdate, error) {
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return AddonVersionInfoUpdate{}, err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+	if err != nil {
+		return AddonVersionInfoUpdate{}, err
+	}
+	currentVersion := currentClusterVersion.String()
+	latestAddonVersions := kubernetes.Versions[currentVersion].AddonsVersion
+
+	skubaConfig, err := skubaconfig.GetSkubaConfiguration()
+	if err != nil {
+		return AddonVersionInfoUpdate{}, err
+	}
+	aviu := AddonVersionInfoUpdate{
+		Current: kubernetes.AddonsVersion{},
+		Updated: kubernetes.AddonsVersion{},
+	}
+
+	for addonName, version := range latestAddonVersions {
+		skubaConfigVersion := skubaConfig.AddonsVersion[addonName]
+		aviu.Current[addonName] = skubaConfigVersion
+		if version.Version > skubaConfigVersion.Version || version.ManifestVersion > skubaConfigVersion.ManifestVersion {
+			aviu.Updated[addonName] = version
+		}
+	}
+	return aviu, nil
+}
+
+func HasAddonUpdate(aviu AddonVersionInfoUpdate) bool {
+	for addon, _ := range aviu.Updated {
+		if HasAddonManifestUpdateWithAddon(aviu, addon) || HasAddonVersionUpdateWithAddon(aviu, addon) {
+			return true
+		}
+	}
+	return false
+}
+
+func HasAddonManifestUpdateWithAddon(aviu AddonVersionInfoUpdate, addon kubernetes.Addon) bool {
+	return aviu.Updated[addon].ManifestVersion > aviu.Current[addon].ManifestVersion
+}
+
+func HasAddonVersionUpdateWithAddon(aviu AddonVersionInfoUpdate, addon kubernetes.Addon) bool {
+	return aviu.Updated[addon].Version > aviu.Current[addon].Version
+}

--- a/pkg/skuba/actions/addon/upgrade/plan.go
+++ b/pkg/skuba/actions/addon/upgrade/plan.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
+	"github.com/SUSE/skuba/pkg/skuba"
+)
+
+func Plan() error {
+	fmt.Printf("%s\n", skuba.CurrentVersion().String())
+
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+	if err != nil {
+		return err
+	}
+	currentVersion := currentClusterVersion.String()
+	latestVersion := kubernetes.LatestVersion().String()
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo()
+	if err != nil {
+		return err
+	}
+	allNodesMatchClusterVersion := kubernetes.AllNodesMatchClusterVersionWithVersioningInfo(allNodesVersioningInfo, currentClusterVersion)
+	fmt.Printf("Current Kubernetes cluster version: %s\n", currentVersion)
+	fmt.Printf("Latest Kubernetes version: %s\n", latestVersion)
+	fmt.Println()
+
+	if !allNodesMatchClusterVersion {
+		return errors.Errorf("Not all nodes match clusterVersion %s", currentVersion)
+	}
+
+	updatedAddons, err := addon.UpdatedAddons()
+	if err != nil {
+		return err
+	}
+
+	if addon.HasAddonUpdate(updatedAddons) {
+		fmt.Println("Addon upgrades:")
+		for addonName, versions := range updatedAddons.Updated {
+			currentVersion := updatedAddons.Current[addonName].Version
+			currentManifest := updatedAddons.Current[addonName].ManifestVersion
+			updatedVersion := versions.Version
+			updatedManifest := versions.ManifestVersion
+			hasVersionUpdate := addon.HasAddonVersionUpdateWithAddon(updatedAddons, addonName)
+			hasManifestUpdate := addon.HasAddonManifestUpdateWithAddon(updatedAddons, addonName)
+			if hasVersionUpdate && !hasManifestUpdate {
+				fmt.Printf("  - %s: %s -> %s\n", addonName, currentVersion, updatedVersion)
+			} else if hasVersionUpdate || hasManifestUpdate {
+				fmt.Printf("  - %s: %s -> %s (manifest version from %d to %d)\n", addonName, currentVersion, updatedVersion, currentManifest, updatedManifest)
+			}
+		}
+	} else {
+		fmt.Println("Congratulations! Addons are already at the latest version available")
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Why is this PR needed?

Check if there are new addon updates available

## What does this PR do?

Adds a new command `skuba addon upgrade plan`

## Anything else a reviewer needs to know?

Can be tested by manipulating [these numbers](https://github.com/SUSE/skuba/blob/master/internal/pkg/skuba/kubernetes/versions.go#L92-L96)

## Docs

will follow