### PR TITLE
Use IBS Mirror

### DIFF
--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -13,8 +13,7 @@ skuba:
 # platform settings
 terraform:
   internal_net: "" # name of the internal network
-# disable mirrors
-# mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
+  mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
   plugin_dir: "" # path to the terraform plugin dir
   stack_name: "" # name of the stack
   tfdir: ""  # path to terraform templates


### PR DESCRIPTION
## Why is this PR needed?

IBS mirror was disable because it was experiencing
problems. However, using IBS repositories from NUE
slows down the test process considerably.

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.


## What does this PR do?

Sets the mirror configuration parameter for testrunner
 
# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
