### PR TITLE
skuba node upgrade shows component downgrade (bsc#1154085)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,6 @@ Fixes #
 **Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
 appear in the changelog.
 
-
 ## What does this PR do?
 
 please include a brief "management" technical overview (details are in the code)
@@ -39,13 +38,11 @@ this issue is not fixed.
 
 How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.
 
-
 ## Docs
 
 If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
 At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
 but the documentation needs to be finalized before the PR can be merged. 
-
 
 # Merge restrictions
 
@@ -58,7 +55,6 @@ We are in *v4-maintenance phase*, so we will restrict what can be merged to prev
             1 developer: code is fine
             1 QA: QA is fine
         there is a PR for updating documentation (or a statement that this is not needed)
-
 
 <!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
     If you can, please apply all applicable labels to help reviews out! -->

--- a/internal/pkg/skuba/etcd/member_test.go
+++ b/internal/pkg/skuba/etcd/member_test.go
@@ -53,7 +53,7 @@ apiServer:
 
 	fakeConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubeadm-config",
+			Name:      kubeadmconstants.KubeadmConfigConfigMap,
 			Namespace: metav1.NamespaceSystem,
 		},
 		Data: map[string]string{

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -52,17 +52,22 @@ func (nviu NodeVersionInfoUpdate) HasMajorOrMinorUpdate() bool {
 		}
 	}
 	return nviu.Update.KubeletVersion.Major() > nviu.Current.KubeletVersion.Major() ||
-		nviu.Update.KubeletVersion.Minor() > nviu.Current.KubeletVersion.Minor()
+		nviu.Update.KubeletVersion.Minor() > nviu.Current.KubeletVersion.Minor() ||
+		nviu.Update.ContainerRuntimeVersion.Major() > nviu.Current.ContainerRuntimeVersion.Major() ||
+		nviu.Update.ContainerRuntimeVersion.Minor() > nviu.Current.ContainerRuntimeVersion.Minor()
 }
 
 func (nviu NodeVersionInfoUpdate) IsUpdated() bool {
-	return reflect.DeepEqual(nviu.Current.KubeletVersion, nviu.Update.KubeletVersion) &&
-		reflect.DeepEqual(nviu.Current.APIServerVersion, nviu.Update.APIServerVersion) &&
+	return reflect.DeepEqual(nviu.Current.APIServerVersion, nviu.Update.APIServerVersion) &&
 		reflect.DeepEqual(nviu.Current.ControllerManagerVersion, nviu.Update.ControllerManagerVersion) &&
 		reflect.DeepEqual(nviu.Current.SchedulerVersion, nviu.Update.SchedulerVersion) &&
 		reflect.DeepEqual(nviu.Current.EtcdVersion, nviu.Update.EtcdVersion) &&
+		nviu.Current.KubeletVersion.Major() == nviu.Update.KubeletVersion.Major() &&
+		nviu.Current.KubeletVersion.Minor() == nviu.Update.KubeletVersion.Minor() &&
+		nviu.Current.KubeletVersion.Patch() >= nviu.Update.KubeletVersion.Patch() &&
 		nviu.Current.ContainerRuntimeVersion.Major() == nviu.Update.ContainerRuntimeVersion.Major() &&
-		nviu.Current.ContainerRuntimeVersion.Minor() == nviu.Update.ContainerRuntimeVersion.Minor()
+		nviu.Current.ContainerRuntimeVersion.Minor() == nviu.Update.ContainerRuntimeVersion.Minor() &&
+		nviu.Current.ContainerRuntimeVersion.Patch() >= nviu.Update.ContainerRuntimeVersion.Patch()
 }
 
 func (nviu NodeVersionInfoUpdate) IsFirstControlPlaneNodeToBeUpgraded() (bool, error) {


### PR DESCRIPTION
## Why is this PR needed?

The components `kubelet` and `cri-o` are handled by `skuba-update`, therefore, the patch version might mismatch compares to the kubernetes version. This would encounter a corner case that when the user runs `skuba node upgrade plan <worker-node>`, skuba shows component `kubelet` or `cri-o` downgrade.

Fixes https://github.com/SUSE/avant-garde/issues/959

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

- Function `HasMajorOrMinorUpdate()`:
  - The node is control plane, and if _updated_ apiserver major/minor version > _current_ apiserver major/minor version, return `true`; otherwise, return `false`.
  - The node is worker node, and if _updated_ kubelet major/minor version > _current_ kubelet major/minor version or if updated _cri-o_ major/minor version > current _cri-o_ major/minor version, return `true`; otherwise, return `false`.

- Function `IsUpdated()`:
  Check both `kubelet` and `cri-o` version is updated when:
  - Current major and minor version the same as updated major and minor version.
  - Current patch version large than or equals to updated patch version.

- Add unit tests to test the above functions.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

1. Deploy a cluster (1 master node, 1 worker node) with version `1.15.0`
```
skuba cluster init --control-plane <IP/FQDN> --kubernetes-version 1.15.0 <cluster-name>
```
2. Run node upgrade plan on worker node
```
skuba node upgrade plan <worker-node-ip-fqdn>
```
3. Console output indicates `kubelet` downgrade
```
Current Kubernetes cluster version: 1.15.0
Latest Kubernetes version: 1.15.2

Current Node version: 1.15.2

Component versions in 10.86.0.32
  - kubelet: 1.15.2 -> 1.15.0
  - cri-o: 1.15.0 -> 1.15.0
```

### Status **AFTER** applying the patch

1. Deploy a cluster (1 master node, 1 worker node) with version `1.15.0`
```
skuba cluster init --control-plane <IP/FQDN> --kubernetes-version 1.15.0 <cluster-name>
```
2. Run node upgrade plan on worker node
```
skuba node upgrade plan <worker-node-ip-fqdn>
```
3. Console output indicates worker node is up to date
```
Current Kubernetes cluster version: 1.15.0
Latest Kubernetes version: 1.15.2

Current Node version: 1.15.2

Node 10.86.0.32 is up to date
```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>