### PR TITLE
Avoid race condition on deploying lb with libvirt

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -148,7 +148,7 @@ resource "null_resource" "lb_push_haproxy_cfg" {
 }
 
 resource "null_resource" "lb_reboot" {
-  depends_on = ["null_resource.lb_wait_cloudinit"]
+  depends_on = ["null_resource.lb_push_haproxy_cfg"]
   count      = "${var.lbs}"
 
   provisioner "local-exec" {


### PR DESCRIPTION
## Why is this PR needed?

Fixes an issue that can arise when manually deploying the terraform templates with libvirt

Fixes #

N/A

## What does this PR do?

There seems to be a race condition on the 2 resources
of the libvirt lb (reboot, haproxy) which are launched
inmediatly after the cloud init resource has finished
and can lead to the haproxy resource never completing
because the machine rebooted.

Instead, make the reboot dependant on the haproxy
resource, so its done in a linear fashion.

## Anything else a reviewer needs to know?

N/A

## Info for QA
N/A

### Related info
N/A

### Status **BEFORE** applying the patch

Creating libvirt resources with the terraform templates could lead to a timeout of the lb_push_haproxy_cfg resource

### Status **AFTER** applying the patch

Creating libvirt resources with the terraform template will never timeout the lb_push_haproxy_cfg resource


## Docs

N/A


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
