### PR TITLE
Fix dockercaps test

### DIFF
--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -1,11 +1,10 @@
-import json
 import pytest
 
 import platforms
 from kubectl import Kubectl
 from skuba import Skuba
 from utils import BaseConfig
-from tests.utils import wait
+from tests.utils import (check_pods_ready, wait)
 
 
 def pytest_addoption(parser):
@@ -47,20 +46,14 @@ def bootstrap(request, provision, skuba):
     skuba.node_bootstrap()
 
 
-def check_system_pods_ready(kubectl):
-    pods = json.loads(kubectl.run_kubectl('get pods --namespace=kube-system -o json'))['items']
-    for pod in pods:
-        pod_status = pod['status']['phase']
-        pod_name   = pod['metadata']['name']
-        assert pod_status in ['Running', 'Completed'], f'Pod {pod_name} status {pod_status} != Running or Completed'
-
 @pytest.fixture
 def deployment(request, bootstrap, skuba, kubectl):
     if request.config.getoption("skip_setup") != 'deployed':
         skuba.join_nodes()
 
-    wait(check_system_pods_ready,
+    wait(check_pods_ready,
          kubectl,
+         namespace="kube-system",
          wait_delay=60,
          wait_timeout=10,
          wait_backoff=60,

--- a/ci/infra/testrunner/tests/test_dockercaps.py
+++ b/ci/infra/testrunner/tests/test_dockercaps.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from tests.utils import wait
+from tests.utils import (check_pods_ready, wait)
 
 logger = logging.getLogger("testrunner")
 
@@ -66,13 +66,13 @@ def test_dockercaps(deployment, kubectl, setup_manifest):
     kubectl.run_kubectl(
         "apply -f {}".format(setup_manifest))
 
-    wait(kubectl.run_kubectl,
-         "wait --for=condition=ready pods --all --timeout=0",
+    wait(check_pods_ready,
+         kubectl,
          wait_delay=30,
          wait_timeout=10,
          wait_backoff=30,
          wait_elapsed=180,
-         wait_allow=(RuntimeError))
+         wait_allow=(AssertionError))
 
     logger.info("Test: Run 'su root -c id' on the containers")
     pods = ["sle12sp4", "leap", "sle15", "sle15sp1"]

--- a/ci/infra/testrunner/tests/test_dockercaps.py
+++ b/ci/infra/testrunner/tests/test_dockercaps.py
@@ -8,7 +8,7 @@ from tests.utils import (check_pods_ready, wait)
 
 logger = logging.getLogger("testrunner")
 
-CONTENT = """---
+MANIFEST = """---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -50,21 +50,11 @@ spec:
       command: ['/bin/sh', '-c', 'sleep 3600']"""
 
 
-@pytest.fixture
-def setup_manifest():
-    cwd = pathlib.Path.cwd()
-    p = cwd / "pods.yaml"
-    p.touch()
-    p.write_text(textwrap.dedent(CONTENT))
-    yield p
-    p.unlink()
-
-
 @pytest.mark.flaky
-def test_dockercaps(deployment, kubectl, setup_manifest):
+def test_dockercaps(deployment, kubectl):
     logger.info("Deploy testcases")
     kubectl.run_kubectl(
-        "apply -f {}".format(setup_manifest))
+        "apply -f -", stdin=MANIFEST.encode())
 
     wait(check_pods_ready,
          kubectl,
@@ -89,4 +79,4 @@ def test_dockercaps(deployment, kubectl, setup_manifest):
 
     # Remove the testing pods
     kubectl.run_kubectl(
-        "delete -f {}".format(setup_manifest))
+        "delete -f -", stdin=MANIFEST.encode())

--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -1,3 +1,4 @@
+import json
 import signal
 import time
 
@@ -11,6 +12,16 @@ def check_nodes_ready(kubectl):
     for node in nodes:
         node_name, node_status = node.split(":")
         assert node_status == "True", f'Node {node_name} is not Ready'
+
+def check_pods_ready(kubectl, namespace=None, statuses=['Running', 'Completed']):
+    
+    kubectl_cmd = f'get pods {" --namespace="+namespace if namespace else ""} -o json'
+
+    pods = json.loads(kubectl.run_kubectl(kubectl_cmd))['items']
+    for pod in pods:
+        pod_status = pod['status']['phase']
+        pod_name   = pod['metadata']['name']
+        assert pod_status in statuses, f'Pod {pod_name} status {pod_status} != Running or Completed'
 
 def wait(func, *args, **kwargs):
 


### PR DESCRIPTION
## Why is this PR needed?

Changes the way pod readiness is checked in Docker CAPS test to make it more reliable.

Fixes https://github.com/SUSE/avant-garde/issues/995

## What does this PR do?

Refactors the logic used for testing system pod readiness in the deployment fixture to reuse it as a generic function for testing readiness of pods in a namespace. Uses this function in the Docker CAPS tests.

Additionally, simplifies the test by using `run_kubectl` function's `stdin` parameter to pass a manifest without having to write it to a file first.
 
# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
