### PR TITLE
Fix bsc#1153913

### DIFF
--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -19,7 +19,6 @@ package skuba
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 
@@ -80,17 +79,6 @@ func CriDockerDefaultsConfFile() string {
 }
 
 func KubeConfigAdminFile() string {
-	// give high precedence to local `admin.conf`
-	if _, err := os.Stat("admin.conf"); os.IsNotExist(err) {
-		env := os.Getenv("KUBECONFIG")
-		if env != "" {
-			return env
-		}
-		// TODO handle error
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, ".kube", "config")
-	}
-
 	return "admin.conf"
 }
 


### PR DESCRIPTION
## Why is this PR needed?

Do not try to guess the kubeconfig file to be used. The code slipped into by mistake (it was a POC).


Fixes [bsc#1153913](https://bugzilla.suse.com/show_bug.cgi?id=1153913)

## What does this PR do?

Go back to the old behaviour and rely on a hard-coded value.

## Anything else a reviewer needs to know?

Nothing.

## Info for QA

Just ensure you can do a `skuba node bootstrap` even if you have a `~/.kube/config` file inside on your machine.

### Status **BEFORE** applying the patch

Node bootstrap doesn't work. See bug report.

### Status **AFTER** applying the patch

Node bootstrap works as expected.

## Docs

Nothing to change.