### PR TITLE
Add man-page for addon upgrade plan

### DIFF
--- a/docs/man/skuba-addon-upgrade-plan.1.md
+++ b/docs/man/skuba-addon-upgrade-plan.1.md
@@ -1,0 +1,18 @@
+% skuba-addon-upgrade-plan(1) # skuba addon upgrade plan - Plan addon upgrade
+
+# NAME
+
+plan - Print the addon upgrade plan of the cluster
+
+# SYNOPSIS
+**plan**
+[**--help**|**-h**]
+*plan* [-h]
+
+# DESCRIPTION
+**plan** Evaluates and prints to stdout the upgrade plan for the cluster
+
+# OPTIONS
+
+**--help, -h**
+  Print usage statement.

--- a/docs/man/skuba.1.md
+++ b/docs/man/skuba.1.md
@@ -27,6 +27,9 @@ reconfiguration in an easy way.
 **node**
   Node handling commands.
 
+**addon**
+  Addon handling commands.
+
 # SEE ALSO
 **skuba-auth-login**(1),
 **skuba-cluster-init**(1),
@@ -37,3 +40,4 @@ reconfiguration in an easy way.
 **skuba-node-remove**(1),
 **skuba-node-upgrade-plan**(1),
 **skuba-node-upgrade-apply**(1),
+**skuba-addon-upgrade-plan**(1),


### PR DESCRIPTION
## What does this PR do?

Add a man page for `skuba addon upgrade plan`

### Related info

Follow up of https://github.com/SUSE/skuba/pull/729
