### PR TITLE
Add verbosity level in man page and skuba help

### DIFF
--- a/cmd/skuba/main.go
+++ b/cmd/skuba/main.go
@@ -79,6 +79,7 @@ func register(local *pflag.FlagSet, globalName string) {
 	if f := flag.CommandLine.Lookup(globalName); f != nil {
 		pflagFlag := pflag.PFlagFromGoFlag(f)
 		pflagFlag.Name = "verbosity"
+		pflagFlag.Usage = "number for the log level verbosity [0-10]"
 		local.AddFlag(pflagFlag)
 	} else {
 		klog.Fatalf("failed to find flag in global flagset (flag): %s", globalName)

--- a/docs/man/skuba.1.md
+++ b/docs/man/skuba.1.md
@@ -17,7 +17,7 @@ reconfiguration in an easy way.
   Print usage statement.
 
 **-v**
-  set verbosity level.
+  number for the log level verbosity [0-10].
 
 # COMMANDS
 


### PR DESCRIPTION
Detail description about log level in skuba man page
Shows the level of log values in skuba help

## Why is this PR needed?

Does it fix an issue? addresses a business case?
https://github.com/SUSE/avant-garde/issues/841

## Anything else a reviewer needs to know?
`local.PrintDefaults()` does not show default values with `skuba -h`.
```
skuba -h
** This is an UNTAGGED version and NOT intended for production usage. **
Usage:
  skuba [command]

Available Commands:
  addon       Commands to handle addons
  auth        Commands to handle authentication
  cluster     Commands to handle a cluster
  help        Help about any command
  node        Commands to handle a specific node
  version     Print version information

Flags:
  -h, --help              help for skuba
  -v, --verbosity Level   number for the log level verbosity [0-10]
```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
