### PR TITLE
Skip the psp image when listing all images for airgap

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -93,7 +93,7 @@ var (
 				Kured:   &AddonVersion{"1.2.0", 0},
 				Dex:     &AddonVersion{"2.16.0", 2},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"1.0.0", 0},
+				PSP:     &AddonVersion{"", 0},
 			},
 		},
 		"1.15.0": KubernetesVersion{
@@ -113,7 +113,7 @@ var (
 				Kured:   &AddonVersion{"1.2.0", 0},
 				Dex:     &AddonVersion{"2.16.0", 2},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"1.0.0", 0},
+				PSP:     &AddonVersion{"", 0},
 			},
 		},
 		"1.14.1": KubernetesVersion{
@@ -133,7 +133,7 @@ var (
 				Kured:   &AddonVersion{"1.2.0", 0},
 				Dex:     &AddonVersion{"2.16.0", 2},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"1.0.0", 0},
+				PSP:     &AddonVersion{"", 0},
 			},
 		},
 	}

--- a/pkg/skuba/actions/cluster/images/images.go
+++ b/pkg/skuba/actions/cluster/images/images.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 )
 
@@ -43,6 +44,10 @@ func Images() error {
 				kubernetes.ComponentVersionForClusterVersion(component, cv)))
 		}
 		for addonName, addonVersion := range kubernetes.Versions[cv.String()].AddonsVersion {
+			if addonVersion.Version == "" {
+				klog.V(1).Infof("Skipping addon %s - empty version detected.", string(addonName))
+				continue
+			}
 			fmt.Printf("%-10v %v\n", cv, images.GetGenericImage(skuba.ImageRepository, string(addonName),
 				addonVersion.Version))
 		}


### PR DESCRIPTION
The psp image is not an actual container, but it pretends to be one for use
cluster update logic.

This is done using a sentinel object for the FakeVersion used by the psp image.
This can then be detected and skipped over.

This is an alternative implementation for #785 

## Why is this PR needed?

Currently the psp image is listed as an image - but the image does not actually exists.

This PR introduces a list of images that should be skipped when outputting images that are needed to bootstrap the cluster.

Fixes SUSE/avant-garde/issues/951

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.


## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
