### PR TITLE
Fix node upgrade not success if patch version bump (bsc#1155173)

### DIFF
--- a/internal/pkg/skuba/kubernetes/node_version_test.go
+++ b/internal/pkg/skuba/kubernetes/node_version_test.go
@@ -28,7 +28,7 @@ import (
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
-func TestNodeVersioningInfoWithClientset(t *testing.T) {
+func TestNodeVersioningInfo(t *testing.T) {
 	testK8sVersion := version.MustParseSemantic("v1.14.1")
 	testEtcdVersion := version.MustParseSemantic("3.3.11")
 	namespace := metav1.NamespaceSystem
@@ -164,7 +164,7 @@ func TestNodeVersioningInfoWithClientset(t *testing.T) {
 				},
 			})
 
-			nodeVersionInfo, _ := nodeVersioningInfoWithClientset(clientset, tt.nodeName)
+			nodeVersionInfo, _ := nodeVersioningInfo(clientset, tt.nodeName)
 			if !reflect.DeepEqual(nodeVersionInfo, tt.expectedNodeVersionInfo) {
 				t.Errorf("got %v, want %v", nodeVersionInfo, tt.expectedNodeVersionInfo)
 			}

--- a/internal/pkg/skuba/kubernetes/nodes.go
+++ b/internal/pkg/skuba/kubernetes/nodes.go
@@ -106,7 +106,7 @@ func DrainNode(client kubernetes.Interface, node *v1.Node, drainTimeout time.Dur
 	return nil
 }
 
-func getPodContainerImageTagWithClientset(client kubernetes.Interface, namespace string, podName string) (string, error) {
+func getPodContainerImageTag(client kubernetes.Interface, namespace string, podName string) (string, error) {
 	podObject, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "could not retrieve pod object")

--- a/internal/pkg/skuba/kubernetes/nodes_test.go
+++ b/internal/pkg/skuba/kubernetes/nodes_test.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestGetPodContainerImageTagWithClientset(t *testing.T) {
+func TestGetPodContainerImageTag(t *testing.T) {
 	podName := "etcd-my-master-0"
 	namespace := metav1.NamespaceSystem
 	expectedEtcdContainerImageTag := "3.3.11"
@@ -46,7 +46,7 @@ func TestGetPodContainerImageTagWithClientset(t *testing.T) {
 			},
 		})
 
-		etcdContainerImageTag, _ := getPodContainerImageTagWithClientset(clientset, namespace, podName)
+		etcdContainerImageTag, _ := getPodContainerImageTag(clientset, namespace, podName)
 		if !reflect.DeepEqual(etcdContainerImageTag, expectedEtcdContainerImageTag) {
 			t.Errorf("got %v, want %v", etcdContainerImageTag, expectedEtcdContainerImageTag)
 		}

--- a/internal/pkg/skuba/upgrade/cluster/drift.go
+++ b/internal/pkg/skuba/upgrade/cluster/drift.go
@@ -51,7 +51,7 @@ func DriftedNodes() ([]kubernetes.NodeVersionInfo, error) {
 	if err != nil {
 		return []kubernetes.NodeVersionInfo{}, err
 	}
-	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo()
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(client)
 	if err != nil {
 		return []kubernetes.NodeVersionInfo{}, err
 	}

--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -40,7 +40,7 @@ func Apply() error {
 	}
 	currentVersion := currentClusterVersion.String()
 	latestVersion := kubernetes.LatestVersion().String()
-	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo()
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(client)
 	if err != nil {
 		return err
 	}

--- a/pkg/skuba/actions/addon/upgrade/plan.go
+++ b/pkg/skuba/actions/addon/upgrade/plan.go
@@ -38,7 +38,7 @@ func Plan() error {
 	}
 	currentVersion := currentClusterVersion.String()
 	latestVersion := kubernetes.LatestVersion().String()
-	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo()
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(client)
 	if err != nil {
 		return err
 	}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -80,13 +80,13 @@ func Apply(target *deployments.Target) error {
 	var initCfgContents []byte
 
 	// Check if the target node is the first control plane to be updated
-	isFirstControlPlaneUpgrade, err := nodeVersionInfoUpdate.IsFirstControlPlaneNodeToBeUpgraded()
+	isFirstControlPlaneUpgrade, err := nodeVersionInfoUpdate.IsFirstControlPlaneNodeToBeUpgraded(client)
 	if err != nil {
 		return err
 	}
 	if isFirstControlPlaneUpgrade {
 		var err error
-		upgradeable, err = kubernetes.AllWorkerNodesTolerateVersion(nodeVersionInfoUpdate.Update.APIServerVersion)
+		upgradeable, err = kubernetes.AllWorkerNodesTolerateVersion(client, nodeVersionInfoUpdate.Update.APIServerVersion)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func Apply(target *deployments.Target) error {
 	} else {
 		// there is already at least one updated control plane node
 		if nodeVersionInfoUpdate.Current.IsControlPlane() {
-			upgradeable, err = kubernetes.AllWorkerNodesTolerateVersion(currentClusterVersion)
+			upgradeable, err = kubernetes.AllWorkerNodesTolerateVersion(client, currentClusterVersion)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Why is this PR needed?

When the difference between _current_ and _update_ cluster version is only patch version, upgrade the first control plane node does not _really_ successfully.

This happens when we have a patched kubernetes version, as `1.15.0` and `1.15.2`. During `1.15.0` cluster deploying, the RPM package component `kubelet` will installed to the latest version `1.15.2`.
This causes the check logic `IsFirstControlPlaneNodeToBeUpgraded` always as `false` when only the patch version updated.

Fixes https://github.com/SUSE/avant-garde/issues/993

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Fix the function `IsFirstControlPlaneNodeToBeUpgraded()`.

## Anything else a reviewer needs to know?

RFC about how to check first/second control plane to be upgraded.
- https://github.com/SUSE/caasp-rfc/blob/master/accepted/0040-platform-upgrade.md#first-control-plane-to-be-upgraded
- https://github.com/SUSE/caasp-rfc/blob/master/accepted/0040-platform-upgrade.md#secondary-control-plane-to-be-upgraded

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Related PR is #793, but this PR address different behavior.

### Status **BEFORE** applying the patch

1. Deploy a version `1.15.0` cluster (1 master, 1 worker).
2. Execute node upgrade apply, it displays upgrade successfully.
```
skuba node upgrade apply --sudo --user sles --target <master-node-ip-fqdn> -v 5
```
3. Run upgrade plan on the master node, it displays still have a version to be upgraded from `1.15.0` to `1.15.2`.
```
skuba node upgrade plan <master-node-name>
```

### Status **AFTER** applying the patch

1. Deploy a version `1.15.0` cluster (1 master, 1 worker).
2. Execute node upgrade apply, it displays upgrade successfully.
```
skuba node upgrade apply --sudo --user sles --target <master-node-ip-fqdn> -v 5
```
3. Run upgrade plan on the master node, it displays the node version is up to date.
```
skuba node upgrade plan <master-node-name>
```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>