### PR TITLE
Fix skuba returns rc 0 when cluster status fails

### DIFF
--- a/cmd/skuba/cluster/status.go
+++ b/cmd/skuba/cluster/status.go
@@ -18,6 +18,8 @@
 package cluster
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
@@ -32,6 +34,7 @@ func NewStatusCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cluster.Status(); err != nil {
 				klog.Errorf("unable to get cluster status: %s", err)
+				os.Exit(1)
 			}
 		},
 		Args: cobra.NoArgs,


### PR DESCRIPTION
## Why is this PR needed?
When calling the cluster status command, if it fails, still returns a return code of 0. This causes problems with test automation which check the return when invoking skuba.

Fixes https://github.com/SUSE/skuba/issues/539

## What does this PR do?
Return rc 1 instead of 0

## Anything else a reviewer needs to know?
None

## Info for QA
None

### Related info
None

### Status **BEFORE** applying the patch
```bash
> skuba cluster status
** This is an UNTAGGED version and NOT intended for production usage. **                                 
E1017 13:17:20.528350    8452 status.go:34] unable to get cluster status: could not retrieve node list: Get https://10.0.100.130:6443/api/v1/nodes: dial tcp 10.0.100.130:6443: connect: no route to host 
> echo $?
0
```

### Status **AFTER** applying the patch
```bash
> skuba cluster status
** This is an UNTAGGED version and NOT intended for production usage. **                     
E1017 13:18:29.488332    9192 status.go:36] unable to get cluster status: could not retrieve node list: Get https://10.0.100.130:6443/api/v1/nodes: dial tcp 10.0.100.130:6443: connect: no route to host                         
> echo $?
1
```

## Docs
None


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
