### PR TITLE
Add missing `--strict-capability-defaults` to man documentation

### DIFF
--- a/docs/man/skuba-cluster-init.1.md
+++ b/docs/man/skuba-cluster-init.1.md
@@ -21,3 +21,6 @@ init - Initialize skuba structure for cluster deployment
 
 **--cloud-provider string**
   Enable cloud provider integration with the chosen cloud. Valid values: openstack
+
+**--strict-capability-defaults**
+  All the containers will start with CRI-O default capabilities

--- a/docs/man/skuba-cluster-init.1.md
+++ b/docs/man/skuba-cluster-init.1.md
@@ -20,7 +20,7 @@ init - Initialize skuba structure for cluster deployment
   (Required) The control plane location (IP/FQDN) that will load balance the master nodes
 
 **--cloud-provider string**
-  Enable cloud provider integration with the chosen cloud. Valid values: openstack
+  Enable cloud provider integration with the chosen cloud. Valid values: aws, openstack
 
 **--strict-capability-defaults**
   All the containers will start with CRI-O default capabilities


### PR DESCRIPTION
## Why is this PR needed?

Add missing `--strict-capability-defaults` to man documentation

xrefs https://github.com/SUSE/doc-caasp/issues/528