### PR TITLE
Addon upgrade only apply needed addons

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -191,7 +191,7 @@ func (addon Addon) HasToBeApplied(addonConfiguration AddonConfiguration, skubaCo
 		return true, nil
 	}
 	addonVersion := kubernetes.AddonVersionForClusterVersion(addon.addon, addonConfiguration.ClusterVersion)
-	return !addonVersionLower(addonVersion, currentAddonVersion), nil
+	return addonVersionLower(currentAddonVersion, addonVersion), nil
 }
 
 func (addon Addon) needsRender(applyBehavior ApplyBehavior) bool {
@@ -260,12 +260,12 @@ func (addon Addon) Apply(addonConfiguration AddonConfiguration, skubaConfigurati
 	return updateSkubaConfigMapWithAddonVersion(addon.addon, addonConfiguration.ClusterVersion, skubaConfiguration)
 }
 
-func addonVersionLower(version1 *kubernetes.AddonVersion, version2 *kubernetes.AddonVersion) bool {
+func addonVersionLower(current *kubernetes.AddonVersion, updated *kubernetes.AddonVersion) bool {
 	// If we don't have a version to compare to, assume it's not lower
-	if version2 == nil {
+	if current == nil {
 		return false
 	}
-	return version1.ManifestVersion < version2.ManifestVersion
+	return current.ManifestVersion < updated.ManifestVersion
 }
 
 func updateSkubaConfigMapWithAddonVersion(addon kubernetes.Addon, clusterVersion *version.Version, skubaConfiguration *skuba.SkubaConfiguration) error {


### PR DESCRIPTION
## Why is this PR needed?

If some addon(s) need upgrades, other addon(s) will get upgraded also.

For example, if gangway addon needs to upgraded (manifest version from 1 to 2), the rest addons (psp, cilium, dex, kured) will get upgraded also since the comparison logic includes the same manifest version.

## What does this PR do?

Correct comparing manifest version, upgrade the addon(s) only on the current manifest version less than the latest manifest version.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

https://github.com/SUSE/skuba/pull/769

### Status **BEFORE** applying the patch

1. Deploy a cluster.
2. Edit the configmap `skuba-config`, decrease one of addon manifest version to 1 (for example, gangway ManifestVersion from 2 to 1).
3. `skuba addon upgrade plan`
   ```
   Addon upgrades for 1.15.2:
     - gangway: 3.1.0-rev4 -> 3.1.0-rev4 (manifest version from 1 to 2)
   ```
4. `skuba addon upgrade apply -v 5`, all the addons got upgraded.
   ```
   I1014 10:24:09.254818    3836 addons.go:226] applying "psp" addon
   I1014 10:24:12.429159    3836 addons.go:141] "psp" addon correctly applied
   I1014 10:24:12.429209    3836 addons.go:226] applying "kured" addon
   I1014 10:24:15.090280    3836 addons.go:141] "kured" addon correctly applied
   I1014 10:24:15.090334    3836 addons.go:226] applying "cilium" addon
   I1014 10:24:19.084159    3836 addons.go:141] "cilium" addon correctly applied
   I1014 10:24:19.084220    3836 addons.go:226] applying "dex" addon
   I1014 10:24:19.296739    3836 config.go:39] loading configuration from "kubeadm-init.conf"
   I1014 10:24:23.099774    3836 addons.go:141] "dex" addon correctly applied
   I1014 10:24:23.099842    3836 addons.go:226] applying "gangway" addon
   I1014 10:24:23.592167    3836 config.go:39] loading configuration from "kubeadm-init.conf"
   I1014 10:24:26.866602    3836 addons.go:141] "gangway" addon correctly applied
   [apply] Successfully upgraded addons
   ```

### Status **AFTER** applying the patch

1. Deploy a cluster.
2. Edit the configmap `skuba-config`, decrease one of addon manifest version to 1 (for example, gangway ManifestVersion from 2 to 1).
3. `skuba addon upgrade plan`
   ```
   Addon upgrades for 1.15.2:
     - gangway: 3.1.0-rev4 -> 3.1.0-rev4 (manifest version from 1 to 2)
   ```

4. `skuba addon upgrade apply -v 5`, only the modified addon(s) got upgraded, skipping the rest addon(s).
   ```
   I1014 10:27:05.353393    4541 addons.go:146] skipping "psp" addon apply
   I1014 10:27:05.353428    4541 addons.go:146] skipping "cilium" addon apply
   I1014 10:27:05.353433    4541 addons.go:146] skipping "dex" addon apply
   I1014 10:27:05.353438    4541 addons.go:226] applying "gangway" addon
   I1014 10:27:05.715253    4541 config.go:39] loading configuration from "kubeadm-init.conf"
   I1014 10:27:08.812274    4541 addons.go:141] "gangway" addon correctly applied
   I1014 10:27:08.812340    4541 addons.go:146] skipping "kured" addon apply
   [apply] Successfully upgraded addon
   ```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->