### PR TITLE
Handle unstable builds

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
@@ -55,6 +55,9 @@ pipeline {
                 deleteDir()
             }
         }
+        unstable {
+            sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }

--- a/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-jjb-validation.Jenkinsfile
@@ -74,6 +74,9 @@ pipeline {
                 deleteDir()
             }
         }
+        unstable {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -110,6 +110,9 @@ pipeline {
                 deleteDir()
             }
         }
+        unstable {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -138,6 +138,9 @@ pipeline {
             }
             sh(script: "rm -f ${SKUBA_BINPATH}; ", label: 'Remove built skuba')
         }
+        unstable {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }

--- a/ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile
@@ -70,6 +70,9 @@ pipeline {
                 deleteDir()
             }
         }
+        unstable {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }

--- a/ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile
@@ -71,6 +71,9 @@ pipeline {
                 deleteDir()
             }
         }
+        unstable {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }

--- a/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-validate-pr-author.Jenkinsfile
@@ -49,6 +49,9 @@ pipeline {
                 deleteDir()
             }
         }
+        unstable {
+            sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
         failure {
             sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
         }


### PR DESCRIPTION
## Why is this PR needed?

When the testrunner tests fail the pipeline is marked as unstable not failed. This is causing the status to not be returned correctly at the end.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.


## What does this PR do?

Handles unstable builds as failures

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
