### PR TITLE
Do not discard error values when retrieving pods

### DIFF
--- a/internal/pkg/skuba/kubernetes/node_version.go
+++ b/internal/pkg/skuba/kubernetes/node_version.go
@@ -185,10 +185,23 @@ func nodeVersioningInfoWithClientset(client kubernetes.Interface, nodeName strin
 
 	// find out the container image tags, depending on the role of the node
 	if IsControlPlane(nodeObject) {
-		apiServerTag, _ := getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "kube-apiserver", nodeName))
-		controllerManagerTag, _ := getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "kube-controller-manager", nodeName))
-		schedulerTag, _ := getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "kube-scheduler", nodeName))
-		etcdTag, _ := getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "etcd", nodeName))
+		var apiServerTag, controllerManagerTag, schedulerTag, etcdTag string
+		apiServerTag, err = getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "kube-apiserver", nodeName))
+		if err != nil {
+			return NodeVersionInfo{}, errors.Wrap(err, "could not retrieve apiserver pod")
+		}
+		controllerManagerTag, err = getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "kube-controller-manager", nodeName))
+		if err != nil {
+			return NodeVersionInfo{}, errors.Wrap(err, "could not retrieve controller-manager pod")
+		}
+		schedulerTag, err = getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "kube-scheduler", nodeName))
+		if err != nil {
+			return NodeVersionInfo{}, errors.Wrap(err, "could not retrieve scheduler pod")
+		}
+		etcdTag, err = getPodContainerImageTagWithClientset(client, metav1.NamespaceSystem, fmt.Sprintf("%s-%s", "etcd", nodeName))
+		if err != nil {
+			return NodeVersionInfo{}, errors.Wrap(err, "could not retrieve etcd pod")
+		}
 
 		nodeVersions.APIServerVersion = version.MustParseSemantic(apiServerTag)
 		nodeVersions.ControllerManagerVersion = version.MustParseSemantic(controllerManagerTag)


### PR DESCRIPTION
Instead return the errors as any non-retrieved version will break during
SemanticParse anyhow

## Why is this PR needed?

Additional debugging information to see why some nightly CI runs break