### PR TITLE
Backward compatible to CaaSP 4.0 GM

### DIFF
--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -112,7 +112,7 @@ data:
     apiServerURL: "https://{{.ControlPlane}}:6443"
     cluster_ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
     trustedCAPath: /etc/gangway/pki/ca.crt
-    customHTMLTemplatesDir: /usr/share/gangway/web/templates/caasp
+    customHTMLTemplatesDir: /usr/share/caasp-gangway/web/templates/caasp
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
## Why is this PR needed?

gangway `3.1.0-rev4` changes the custom HTML path from `/usr/share/gangway/web/templates/caasp` to `/usr/share/caasp-gangway/web/templates/caasp`

CaaSP 4.0 GM uses gangway version `3.1.0` (points to `3.1.0-rev3` actually).
Now, to address this issue [#bsc](https://github.com/SUSE/skuba/pull/755), the gangway version `3.1.0-rev4` proposed and version `3.1.0` points to version `3.1.0-rev4`.

So, using CaaSP 4.0 GM to deploying a cluster, it pulls image `3.1.0` (which is `3.1.0-rev4` actually, not the one it should use `3.1.0-rev3`). 

## What does this PR do?

Revert gangway configmap customHTMLTemplatesDir as CaaSP 4.0 GM was.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

### Status **BEFORE** applying the patch

1. Deploy a cluster by CaaSP 4.0 GM
2. Open browser with gangway URL
3. A path error displays

### Status **AFTER** applying the patch

1. Deploy a cluster by CaaSP 4.0 GM
2. Open browser with gangway URL
3. Correctly display gangway main page

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
