### PR TITLE
Wait timeout enhancements

### DIFF
--- a/ci/infra/testrunner/tests/test_cilium.py
+++ b/ci/infra/testrunner/tests/test_cilium.py
@@ -13,7 +13,7 @@ def test_cillium(deployment, kubectl):
 
     logger.info("Deploy deathstar")
     kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/minikube/http-sw-app.yaml")
-    kubectl.run_kubectl("wait --for=condition=ready pods --all --timeout=3m")
+    kubectl.run_kubectl("wait --for=condition=ready pods --all --timeout=5m")
 
     # FIXME: this hardcoded wait should be replaces with a (cilum?) condition
     time.sleep(100)

--- a/ci/infra/testrunner/tests/test_dockercaps.py
+++ b/ci/infra/testrunner/tests/test_dockercaps.py
@@ -63,7 +63,7 @@ def test_dockercaps(deployment, kubectl, setup_manifest):
     logger.info("Deploy testcases")
     kubectl.run_kubectl(
         "apply -f {}".format(setup_manifest))
-    kubectl.run_kubectl("wait --for=condition=ready pods --all --timeout=3m")
+    kubectl.run_kubectl("wait --for=condition=ready pods --all --timeout=5m")
 
     logger.info("Test: Run 'su root -c id' on the containers")
     pods = ["sle12sp4", "leap", "sle15", "sle15sp1"]


### PR DESCRIPTION
## Why is this PR needed?

waiting in e2e tests is not consistent

## What does this PR do?

make waiting consistent
