### PR TITLE
Check for invalid node name

### DIFF
--- a/pkg/skuba/actions/validate/validate.go
+++ b/pkg/skuba/actions/validate/validate.go
@@ -19,9 +19,12 @@ package validate
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/SUSE/skuba/pkg/skuba"
 )
+
+var nodeNameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
 // NodeName checks whether the node name is valid and accpetable for kubelet.
 func NodeName(nodename string) error {
@@ -29,6 +32,12 @@ func NodeName(nodename string) error {
 		return fmt.Errorf(
 			"invalid node name \"%s\": must be no more than %d characters",
 			nodename, skuba.MaxNodeNameLength)
+	}
+
+	if !nodeNameRegex.MatchString(nodename) {
+		return fmt.Errorf(
+			"invalid node name \"%s\": must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
+			nodename)
 	}
 	return nil
 }

--- a/pkg/skuba/actions/validate/validate_test.go
+++ b/pkg/skuba/actions/validate/validate_test.go
@@ -31,8 +31,12 @@ func TestNodeName(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			nodename:  "my-worker-0",
+			nodename:  "my.worker.0",
 			expectErr: false,
+		},
+		{
+			nodename:  "my_master_0",
+			expectErr: true,
 		},
 		{
 			nodename:  "some-too-long-hostname-foo-bar-baz-fizz-buzz-xyz-zzy-kaboom-ayy-lmao",


### PR DESCRIPTION
This change introduces check for invalid node name. Regular expression
is based on upstream kubernetes check extended for uppercase letters.

## Why is this PR needed?

Currently bootstrap / join are started without checking node names and fail after some time.
```
λ skuba -v5 node bootstrap --user sles --sudo --target 10.86.4.78 master_0
I1004 14:57:23.569780     432 config.go:39] loading configuration from "kubeadm-init.conf"
I1004 14:57:23.575254     432 states.go:35] === applying state kubernetes.install-node-pattern ===
...
I1004 14:57:54.409367     432 ssh.go:167] running command: "sudo sh -c 'kubeadm init --config /tmp/kubeadm-init.conf --skip-token-print '"
I1004 14:57:54.711710     432 ssh.go:190] stderr | name: Invalid value: "master_0": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
I1004 14:57:54.878675     432 ssh.go:167] running command: "sudo sh -c 'rm /tmp/kubeadm-init.conf'"
F1004 14:57:55.160372     432 bootstrap.go:54] error bootstrapping node: failed to apply state kubeadm.init: Process exited with status 3
```

After this change skuba will refuse to run immediatelly:
```
λ skuba -v5 node join -s -u sles -t 10.86.3.69 -r worker 'master_0'
** This is an UNTAGGED version and NOT intended for production usage. **
F1004 17:41:15.220602   23977 join.go:46] invalid node name "master_0": must consist of alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
```

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.


## What does this PR do?

Validates node name before node bootstrap / join is started.

## Anything else a reviewer needs to know?

Regex is based on skuba output:
I1004 14:57:54.711710     432 ssh.go:190] stderr | name: Invalid value: "master_0": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', `regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
