### PR TITLE
Retry upgraded check more often

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -31,7 +31,7 @@ def setup_kubernetes_version(platform, skuba, kubectl, kubernetes_version=None):
 
 
 def node_is_upgraded(kubectl, platform, node_name):
-    for attempt in range(10):
+    for attempt in range(20):
         if platform.all_apiservers_responsive():
             # kubernetes might be a little bit slow with updating the NodeVersionInfo
             version = kubectl.run_kubectl("get nodes {} -o jsonpath='{{.status.nodeInfo.kubeletVersion}}'".format(node_name))


### PR DESCRIPTION
## Why is this PR needed?

The e2e tests are failing sometimes after a successful upgrade of
a node, due to kubernetes being slow updating the NodeVersionInfo.

## What does this PR do?

Double the amount of checks if a node is upgraded.

## Anything else a reviewer needs to know?

example of a failed test:
https://ci.suse.de/view/CaaSP/job/caasp-jobs/job/e2e/job/caasp-v4-openstack-test_upgrade_apply_user_lock-nightly/62/console