### PR TITLE
Maintain kubernetesVersion during cluster init

### DIFF
--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -48,8 +48,9 @@ type InitConfiguration struct {
 
 func NewInitConfiguration(clusterName, cloudProvider, controlPlane, kubernetesDesiredVersion string, strictCapDefaults bool) (InitConfiguration, error) {
 	kubernetesVersion := kubernetes.LatestVersion()
+	var err error
 	if kubernetesDesiredVersion != "" {
-		kubernetesVersion, err := versionutil.ParseSemantic(kubernetesDesiredVersion)
+		kubernetesVersion, err = versionutil.ParseSemantic(kubernetesDesiredVersion)
 		if err != nil || !kubernetes.IsVersionAvailable(kubernetesVersion) {
 			return InitConfiguration{}, fmt.Errorf("Version %s does not exist or cannot be parsed.\n", kubernetesDesiredVersion)
 		}


### PR DESCRIPTION
## Why is this PR needed?

When using the := declaration/assignment notation for kubernetesVersion
it loses the assignment again when exiting the if { } block.

This resulted always in the latest version in the init
configuration.

## What does this PR do?

Overwrites kubernetesVersion during cluster init as intended.

## Anything else a reviewer needs to know?

Follow up of #720 

Fixes the cluster upgrade e2e tests

## Info for QA

run this and check the `kubeadm-init.conf` for `kubernetesVersion`:

```
skuba -v 3 cluster init --control-plane 10.86.3.94 --kubernetes-version=1.14.1 company-cluster
```