### PR TITLE
Fix libvirt load balancer

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -146,21 +146,3 @@ resource "null_resource" "lb_push_haproxy_cfg" {
     ]
   }
 }
-
-resource "null_resource" "lb_reboot" {
-  depends_on = ["null_resource.lb_wait_cloudinit"]
-  count      = "${var.lbs}"
-
-  provisioner "local-exec" {
-    environment = {
-      user = "${var.username}"
-      host = "${element(libvirt_domain.lb.*.network_interface.0.addresses.0, count.index)}"
-    }
-
-    command = <<EOT
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
-# wait for ssh ready after reboot
-ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
-EOT
-  }
-}


### PR DESCRIPTION
## Why is this PR needed?

During the load balancer provisioning, sometimes the process fails during the `lb_push_haproxy_cfg` step fails because the node is rebooted by the `lb_reboot` step. Comparing with the VMware template, it seems this reboot is not needed. 

## What does this PR do?

Remove unnecessary reboot step in load balancer that causes deployment to fail.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
