### PR TITLE
Print Addon updates also on cluster upgrade plan

### DIFF
--- a/internal/pkg/skuba/upgrade/addon/version.go
+++ b/internal/pkg/skuba/upgrade/addon/version.go
@@ -54,27 +54,22 @@ func UpdatedAddons(clusterVersion *version.Version) (AddonVersionInfoUpdate, err
 }
 
 func PrintAddonUpdates(updatedAddons AddonVersionInfoUpdate) {
-	if hasAddonUpdate(updatedAddons) {
-		fmt.Println("Addon upgrades:")
-		for addonName, versions := range updatedAddons.Updated {
-			currentVersion := updatedAddons.Current[addonName].Version
-			currentManifest := updatedAddons.Current[addonName].ManifestVersion
-			updatedVersion := versions.Version
-			updatedManifest := versions.ManifestVersion
-			hasVersionUpdate := hasAddonVersionUpdateWithAddon(updatedAddons, addonName)
-			hasManifestUpdate := hasAddonManifestUpdateWithAddon(updatedAddons, addonName)
-			if hasVersionUpdate && !hasManifestUpdate {
-				fmt.Printf("  - %s: %s -> %s\n", addonName, currentVersion, updatedVersion)
-			} else if hasVersionUpdate || hasManifestUpdate {
-				fmt.Printf("  - %s: %s -> %s (manifest version from %d to %d)\n", addonName, currentVersion, updatedVersion, currentManifest, updatedManifest)
-			}
+	for addonName, versions := range updatedAddons.Updated {
+		currentVersion := updatedAddons.Current[addonName].Version
+		currentManifest := updatedAddons.Current[addonName].ManifestVersion
+		updatedVersion := versions.Version
+		updatedManifest := versions.ManifestVersion
+		hasVersionUpdate := hasAddonVersionUpdateWithAddon(updatedAddons, addonName)
+		hasManifestUpdate := hasAddonManifestUpdateWithAddon(updatedAddons, addonName)
+		if hasVersionUpdate && !hasManifestUpdate {
+			fmt.Printf("  - %s: %s -> %s\n", addonName, currentVersion, updatedVersion)
+		} else if hasVersionUpdate || hasManifestUpdate {
+			fmt.Printf("  - %s: %s -> %s (manifest version from %d to %d)\n", addonName, currentVersion, updatedVersion, currentManifest, updatedManifest)
 		}
-	} else {
-		fmt.Println("Congratulations! Addons (for the current cluster version) are already at the latest version available")
 	}
 }
 
-func hasAddonUpdate(aviu AddonVersionInfoUpdate) bool {
+func HasAddonUpdate(aviu AddonVersionInfoUpdate) bool {
 	for addon, _ := range aviu.Updated {
 		if hasAddonManifestUpdateWithAddon(aviu, addon) || hasAddonVersionUpdateWithAddon(aviu, addon) {
 			return true

--- a/pkg/skuba/actions/addon/upgrade/plan.go
+++ b/pkg/skuba/actions/addon/upgrade/plan.go
@@ -54,29 +54,11 @@ func Plan() error {
 		return errors.Errorf("Not all nodes match clusterVersion %s", currentVersion)
 	}
 
-	updatedAddons, err := addon.UpdatedAddons()
+	updatedAddons, err := addon.UpdatedAddons(currentClusterVersion)
 	if err != nil {
 		return err
 	}
-
-	if addon.HasAddonUpdate(updatedAddons) {
-		fmt.Println("Addon upgrades:")
-		for addonName, versions := range updatedAddons.Updated {
-			currentVersion := updatedAddons.Current[addonName].Version
-			currentManifest := updatedAddons.Current[addonName].ManifestVersion
-			updatedVersion := versions.Version
-			updatedManifest := versions.ManifestVersion
-			hasVersionUpdate := addon.HasAddonVersionUpdateWithAddon(updatedAddons, addonName)
-			hasManifestUpdate := addon.HasAddonManifestUpdateWithAddon(updatedAddons, addonName)
-			if hasVersionUpdate && !hasManifestUpdate {
-				fmt.Printf("  - %s: %s -> %s\n", addonName, currentVersion, updatedVersion)
-			} else if hasVersionUpdate || hasManifestUpdate {
-				fmt.Printf("  - %s: %s -> %s (manifest version from %d to %d)\n", addonName, currentVersion, updatedVersion, currentManifest, updatedManifest)
-			}
-		}
-	} else {
-		fmt.Println("Congratulations! Addons are already at the latest version available")
-	}
+	addon.PrintAddonUpdates(updatedAddons)
 
 	return nil
 }

--- a/pkg/skuba/actions/addon/upgrade/plan.go
+++ b/pkg/skuba/actions/addon/upgrade/plan.go
@@ -55,7 +55,12 @@ func Plan() error {
 	if err != nil {
 		return err
 	}
-	addon.PrintAddonUpdates(updatedAddons)
+	if addon.HasAddonUpdate(updatedAddons) {
+		fmt.Printf("Addon upgrades for %s:\n", currentVersion)
+		addon.PrintAddonUpdates(updatedAddons)
+	} else {
+		fmt.Printf("Congratulations! Addons for %s are already at the latest version available\n", currentVersion)
+	}
 
 	return nil
 }

--- a/pkg/skuba/actions/addon/upgrade/plan.go
+++ b/pkg/skuba/actions/addon/upgrade/plan.go
@@ -25,12 +25,9 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
-	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 func Plan() error {
-	fmt.Printf("%s\n", skuba.CurrentVersion().String())
-
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -26,12 +26,9 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
 	upgradecluster "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/cluster"
-	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 func Plan() error {
-	fmt.Printf("%s\n", skuba.CurrentVersion().String())
-
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
 	upgradecluster "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/cluster"
 	"github.com/SUSE/skuba/pkg/skuba"
 )
@@ -77,6 +78,13 @@ func Plan() error {
 			fmt.Printf("  - %s is running kubelet %s and is not cordoned\n", node.Nodename, node.KubeletVersion.String())
 		}
 	}
+
+	updatedAddons, err := addon.UpdatedAddons(kubernetes.LatestVersion())
+	if err != nil {
+		return err
+	}
+	fmt.Println()
+	addon.PrintAddonUpdates(updatedAddons)
 
 	return nil
 }

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -76,12 +76,19 @@ func Plan() error {
 		}
 	}
 
-	updatedAddons, err := addon.UpdatedAddons(kubernetes.LatestVersion())
+	// fetch addon upgrades for the next available cluster version
+	nextClusterVersion := upgradePath[0]
+	updatedAddons, err := addon.UpdatedAddons(nextClusterVersion)
 	if err != nil {
 		return err
 	}
 	fmt.Println()
-	addon.PrintAddonUpdates(updatedAddons)
+	if addon.HasAddonUpdate(updatedAddons) {
+		fmt.Printf("Addon upgrades for %s:\n", nextClusterVersion.String())
+		addon.PrintAddonUpdates(updatedAddons)
+	} else {
+		fmt.Printf("Congratulations! Addons for %s are already at the latest version available\n", nextClusterVersion.String())
+	}
 
 	return nil
 }

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -31,13 +31,10 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kured"
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
-	"github.com/SUSE/skuba/pkg/skuba"
 	"github.com/pkg/errors"
 )
 
 func Apply(target *deployments.Target) error {
-	fmt.Printf("%s\n", skuba.CurrentVersion().String())
-
 	if err := fillTargetWithNodeName(target); err != nil {
 		return err
 	}

--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -23,12 +23,9 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
-	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 func Plan(nodeName string) error {
-	fmt.Printf("%s\n", skuba.CurrentVersion().String())
-
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Why is this PR needed?

according to the RFC we also need the addon update output on `skuba cluster upgrade plan`

## What does this PR do?

* puts some logic into the addon library
* adds the output also to `cluster upgrade plan`
