### PR TITLE
Move validator job to the right place

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -75,10 +75,10 @@
         - '{name}-test_addon_upgrade_apply-nightly'
 
 - project:
-    name: caasp-jobs/validator
+    name: caasp-jobs/validator/caasp-v4-openstack
     platform: openstack
     jobs:
-        - 'validator-join-nightly'
+        - '{name}-validator-join-nightly'
 
 - job:
     name: caasp-jobs/caasp-jjb

--- a/ci/jenkins/templates/validator-nightly-template.yaml
+++ b/ci/jenkins/templates/validator-nightly-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: 'validator-join-nightly'
+    name: '{name}-validator-join-nightly'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

The job landed in the jenkins root of ci.suse.de

## What does this PR do?

moves the job to the right place (caasp-jobs/validator subfolder)

## Anything else a reviewer needs to know?

Follow up of https://github.com/SUSE/skuba/pull/779
