### PR TITLE
Fix pods ready check in cluster deployment fixture

### DIFF
--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -4,6 +4,7 @@ import platforms
 from kubectl import Kubectl
 from skuba import Skuba
 from utils import BaseConfig
+from tests.utils import wait
 
 
 def pytest_addoption(parser):
@@ -49,7 +50,7 @@ def deployment(request, bootstrap, skuba, kubectl):
     if request.config.getoption("skip_setup") != 'deployed':
         skuba.join_nodes()
 
-    kubectl.run_kubectl('wait --timeout=3m --for=condition=Ready pods --all --namespace=kube-system')
+    wait(kubectl.run_kubectl, 'wait --timeout=1m --for=condition=Ready pods --all --namespace=kube-system', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why is this PR needed?

Some test are failing because the deployment fixture fails when checking for pods to get ready.

Fixes https://github.com/SUSE/avant-garde/issues/927

## What does this PR do?

Use the wait function from test.utils for waiting the pods
to get ready and retry in case of failure, in order to make
this check more robust.


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
