### PR TITLE
Fix hardcoded node names in testrunner

### DIFF
--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -73,6 +73,14 @@ class Platform:
         """
         pass
 
+    def get_nodes_names(self, role):
+        """
+        Get the names of the given type of node
+        :param role: the type of node
+        :return:
+        """
+        return [f'caasp-{role}+{n}' for n in range(self.get_num_nodes(role))]
+
     def get_nodes_ipaddrs(self, role):
         """
         Get the IP addresses of the given type of node

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -81,6 +81,10 @@ class Terraform(Platform):
     def get_num_nodes(self, role):
         return len(self.get_nodes_ipaddrs(role))
 
+    def get_nodes_names(self, role):
+        stack_name = self.conf.terraform.stack_name
+        return [f'caasp-{role}-{stack_name}-{i}' for i in range(self.get_num_nodes(role))] 
+
     def get_nodes_ipaddrs(self, role):
         self._load_tfstate()
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -83,7 +83,7 @@ class Terraform(Platform):
 
     def get_nodes_names(self, role):
         stack_name = self.conf.terraform.stack_name
-        return [f'caasp-{role}-{stack_name}-{i}' for i in range(self.get_num_nodes(role))] 
+        return [f'caasp-{role}-{stack_name.lower()}-{i}' for i in range(self.get_num_nodes(role))] 
 
     def get_nodes_ipaddrs(self, role):
         self._load_tfstate()

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -132,7 +132,7 @@ def main():
                         deployed nodes in your platform")
     cmd_bootstrap.add_argument("-k", "--kubernetes-version", help="kubernetes version",
                                dest="kubernetes_version", default=None)
-    cmd_bootstrap.add_argument("-c", "--cloud-provider", action='store_true',
+    cmd_bootstrap.add_argument("-c", "--cloud-provider", dest="cloud_provider",
                                help="The cloud provider you're targeting. Default is openstack")
     cmd_bootstrap.set_defaults(func=bootstrap)
 

--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -1,12 +1,10 @@
 import time
-
 import pytest
 
 from tests.utils import wait
 
 PREVIOUS_VERSION = "1.14.1"
 CURRENT_VERSION = "1.15.2"
-
 
 @pytest.fixture
 def setup(request, platform, skuba):
@@ -38,22 +36,32 @@ def setup_kubernetes_version(platform, skuba, kubectl, kubernetes_version=None):
          wait_allow=(RuntimeError))
 
 
-def node_is_upgraded(kubectl, platform, node_name):
+def node_is_upgraded(kubectl, platform, role, nr):
+    node_name = platform.get_nodes_names(role)[nr]
     for attempt in range(20):
         if platform.all_apiservers_responsive():
             # kubernetes might be a little bit slow with updating the NodeVersionInfo
-            version = kubectl.run_kubectl("get nodes {} -o jsonpath='{{.status.nodeInfo.kubeletVersion}}'".format(node_name))
+            cmd = ("get nodes {} -o jsonpath="
+                   "'{{.status.nodeInfo.kubeletVersion}}'").format(node_name)
+            version = kubectl.run_kubectl(cmd)
             if version.find(PREVIOUS_VERSION) == 0:
                 time.sleep(2)
             else:
                 break
         else:
             time.sleep(2)
-    return kubectl.run_kubectl("get nodes {} -o jsonpath='{{.status.nodeInfo.kubeletVersion}}'".format(node_name)).find(CURRENT_VERSION) != -1
+
+    cmd = "get nodes {} -o jsonpath='{{.status.nodeInfo.kubeletVersion}}'".format(node_name)
+    return kubectl.run_kubectl(cmd).find(CURRENT_VERSION) != -1
 
 
-def node_is_ready(kubectl, node_name):
-    return kubectl.run_kubectl("get nodes {} -o jsonpath='{{range @.status.conditions[*]}}{{@.type}}={{@.status}};{{end}}'".format(node_name)).find("Ready=True") != -1
+def node_is_ready(platform, kubectl, role, nr):
+    node_name = platform.get_nodes_names(role)[nr]
+    cmd = ("get nodes {} -o jsonpath='{{range @.status.conditions[*]}}"
+           "{{@.type}}={{@.status}};{{end}}'").format(node_name)
+
+    return kubectl.run_kubectl(cmd).find("Ready=True") != -1
+
 
 
 @pytest.mark.disruptive
