### PR TITLE
[WIP] Update versions file to match Cilium update

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -89,7 +89,7 @@ var (
 				ToolingVersion:          "0.1.0",
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:  &AddonVersion{"1.5.3", 1},
+				Cilium:  &AddonVersion{"1.5.7", 0},
 				Kured:   &AddonVersion{"1.2.0", 0},
 				Dex:     &AddonVersion{"2.16.0", 3},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},


### PR DESCRIPTION
## Why is this PR needed?

The version of Cilium needs bumped to match the upcoming fix.  This requires that the updated images exist, first.  Hence WIP.

Fixes #

## What does this PR do?

Matches Cilium version string to pending release version

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

### Related info

https://build.suse.de/package/view_file/Devel:CaaSP:4.0/cilium/cilium.spec?expand=1

### Status **BEFORE** applying the patch

N/A

### Status **AFTER** applying the patch

N/A

## Docs

No documents I'm aware of refer to a specific Cilium version.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
