### PR TITLE
Implemented the `skuba addon upgrade apply` command

### DIFF
--- a/ci/infra/.gitignore
+++ b/ci/infra/.gitignore
@@ -2,3 +2,4 @@
 terraform.tfvars
 terraform.tfvars.json
 terraform.tfstate*
+terraform.d/

--- a/cmd/skuba/addon/upgrade.go
+++ b/cmd/skuba/addon/upgrade.go
@@ -35,6 +35,7 @@ func NewUpgradeCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		newUpgradePlanCmd(),
+		newUpgradeApplyCmd(),
 	)
 
 	return cmd
@@ -47,6 +48,20 @@ func newUpgradePlanCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := addons.Plan(); err != nil {
 				fmt.Printf("Unable to plan addon upgrade: %s\n", err)
+				os.Exit(1)
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+}
+
+func newUpgradeApplyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "apply",
+		Short: "Apply addon upgrade",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := addons.Apply(); err != nil {
+				fmt.Printf("Unable to Apply addons upgrade: %s\n", err)
 				os.Exit(1)
 			}
 		},

--- a/docs/man/skuba-addon-upgrade-apply.1.md
+++ b/docs/man/skuba-addon-upgrade-apply.1.md
@@ -1,0 +1,18 @@
+% skuba-addon-upgrade-apply(1) # skuba addon upgrade apply - Apply addon upgrade
+
+# NAME
+
+apply - Apply a cluster-wide addon upgrade
+
+# SYNOPSIS
+**apply**
+[**--help**|**-h**]
+*apply* [-h]
+
+# DESCRIPTION
+**apply** Applies the latest available versions for the installed addons cluster-wide.
+
+# OPTIONS
+
+**--help, -h**
+  Print usage statement.

--- a/docs/man/skuba.1.md
+++ b/docs/man/skuba.1.md
@@ -41,3 +41,4 @@ reconfiguration in an easy way.
 **skuba-node-upgrade-plan**(1),
 **skuba-node-upgrade-apply**(1),
 **skuba-addon-upgrade-plan**(1),
+**skuba-addon-upgrade-apply**(1)

--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"fmt"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
+	"github.com/pkg/errors"
+)
+
+// Apply implements the `skuba addon upgrade apply` command.
+func Apply() error {
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return err
+	}
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+	if err != nil {
+		return err
+	}
+	currentVersion := currentClusterVersion.String()
+	latestVersion := kubernetes.LatestVersion().String()
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo()
+	if err != nil {
+		return err
+	}
+	allNodesMatchClusterVersion := kubernetes.AllNodesMatchClusterVersionWithVersioningInfo(allNodesVersioningInfo, currentClusterVersion)
+	fmt.Printf("Current Kubernetes cluster version: %s\n", currentVersion)
+	fmt.Printf("Latest Kubernetes version: %s\n", latestVersion)
+	fmt.Println()
+
+	if !allNodesMatchClusterVersion {
+		return errors.Errorf("[apply] Not all nodes match clusterVersion %s", currentVersion)
+	}
+
+	clusterConfiguration, err := kubeadm.GetClusterConfiguration(client)
+	if err != nil {
+		return errors.Wrap(err, "[apply] Could not fetch cluster configuration")
+	}
+
+	updatedAddons, err := addon.UpdatedAddons()
+	if err != nil {
+		return err
+	}
+
+	if addon.HasAddonUpdate(updatedAddons) {
+		addonConfiguration := addons.AddonConfiguration{
+			ClusterVersion: currentClusterVersion,
+			ControlPlane:   clusterConfiguration.ControlPlaneEndpoint,
+			ClusterName:    clusterConfiguration.ClusterName,
+		}
+		if err := addons.DeployAddons(addonConfiguration, addons.AlwaysRender); err != nil {
+			return errors.Wrap(err, "[apply] Failed to deploy addons")
+		}
+		fmt.Println("[apply] Successfully upgraded addons")
+	} else {
+		fmt.Printf("[apply] Congratulations! Addons for %s are already at the latest version available\n", currentVersion)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Why is this PR needed?

Applies an upgrade for outdated addons. It also adds the `terraform.d` directory in the .gitignore for `ci/infra/libvirt`, which might be used in some cases when creating the infrastructure with libvirt.

## What does this PR do?

Add a new command `skuba addon upgrade apply`.

## Anything else a reviewer needs to know?

Can be tested by manipulating [these numbers](https://github.com/SUSE/skuba/blob/master/internal/pkg/skuba/kubernetes/versions.go#L92-L96)

## Tests

To be done in the form of end-to-end tests.

## Docs

Added a new man page and linked it on the main man page.