@@ -103,10 +111,11 @@ def test_upgrade_plan_from_previous(setup, skuba, kubectl, platform):
             pv=PREVIOUS_VERSION, cv=CURRENT_VERSION)) != -1
 
     workers = platform.get_num_nodes("worker")
+    worker_names = platform.get_nodes_names("worker")
     for n in range(0, workers):
         worker = skuba.node_upgrade("plan", "worker", n, ignore_errors=True)
         # If the control plane nodes are not upgraded yet, skuba disallows upgrading a worker
-        assert worker.find("Unable to plan node upgrade: caasp-worker-{} is not upgradeable until all control plane nodes are upgraded".format(n))
+        assert worker.find("Unable to plan node upgrade: {} is not upgradeable until all control plane nodes are upgraded".format(worker_names[n]))
 
 
 @pytest.mark.disruptive
@@ -119,11 +128,10 @@ def test_upgrade_plan_from_previous_with_upgraded_control_plane(setup, skuba, ku
 
     masters = platform.get_num_nodes("master")
     for n in range(0, masters):
-        node = "caasp-master-{}".format(n)
-        assert node_is_ready(kubectl, node)
+        assert node_is_ready(platform, kubectl, "master", n)
         master = skuba.node_upgrade("apply", "master", n)
         assert master.find("successfully upgraded") != -1
-        assert node_is_upgraded(kubectl, platform, node)
+        assert node_is_upgraded(kubectl, platform, "master", n)
 
     workers = platform.get_num_nodes("worker")
     for n in range(0, workers):
@@ -146,17 +154,19 @@ def test_upgrade_apply_all_fine(setup, platform, skuba, kubectl):
 
     # node upgrade apply
     masters = platform.get_num_nodes("master")
+    master_names = platform.get_nodes_names("master")
     for n in range(0, masters):
         master = skuba.node_upgrade("plan", "master", n)
         assert master.find(
-            "Node caasp-master-{} is up to date".format(n)
+            f'Node {master_names[n]} is up to date'
         ) != -1
 
     workers = platform.get_num_nodes("worker")
+    workers_names = platform.get_nodes_names("worker")
     for n in range(0, workers):
         worker = skuba.node_upgrade("plan", "worker", n)
         assert worker.find(
-            "Node caasp-worker-{} is up to date".format(n)
+            f'Node {workers_names[n]} is up to date'
         ) != -1
 
 
@@ -168,20 +178,13 @@ def test_upgrade_apply_from_previous(setup, platform, skuba, kubectl):
 
     setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
 
-    masters = platform.get_num_nodes("master")
-    for n in range(0, masters):
-        node = "caasp-master-{}".format(n)
-        assert node_is_ready(kubectl, node)
-        master = skuba.node_upgrade("apply", "master", n)
-        assert master.find("successfully upgraded") != -1
-        assert node_is_upgraded(kubectl, platform, node)
-
-    workers = platform.get_num_nodes("worker")
-    for n in range(0, workers):
-        node = "caasp-worker-{}".format(n)
-        worker = skuba.node_upgrade("apply", "worker", n)
-        assert worker.find("successfully upgraded") != -1
-        assert node_is_upgraded(kubectl, platform, node)
+    for role in ("master", "worker"):
+        num_nodes = platform.get_num_nodes(role)
+        for n in range(0, num_nodes):
+            assert node_is_ready(platform, kubectl, role, n)
+            result = skuba.node_upgrade("apply", role, n)
+            assert result.find("successfully upgraded") != -1
+            assert node_is_upgraded(kubectl, platform, role, n)
 
 
 @pytest.mark.disruptive
@@ -193,28 +196,23 @@ def test_upgrade_apply_user_lock(setup, platform, kubectl, skuba):
     setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
 
     # lock kured
-    kubectl.run_kubectl("-n kube-system annotate ds kured weave.works/kured-node-lock='{\"nodeID\":\"manual\"}'")
+    kubectl_cmd = (
+        "-n kube-system annotate ds kured weave.works/kured-node-lock="
+        "'{\"nodeID\":\"manual\"}'")
+    kubectl.run_kubectl(kubectl_cmd)
 
-    masters = platform.get_num_nodes("master")
-    for n in range(0, masters):
-        node = "caasp-master-{}".format(n)
-        # disable skuba-update.timer
-        platform.ssh_run("master", n, "sudo systemctl disable --now skuba-update.timer")
-        assert node_is_ready(kubectl, node)
-        master = skuba.node_upgrade("apply", "master", n)
-        assert master.find("successfully upgraded") != -1
-        assert node_is_upgraded(kubectl, platform, node)
-        assert platform.ssh_run("master", n, "sudo systemctl is-enabled skuba-update.timer || :").find("disabled") != -1
+    for role in ("master", "worker"):
+        num_nodes = platform.get_num_nodes(role)
+        for n in range(0, num_nodes):
+            # disable skuba-update.timer
+            platform.ssh_run(role, n, "sudo systemctl disable --now skuba-update.timer")
+            assert node_is_ready(platform, kubectl, role, n)
+            result = skuba.node_upgrade("apply", role, n)
+            assert result.find("successfully upgraded") != -1
+            assert node_is_upgraded(kubectl, platform, role, n)
+            ssh_cmd = "sudo systemctl is-enabled skuba-update.timer || :"
+            assert platform.ssh_run(role, n, ssh_cmd).find("disabled") != -1
 
-    workers = platform.get_num_nodes("worker")
-    for n in range(0, workers):
-        node = "caasp-worker-{}".format(n)
-        # disable skuba-update.timer
-        platform.ssh_run("worker", n, "sudo systemctl disable --now skuba-update.timer")
-        assert node_is_ready(kubectl, node)
-        worker = skuba.node_upgrade("apply", "worker", n)
-        assert worker.find("successfully upgraded") != -1
-        assert node_is_upgraded(kubectl, platform, node)
-        assert platform.ssh_run("worker", n, "sudo systemctl is-enabled skuba-update.timer || :").find("disabled") != -1
-
-    assert kubectl.run_kubectl(r"-n kube-system get ds/kured -o jsonpath='{.metadata.annotations.weave\.works/kured-node-lock}'").find("manual") != -1
+    kubeclt_cmd = (r"-n kube-system get ds/kured -o jsonpath="
+                   r"'{.metadata.annotations.weave\.works/kured-node-lock}'")
+    assert kubectl.run_kubectl(kubectl_cmd).find("manual") != -1

--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -1,6 +1,17 @@
 import signal
 import time
 
+
+def check_nodes_ready(kubectl):
+    # Retrieve the node name and the Ready condition (True, or False)
+    cmd = ("get nodes -o jsonpath='{ range .items[*]}{@.metadata.name}{\":\"}"
+           "{range @.status.conditions[?(.type==\"Ready\")]}{@.status}{\" \"}'")
+
+    nodes = kubectl.run_kubectl(cmd).strip().split(" ")
+    for node in nodes:
+        node_name, node_status = node.split(":")
+        assert node_status == "True", f'Node {node_name} is not Ready'
+
 def wait(func, *args, **kwargs):
 
     class TimeoutError(Exception):


### PR DESCRIPTION
## Why is this PR needed?

When the cloud-provider option is used for bootstrapping a cluster, the process fails because testrunner invokes skuba bootstrap command with a node name that doesn't match the name expected by openstack. 

Fixes https://github.com/SUSE/avant-garde/issues/1000

## What does this PR do?

The hardcoded names used in testrunner code are changes by names provided by the Platform used to provision the cluster. In the case of openstack, the name are according to the expected name by the cloud provider.

This change also impacted some tests that used hardcoded node names.  The tests were fixed and simplified removing duplicated code that was affected by the changes. 

Finally, the logic used for checking the nodes are ready after update was also change to make tests run more reliably.
 
## Anything else a reviewer needs to know?

Some changes in the tests were not strictly required for the purpose of this PR but required to make tests run reliably.

Some tests are failing, but for reasons that seems not to be related to this PR. Those issues will be addressed in follow up PRs.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
