### PR TITLE
addon upgrades: only use manifest version to determine upgrade

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_addon_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_addon_upgrade.py
@@ -22,7 +22,7 @@ def decrease_one_addon_manifest(addons_dict, skip=None):
     for addon in addons_dict:
         if addon == skip:
             continue
-        ver = addons_dict[addon]['ManifestVersion'] 
+        ver = addons_dict[addon]['ManifestVersion']
         if ver > 0:
             addons_dict[addon]['ManifestVersion'] -= 1
             return (
@@ -55,9 +55,7 @@ def test_addon_upgrade_plan(deployment, kubectl, skuba):
     addons_dict = skubaConf_dict['AddonsVersion']
 
     u_manif = decrease_one_addon_manifest(addons_dict)
-    u_img = decrease_one_addon_image(addons_dict, skip=u_manif[0])
 
-    u_img_msg = '{0}: {1} -> {2}'.format(u_img[0], u_img[1][0], u_img[1][1])
     u_manif_msg = '{0}: {1} -> {1} (manifest version from {2} to {3})'.format(
         u_manif[0], u_manif[1], u_manif[2][0], u_manif[2][1]
     )
@@ -69,7 +67,6 @@ def test_addon_upgrade_plan(deployment, kubectl, skuba):
 
     out = skuba.addon_upgrade('plan')
     assert out.find(u_manif_msg) != -1
-    assert out.find(u_img_msg) != -1
 
 def test_addon_upgrade_apply(deployment, kubectl, skuba):
     skubaConf_dict = get_skubaConfiguration_dict(kubectl)
@@ -84,7 +81,7 @@ def test_addon_upgrade_apply(deployment, kubectl, skuba):
     assert out.find("configmap/skuba-config replaced") != -1
 
     assert not addons_up_to_date(skuba)
-    
+
     out = skuba.addon_upgrade('apply')
     assert out.find("Successfully upgraded addons") != -1
     assert addons_up_to_date(skuba)

--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"text/template"
 
@@ -266,9 +265,7 @@ func addonVersionLower(version1 *kubernetes.AddonVersion, version2 *kubernetes.A
 	if version2 == nil {
 		return false
 	}
-	return version.MustParseSemantic(version1.Version).LessThan(version.MustParseSemantic(version2.Version)) ||
-		(reflect.DeepEqual(version.MustParseSemantic(version1.Version), version.MustParseSemantic(version2.Version)) &&
-			version1.ManifestVersion < version2.ManifestVersion)
+	return version1.ManifestVersion < version2.ManifestVersion
 }
 
 func updateSkubaConfigMapWithAddonVersion(addon kubernetes.Addon, clusterVersion *version.Version, skubaConfiguration *skuba.SkubaConfiguration) error {


### PR DESCRIPTION
## Why is this PR needed?

When determining when an addon has to be upgraded (using `skuba addon
upgrade apply` or `skuba addon upgrade plan`), rely on the manifest
version exclusively, and if different, treat the addon version as a
regular string.

If the manifest version is always bumped with every single change,
necessarily it has to be a newer version of the addon, so no need to
perform a semver parsing of the actual version of the addon (that may
contain semver pre-releases suffixes, or metadata builds -- ignored
when comparing, or not deeply compared; e.g. any prerelease
information < no prerelease information, since it's considered
prerelease vs release [1]).

[1] https://semver.org/#spec-item-11