### PR TITLE
Fix addon upgrade breaking generated manifests by invalid control plane value

### DIFF
--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/version"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
@@ -73,9 +74,15 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	if err != nil {
 		return errors.Wrapf(err, "could not parse semantic version: %s", initConfiguration.KubernetesVersion)
 	}
+
+	var controlPlane string
+	if controlPlane, _, err = kubeadmutil.ParseHostPort(initConfiguration.ControlPlaneEndpoint); err != nil {
+		return errors.Wrap(err, "[bootstrap] Failed to get control plane host")
+	}
+
 	addonConfiguration := addons.AddonConfiguration{
 		ClusterVersion: versionToDeploy,
-		ControlPlane:   initConfiguration.ControlPlaneEndpoint,
+		ControlPlane:   controlPlane,
 		ClusterName:    initConfiguration.ClusterName,
 	}
 	if err := addons.DeployAddons(addonConfiguration, addons.SkipRenderIfConfigFilePresent); err != nil {


### PR DESCRIPTION
## Why is this PR needed?

Fix broken generated addon manifests from `skuba addon upgrade apply` caused by invalid control plane value.

Fixes https://github.com/SUSE/avant-garde/issues/944

## What does this PR do?

Use the correct control plane value w/o port to generate correct addon manifests, but this fix doesn’t handle customized manifest changed by user that should be tackled by another PR based on kustomize based on a RFC proposal.

## Anything else a reviewer needs to know?

N/A

## Info for QA

Please just follow up the steps mentioned in https://github.com/SUSE/avant-garde/issues/944 to verify gangway addon upgrade w/ valid gangway configmap, but this does not handle customized manifest changed by user.

### Related info
n/a

### Status **BEFORE** applying the patch
After applying gangway addon upgrade, it's config map should has invalid URLs.

```
redirectURL: "https://10.84.153.111:6443:32001/callback"
authorizeURL: "https://10.84.153.111:6443:32000/auth"
tokenURL: "https://10.84.153.111:6443:32000/token"
apiServerURL: "https://10.84.153.111:6443:6443"
```

### Status **AFTER** applying the patch
After applying gangway addon upgrade, it's config map should has valid URLs.

```
redirectURL: "https://10.84.153.111:32001/callback"
authorizeURL: "https://10.84.153.111:32000/auth"
tokenURL: "https://10.84.153.111:32000/token"
apiServerURL: "https://10.84.153.111:6443"
```

## Docs
n/a

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
