### PR TITLE
Fix build: `UpdatedAddons` now takes the version of the cluster

### DIFF
--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -57,7 +57,7 @@ func Apply() error {
 		return errors.Wrap(err, "[apply] Could not fetch cluster configuration")
 	}
 
-	updatedAddons, err := addon.UpdatedAddons()
+	updatedAddons, err := addon.UpdatedAddons(currentClusterVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why is this PR needed?

`UpdatedAddons` now takes the version of the cluster, pass this
information when calling to `skuba addon upgrade apply`.