### PR TITLE
AWS feedback

### DIFF
--- a/ci/infra/aws/master-instance.tf
+++ b/ci/infra/aws/master-instance.tf
@@ -10,6 +10,7 @@ resource "aws_instance" "control_plane" {
   iam_instance_profile        = "${length(var.iam_profile_master) == 0 ? local.aws_iam_policy_master_terraform : var.iam_profile_master}"
 
   depends_on = [
+    "aws_internet_gateway.platform",
     "aws_iam_policy.master",
   ]
 

--- a/ci/infra/aws/network.tf
+++ b/ci/infra/aws/network.tf
@@ -41,9 +41,8 @@ resource "aws_subnet" "public" {
 }
 
 resource "aws_subnet" "private" {
-  availability_zone       = "${element(data.aws_availability_zones.az.names, 0)}"
-  cidr_block              = "${var.private_subnet}"
-  map_public_ip_on_launch = true
+  availability_zone = "${element(data.aws_availability_zones.az.names, 0)}"
+  cidr_block        = "${var.private_subnet}"
 
   tags = "${merge(local.tags, map(
     "Name", "${var.stack_name}-subnet-private-${element(data.aws_availability_zones.az.names, 0)}",
@@ -74,10 +73,10 @@ resource "aws_route_table" "private" {
     "Class", "RouteTable"))}"
 }
 
-resource "aws_route" "private_to_everywhere" {
+resource "aws_route" "private_nat_gateway" {
   route_table_id         = "${aws_route_table.private.id}"
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.platform.id}"
+  nat_gateway_id         = "${aws_nat_gateway.nat_gw.id}"
 }
 
 resource "aws_main_route_table_association" "main" {

--- a/ci/infra/aws/output.tf
+++ b/ci/infra/aws/output.tf
@@ -6,10 +6,6 @@ output "control_plane.private_dns" {
   value = "${aws_instance.control_plane.*.private_dns}"
 }
 
-output "nodes.public_ip" {
-  value = "${aws_instance.nodes.*.public_ip}"
-}
-
 output "nodes.private_dns" {
   value = "${aws_instance.nodes.*.private_dns}"
 }

--- a/ci/infra/aws/vpc_peering_connection.tf
+++ b/ci/infra/aws/vpc_peering_connection.tf
@@ -26,9 +26,16 @@ resource "aws_route" "peer_to_k8s" {
   vpc_peering_connection_id = "${element(aws_vpc_peering_connection.tunnel.*.id, count.index)}"
 }
 
-resource "aws_route" "k8s_to_peer" {
+resource "aws_route" "public_subnet_to_peer" {
   count                     = "${length(var.peer_vpc_ids)}"
   route_table_id            = "${aws_route_table.public.id}"
+  destination_cidr_block    = "${element(data.aws_vpc.peer.*.cidr_block, count.index)}"
+  vpc_peering_connection_id = "${element(aws_vpc_peering_connection.tunnel.*.id, count.index)}"
+}
+
+resource "aws_route" "private_subnet_to_peer" {
+  count                     = "${length(var.peer_vpc_ids)}"
+  route_table_id            = "${aws_route_table.private.id}"
   destination_cidr_block    = "${element(data.aws_vpc.peer.*.cidr_block, count.index)}"
   vpc_peering_connection_id = "${element(aws_vpc_peering_connection.tunnel.*.id, count.index)}"
 }

--- a/ci/infra/aws/worker-instance.tf
+++ b/ci/infra/aws/worker-instance.tf
@@ -5,7 +5,6 @@ resource "aws_instance" "nodes" {
   instance_type               = "${var.worker_size}"
   key_name                    = "${aws_key_pair.kube.key_name}"
   source_dest_check           = false
-  iam_instance_profile        = "${var.iam_profile_worker}"
   iam_instance_profile        = "${length(var.iam_profile_worker) == 0 ? local.aws_iam_policy_worker_terraform : var.iam_profile_worker}"
 
   depends_on = [

--- a/ci/infra/aws/worker-instance.tf
+++ b/ci/infra/aws/worker-instance.tf
@@ -1,19 +1,18 @@
 resource "aws_instance" "nodes" {
   ami                         = "${data.susepubliccloud_image_ids.sles15sp1_chost_byos.ids[0]}"
-  associate_public_ip_address = true
+  associate_public_ip_address = false
   count                       = "${var.workers}"
   instance_type               = "${var.worker_size}"
   key_name                    = "${aws_key_pair.kube.key_name}"
   source_dest_check           = false
+  user_data                   = "${data.template_cloudinit_config.cfg.rendered}"
   iam_instance_profile        = "${length(var.iam_profile_worker) == 0 ? local.aws_iam_policy_worker_terraform : var.iam_profile_worker}"
+  subnet_id                   = "${aws_subnet.private.0.id}"
 
   depends_on = [
+    "aws_route.private_nat_gateway",
     "aws_iam_policy.worker",
   ]
-
-  # TODO: remove from the public network once we have bastion hosts
-  subnet_id = "${aws_subnet.public.0.id}"
-  user_data = "${data.template_cloudinit_config.cfg.rendered}"
 
   tags = "${merge(local.tags, map(
     "Name", "${var.stack_name}-node-${count.index}",


### PR DESCRIPTION
## Why is this PR needed?

This PR addresses the feedback raised on this PR https://github.com/SUSE/skuba/pull/637#issuecomment-535254583 by @rssfed23.

## What does this PR do?

### Be more secure

All the worker nodes are now moved inside of a private subnet. The subnet was already there, we weren't simply using it (dunno why).
This design is more secure and reflects a [common pattern on AWS](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Scenario2.html).

TBH, we could move also the master nodes into the secure network, but then we would need to have a bastion host. This is definitely something for later, once we collect more feedback from users.

### Fix IAM role creation for worker node

@rssfed23 faced the issue. Terraform wasn't creating a IAM role for the worker nodes due to a leftover inside of the state file.

## Anything else a reviewer needs to know?

This is not yet going to be exposed to our customers, right now our packages don't have any AWS terraform stuff in them.

## Info for QA

Nothing special to do: just ensure all the worker nodes are inside of the private subnet and the cluster can still be provisioned as expected via skuba.

### Related info

Nothing.

### Status **BEFORE** applying the patch

All the worker nodes had a public IP.

### Status **AFTER** applying the patch

Only master nodes have a public IP. Worker nodes are reachable from nodes located inside of the VPC created by terraform.

## Docs

Docs need to be updated, I'm going to file a PR. The contents about AWS are already dated.