### PR TITLE
Support multiple package installation scenarios

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -32,8 +32,7 @@
     },
     "packages": [
         "kernel-default",
-        "-kernel-default-base",
-        "ca-certificates-suse"
+        "-kernel-default-base"
     ],
     "authorized_keys": [],
     "ntp_servers": [

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -28,8 +28,7 @@
     },
     "packages": [
         "kernel-default",
-        "-kernel-default-base",
-        "ca-certificates-suse"
+        "-kernel-default-base"
     ],
     "authorized_keys": [],
     "ntp_servers": [

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -117,15 +117,16 @@ There are some arguments that are currently at the top level of the configuratio
 #### Packages
 The `packages` section configures the source of the packages to be installed in the nodes:
 
-* certificates: package with the certificates to be installed in the nodes in order to install other packages and images. For example, for installing SUSE self-signed packages:
+* additional_pkgs: list with additional packages to be installed in the nodes. For example, for installing SUSE certificates for self-signed packages in development environments:
 ```
 packages:
-  certificates: "ca-certificates-suse"
+  additional_pkgs:
+  - "ca-certificates-suse"
 ```
-* maintenance: repositories to be added to the installation repositories for installing maintenance updates. It takes the form of a map:
+* additional_repos: repositories to be added to the nodes. For example, for installing maintenance updates. It takes the form of a map:
 ```
 packages:
-  maintenance:
+  additional_repos:
     repo1: url/to/repo1
     repo2: url/to/repo2
 ```

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -6,6 +6,7 @@
 - [Design](#design)
 - [Configuration](#configuration-parameters)
   - [Work Environment](#work-environment)
+  - [Packages](#packages)
   - [Platform](#platform)
     - [Terraform](#terraform)
     - [Openstack](#openstack)
@@ -111,12 +112,16 @@ There are some arguments that are currently at the top level of the configuratio
 - nodeuser: the user name used to login into the platform nodes. Optional. 
 - ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
 
+#### Packages
+The `packages` section configures the source of the packages to be installed in the nodes:
+
+* mirror: URL for the repository mirrors to be used when setting up the skuba nodes, replacing the URL of the repositories defined in terraform. Used, for instance, to switch to development repositories or internal repositories when running in the CI pipeline.
+
 #### Terraform
 
 General setting for terraform-based platforms such as [Openstack](#openstack) and [VMware](#vmware). 
 
 * internal_net: name of the network used when provisioning the platform. Defaults to `stack_name`
-* mirror: URL for the repository mirrors to be used when setting up the skuba nodes, replacing the URL of the repositories defined in terraform. Used, for instance, to switch to development repositories or internal repositories when running in the CI pipeline.
 * plugin_dir: directory used for retrieving terraform plugins. If not set, plugins are installed using terraform [discovery mechanism](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery)
 * retries: maximum number of attempts to recover from failures during terraform provisioning 
 * stack name: the unique name of the platform stack on the shared infrastructure, used as prefix by many resources such as networks, nodes, among others. If not specified, the `username` is used.

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -27,6 +27,8 @@
 - [Examples](#examples)
   - [Create K8s Cluster](#create-k8s-cluster)
   - [Collect logs](#collect-logs)
+  - [Install using registration code](#install-using-registration-code)
+  - [Install packages from mirror](#install-packages-from-mirror)
 
 ## Summary
 
@@ -523,3 +525,32 @@ Logs that are currently being collected are the cloud-init logs for each of the 
     /var/log/cloud-init.log
 
 These are stored each in their own folder named `path/to/workspace/testrunner_logs/{master|worker}_ip_address/`
+
+### Install using registration code
+
+1. Configure the registration code to be passed to nodes:
+
+`vars.yaml`
+```
+packages:
+  registry_code: "<registry code>"
+```
+2. Configure `testrunner` to use a `skuba` binary compatible with the version installed in the nodes:
+
+`vars.yaml`
+```
+skuba:
+  bin_path: "/path/to/skuba"
+```
+
+### Install packages from mirror
+
+Specify the mirror an enable the installation of certifates package:
+
+`vars.yaml`
+```
+packages:
+  mirror: "my.mirror.site"
+  certificates: "certificates-package"
+```
+

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -115,8 +115,14 @@ There are some arguments that are currently at the top level of the configuratio
 #### Packages
 The `packages` section configures the source of the packages to be installed in the nodes:
 
+* certificates: package with the certificates to be installed in the nodes in order to install other packages and images. For example, for installing SUSE self-signed packages:
+```
+packages:
+  certificates: "ca-certificates-suse"
+```
 * maintenance: repositories to be added to the installation repositories for installing maintenance updates. It takes the form of a map:
 ```
+packages:
   maintenance:
     repo1: url/to/repo1
     repo2: url/to/repo2

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -115,6 +115,12 @@ There are some arguments that are currently at the top level of the configuratio
 #### Packages
 The `packages` section configures the source of the packages to be installed in the nodes:
 
+* maintenance: repositories to be added to the installation repositories for installing maintenance updates. It takes the form of a map:
+```
+  maintenance:
+    repo1: url/to/repo1
+    repo2: url/to/repo2
+```
 * mirror: URL for the repository mirrors to be used when setting up the skuba nodes, replacing the URL of the repositories defined in terraform. Used, for instance, to switch to development repositories or internal repositories when running in the CI pipeline.
 
 #### Terraform

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -122,6 +122,7 @@ The `packages` section configures the source of the packages to be installed in 
     repo2: url/to/repo2
 ```
 * mirror: URL for the repository mirrors to be used when setting up the skuba nodes, replacing the URL of the repositories defined in terraform. Used, for instance, to switch to development repositories or internal repositories when running in the CI pipeline.
+* registry_code: code use for registering CaaSP product. If specified, the registries from the tfvars are ignored. Additional repositories can still be defined using the `maintenance` configuration parameter.
 
 #### Terraform
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -146,6 +146,9 @@ class Terraform(Platform):
                 url_parsed = urlparse(url)
                 url_updated = url_parsed._replace(netloc=self.conf.packages.mirror)
                 tfvars["repositories"][name] = url_updated.geturl()
+	
+        if self.conf.packages.certificates:
+            tfvars["packages"].append(self.conf.packages.certificates)
 
     def _run_terraform_command(self, cmd, env={}):
         """Running terraform command in {terraform.tfdir}/{platform}"""

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -130,9 +130,13 @@ class Terraform(Platform):
                 else:
                     tfvars[k] = v
 
+        # if registry code specified, repositories are not needed
+        if self.conf.packages.registry_code:
+            tfvars["caasp_registry_code"] = self.conf.packages.registry_code
+            tfvars["repositories"] = {}
+
         # Update mirror urls
         repos = tfvars.get("repositories", {})
-
         if self.conf.packages.maintenance:
            for name, url in self.conf.packages.maintenance.items():
                repos[name] = url

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -130,8 +130,13 @@ class Terraform(Platform):
                     tfvars[k] = v
 
         # Update mirror urls
-        repos = tfvars.get("repositories")
-        if self.conf.packages.mirror and repos is not None:
+        repos = tfvars.get("repositories", {})
+
+        if self.conf.packages.maintenance:
+           for name, url in self.conf.packages.maintenance.items():
+               repos[name] = url
+
+        if self.conf.packages.mirror and repos:
             for name, url in repos.items():
                 tfvars["repositories"][name] = url.replace("download.suse.de", self.conf.packages.mirror)
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -131,9 +131,9 @@ class Terraform(Platform):
 
         # Update mirror urls
         repos = tfvars.get("repositories")
-        if self.conf.terraform.mirror and repos is not None:
+        if self.conf.packages.mirror and repos is not None:
             for name, url in repos.items():
-                tfvars["repositories"][name] = url.replace("download.suse.de", self.conf.terraform.mirror)
+                tfvars["repositories"][name] = url.replace("download.suse.de", self.conf.packages.mirror)
 
     def _run_terraform_command(self, cmd, env={}):
         """Running terraform command in {terraform.tfdir}/{platform}"""

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -135,20 +135,20 @@ class Terraform(Platform):
             tfvars["caasp_registry_code"] = self.conf.packages.registry_code
             tfvars["repositories"] = {}
 
-        # Update mirror urls
         repos = tfvars.get("repositories", {})
-        if self.conf.packages.maintenance:
-           for name, url in self.conf.packages.maintenance.items():
+        if self.conf.packages.additional_repos:
+           for name, url in self.conf.packages.additional_repos.items():
                repos[name] = url
 
+        # Update mirror urls
         if self.conf.packages.mirror and repos:
             for name, url in repos.items():
                 url_parsed = urlparse(url)
                 url_updated = url_parsed._replace(netloc=self.conf.packages.mirror)
                 tfvars["repositories"][name] = url_updated.geturl()
 	
-        if self.conf.packages.certificates:
-            tfvars["packages"].append(self.conf.packages.certificates)
+        if self.conf.packages.additional_pkgs:
+            tfvars["packages"].extend(self.conf.packages.additional_pkgs)
 
     def _run_terraform_command(self, cmd, env={}):
         """Running terraform command in {terraform.tfdir}/{platform}"""

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from urllib.parse import urlparse
 
 import hcl
 
@@ -138,7 +139,9 @@ class Terraform(Platform):
 
         if self.conf.packages.mirror and repos:
             for name, url in repos.items():
-                tfvars["repositories"][name] = url.replace("download.suse.de", self.conf.packages.mirror)
+                url_parsed = urlparse(url)
+                url_updated = url_parsed._replace(netloc=self.conf.packages.mirror)
+                tfvars["repositories"][name] = url_updated.geturl()
 
     def _run_terraform_command(self, cmd, env={}):
         """Running terraform command in {terraform.tfdir}/{platform}"""

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -28,14 +28,15 @@ class BaseConfig:
         obj.openstack = BaseConfig.Openstack()
         obj.vmware = BaseConfig.VMware()
         obj.skuba = BaseConfig.Skuba()
-
         obj.lb = BaseConfig.NodeConfig()
         obj.master = BaseConfig.NodeConfig()
         obj.worker = BaseConfig.NodeConfig()
         obj.test = BaseConfig.Test()
         obj.log = BaseConfig.Log()
+        obj.packages = BaseConfig.Packages()
 
         config_classes = (
+            BaseConfig.Packages,
             BaseConfig.NodeConfig,
             BaseConfig.Test,
             BaseConfig.Log,
@@ -73,7 +74,6 @@ class BaseConfig:
             super().__init__()
             self.retries = 5
             self.internal_net = None
-            self.mirror = None
             self.stack_name = None
             self.tfdir = None
             self.tfvars = Constant.TERRAFORM_EXAMPLE
@@ -103,6 +103,11 @@ class BaseConfig:
         def __init__(self):
             self.env_file = None
             self.template_name = None
+
+
+    class Packages:
+        def __init__(self):
+            self.mirror = None
 
     @staticmethod
     def get_yaml_path(yaml_path):

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -108,9 +108,9 @@ class BaseConfig:
     class Packages:
         def __init__(self):
             self.mirror = None
-            self.maintenance = None
             self.registry_code = None
-            self.certificates = None
+            self.additional_repos = None
+            self.additional_pkgs = None
 
     @staticmethod
     def get_yaml_path(yaml_path):

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -110,6 +110,7 @@ class BaseConfig:
             self.mirror = None
             self.maintenance = None
             self.registry_code = None
+            self.certificates = None
 
     @staticmethod
     def get_yaml_path(yaml_path):

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -109,6 +109,7 @@ class BaseConfig:
         def __init__(self):
             self.mirror = None
             self.maintenance = None
+            self.registry_code = None
 
     @staticmethod
     def get_yaml_path(yaml_path):

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -108,6 +108,7 @@ class BaseConfig:
     class Packages:
         def __init__(self):
             self.mirror = None
+            self.maintenance = None
 
     @staticmethod
     def get_yaml_path(yaml_path):

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -13,12 +13,14 @@ skuba:
 # platform settings
 terraform:
   internal_net: "" # name of the internal network
-# disable mirrors
-# mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
   plugin_dir: "" # path to the terraform plugin dir
   stack_name: "" # name of the stack
   tfdir: ""  # path to terraform templates
   tfvars: "" # terraform vars
+
+packages:
+# disable mirrors
+# mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
 
 openstack:
   openrc: "" #os.getenv("OPENSTACK_OPENRC")

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -21,7 +21,8 @@ terraform:
 packages:
 # disable mirrors
 # mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
-  certificates: "ca-certificates-suse"
+  additional_pkgs:
+  - "ca-certificates-suse"
 
 openstack:
   openrc: "" #os.getenv("OPENSTACK_OPENRC")

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -21,6 +21,7 @@ terraform:
 packages:
 # disable mirrors
 # mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
+  certificates: "ca-certificates-suse"
 
 openstack:
   openrc: "" #os.getenv("OPENSTACK_OPENRC")

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -30,7 +30,6 @@
         "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
     },
     "packages": [
-        "ca-certificates-suse"
     ],
     "authorized_keys": [],
     "ntp_servers": [


### PR DESCRIPTION
## Why is this PR needed?

There are different test scenarios which are not easily covered without manual setup or extensive changes in the terrarform configuration used by testrunner. Concretely:
* Installing maintenance packages in the nodes
* Installing packages in the nodes from release repositories using registry codes

Fixes https://github.com/SUSE/avant-garde/issues/880

## What does this PR do?
* Introduces a new  section in testrunner configuration file that consolidates all options related to package installation
* Add an option for using a registration code and ignore repositories in the terraform file
* add option for specifying maintenance repositories
* Add option for adding certificates packages to installation, needed when testing self-signed packages
* Improves the logic used for setting repository mirrors


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
