### PR TITLE
Set timeout for setup_kubernetes to 10 minutes

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -30,9 +30,9 @@ def setup_kubernetes_version(platform, skuba, kubectl, kubernetes_version=None):
     skuba.join_nodes()
 
     wait(kubectl.run_kubectl,
-         "wait --for=condition=ready nodes --all --timeout=0",
+         "wait --for=condition=ready nodes --all --timeout=30m",
          wait_delay=60,
-         wait_timeout=30,
+         wait_timeout=30 * 60,
          wait_backoff=30,
          wait_retries=5,
          wait_allow=(RuntimeError))

--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -1,5 +1,11 @@
 import signal
 import time
+from utils.timeit import timed
+import logging
+
+
+logger = logging.getLogger('testrunner')
+
 
 def wait(func, *args, **kwargs):
 
@@ -31,7 +37,9 @@ def wait(func, *args, **kwargs):
         signal.signal(signal.SIGALRM, _handle_timeout)
         signal.alarm(timeout)
         try:
-            return func(*args, **kwargs)
+            with timed(func.__name__):
+                result = func(*args, **kwargs)
+            return result
         except TimeoutError:
             if elapsed > 0 and int(time.time())-start >= elapsed:
                reason = "maximum wait time exceeded: {}s".format(elapsed)

--- a/ci/infra/testrunner/utils/timeit.py
+++ b/ci/infra/testrunner/utils/timeit.py
@@ -1,0 +1,14 @@
+import contextlib
+import logging
+from timeit import default_timer as timer
+
+
+logger = logging.getLogger('testrunner')
+
+
+@contextlib.contextmanager
+def timed(description: str) -> None:
+    start = timer()
+    yield
+    end = timer()
+    logger.info("Executing {} took: {} seconds".format(description, end - start))

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -10,7 +10,6 @@ from threading import Thread
 
 import requests
 from timeout_decorator import timeout
-
 from utils.constants import Constant
 from utils.format import Format
 

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -8,7 +8,7 @@ nodeuser: "sles"  # Default node username
 skuba:
   binpath: "" # path to skuba binary
   srcpath: "" # path to skuba source
-  verbosity: 5 # default value passed to skuba with -v
+  verbosity: 10 # default value passed to skuba with -v
 
 # platform settings
 terraform:


### PR DESCRIPTION
With timeout 0 it will only check once and fail otherwise.

## Why is this PR needed?

Attempt to fix `setup_kubernetes_version` - spuriously fails when running nightly tests, especially on VMWare.

With the 10 minute timeout the pipeline on `vmware` seems to work.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
