### PR TITLE
Rename validation job

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -75,10 +75,10 @@
         - '{name}-test_addon_upgrade_apply-nightly'
 
 - project:
-    name: caasp-jobs/validator/caasp-v4-openstack
+    name: caasp-jobs/validation/caasp-v4-openstack
     platform: openstack
     jobs:
-        - '{name}-validator-join-nightly'
+        - '{name}-devel-base-nightly'
 
 - job:
     name: caasp-jobs/caasp-jjb

--- a/ci/jenkins/templates/validation-nightly-template.yaml
+++ b/ci/jenkins/templates/validation-nightly-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-validator-join-nightly'
+    name: '{name}-devel-base-nightly'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30
@@ -13,7 +13,7 @@
     parameters:
         - string:
             name: VALIDATOR_ARGS
-            default: '-p {platform} -t join -n 3:2 -c'
+            default: '-p {platform} -t base -n 3:2 -c'
             description: The arguments for validator_caasp
     pipeline-scm:
         scm:


### PR DESCRIPTION
## Why is this PR needed?

Naming should be more clear

## What does this PR do?

renames the validation job to the following format:

`{name}-{devel/staging/release}-{testname}-nightly`

Also make 'base' test the default for validator

https://github.com/SUSE/avant-garde/issues/973