### PR TITLE
Handle RuntimeError in deployment fixture

### DIFF
--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -50,7 +50,7 @@ def deployment(request, bootstrap, skuba, kubectl):
     if request.config.getoption("skip_setup") != 'deployed':
         skuba.join_nodes()
 
-    wait(kubectl.run_kubectl, 'wait --timeout=1m --for=condition=Ready pods --all --namespace=kube-system', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5)
+    wait(kubectl.run_kubectl, 'wait --timeout=1m --for=condition=Ready pods --all --namespace=kube-system', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Why is this PR needed?

This fixture joins all nodes and then waits until
the system pods are ready. In some circumstances,
some of the nodes may not respond and this causes
a RuntimeError which should be retried.

## What does this PR do?

Add the RuntimeError as a retriable exception to the wait function that checks for pod availability

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
