### PR TITLE
Fix certificate path on CPI clusters

### DIFF
--- a/ci/infra/openstack/cpi.auto.tfvars
+++ b/ci/infra/openstack/cpi.auto.tfvars
@@ -2,4 +2,4 @@
 #cpi_enable = true
 
 # Used to specify the path to your custom CA file
-#ca_file = "/etc/ssl/certs/SUSE_Trust_Root.pem"
+#ca_file = "/etc/pki/trust/anchors/SUSE_Trust_Root.pem"


### PR DESCRIPTION
## Why is this PR needed?

If certificate is uploaded to /etc/ssl/certs it disappears if cluster update contains new certificates. That means kubernetes looses access to openstack and cluster dies.
    
## Anything else a reviewer needs to know?

To reproduce deploy CPI cluster & wait for OS upgrade.
After reboot nodes will go to NotReady state.

## Related documentation issue
https://github.com/SUSE/doc-caasp/issues/537