### PR TITLE
Add support for libvirt platform

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -278,6 +278,18 @@ or as an environment variable: `export VMWARE_ENV_FILE=/path/to/vmware-env.sh`
 
 3. Be sure to use the `-p` or `--platform` argument when invoking `testrunner` and set it to `vmware`, otherwise `openstack` is used. 
 
+#### Libvirt
+
+`testruner` can provision a cluster of virtual machines using terraform libvirt provider. The only noticeable difference with other platforms is the dependency on the terraform libvirt provider plugin which is not available from the official terraform plugin site, neither is delivered as part of the CaaSP packages. Moreover, the version of this plugin must be compatible with the version of terraform used by skuba (and by extension, the testrunner) which as of today is `0.11`. [This version](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) has been tested to work. Notice it requires an updated version of libvirt (4.1.0 or above). 
+
+Once the plugin is installed locally, it must be made available to terraform by copying the plugin binary to `ci/infra/libvirt/terraform.d/plugins/linux_<arch>/`, where `<arch>` is the architecture of the computer where terraform is running (e.g. `amd64`).
+
+**Note**: setting the `tf_plugin_dir` parameter in the `testrunner` configuration as shown bellow **will not work**. The reason is that terraform will disable the [default discovery process](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery) and therefore the other required plugings will not be available.
+```
+terraform:
+  plugin_dir: "/path/to/libvirt/provider"
+```
+
 ### Jenkins Setup
 
 In your Jenkins file, you need to set up environment variables which will replace options in the yaml file. This is more convenient than having to edit the yaml file in the CI pipeline. 

--- a/ci/infra/testrunner/platforms/__init__.py
+++ b/ci/infra/testrunner/platforms/__init__.py
@@ -1,16 +1,16 @@
 from platforms.openstack import Openstack
 from platforms.vmware import VMware
-
+from platforms.libvirt import Libvirt
 
 def get_platform(conf, platform):
     if platform.lower() == "openstack":
         platform = Openstack(conf)
     elif platform.lower() == "vmware":
         platform = VMware(conf)
+    elif platform.lower() == "libvirt":
+         platform = Libvirt(conf) 
     elif platform.lower() == "bare-metal":
         raise Exception("bare-metal is not available")
-    elif platform.lower() == "libvirt":
-        raise Exception("libvirt is not available")
     else:
         raise Exception("Platform Error: {} is not recognized".format(platform))
 

--- a/ci/infra/testrunner/platforms/libvirt.py
+++ b/ci/infra/testrunner/platforms/libvirt.py
@@ -1,0 +1,19 @@
+import os
+import stat
+
+from timeout_decorator import timeout
+from platforms.terraform import Terraform
+from utils import Format
+
+
+class Libvirt(Terraform):
+    def __init__(self, conf):
+        super().__init__(conf, 'libvirt')
+
+    def _env_setup_cmd(self):
+        return ":"
+
+    @timeout(600)
+    def _cleanup_platform(self):
+        self.destroy()
+

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -25,7 +25,7 @@ class Terraform(Platform):
         self.tmp_files = [self.tfout_path,
                           self.tfjson_path]
 
-    def destroy(self, variables):
+    def destroy(self, variables=[]):
         cmd = "destroy -auto-approve"
 
         for var in variables:


### PR DESCRIPTION
## Why is this PR needed?

Using the testrunner with a cluster deployed using libvirt

Fixes https://github.com/SUSE/avant-garde/issues/894


## What does this PR do?

Add libvirt platform extending Terraform platform.
Documents setup of terraform needed for using this platform.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
