### PR TITLE
Pass kubernetes.Interface to functions that need it

### DIFF
--- a/cmd/skuba/addon/upgrade.go
+++ b/cmd/skuba/addon/upgrade.go
@@ -22,7 +22,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	addons "github.com/SUSE/skuba/pkg/skuba/actions/addon/upgrade"
 )
 
@@ -46,7 +48,12 @@ func newUpgradePlanCmd() *cobra.Command {
 		Use:   "plan",
 		Short: "Plan addon upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := addons.Plan(); err != nil {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := addons.Plan(clientSet); err != nil {
 				fmt.Printf("Unable to plan addon upgrade: %s\n", err)
 				os.Exit(1)
 			}
@@ -60,7 +67,12 @@ func newUpgradeApplyCmd() *cobra.Command {
 		Use:   "apply",
 		Short: "Apply addon upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := addons.Apply(); err != nil {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := addons.Apply(clientSet); err != nil {
 				fmt.Printf("Unable to Apply addons upgrade: %s\n", err)
 				os.Exit(1)
 			}

--- a/cmd/skuba/cluster/status.go
+++ b/cmd/skuba/cluster/status.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	clientset "github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	cluster "github.com/SUSE/skuba/pkg/skuba/actions/cluster/status"
 )
 
@@ -32,7 +33,13 @@ func NewStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Show cluster status",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := cluster.Status(); err != nil {
+			clientSet, err := clientset.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+
+			if err := cluster.Status(clientSet); err != nil {
 				klog.Errorf("unable to get cluster status: %s", err)
 				os.Exit(1)
 			}

--- a/cmd/skuba/cluster/upgrade.go
+++ b/cmd/skuba/cluster/upgrade.go
@@ -22,7 +22,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba/actions/cluster/upgrade"
 )
 
@@ -45,7 +47,12 @@ func newUpgradePlanCmd() *cobra.Command {
 		Use:   "plan",
 		Short: "Plan cluster upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := upgrade.Plan(); err != nil {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := upgrade.Plan(clientSet); err != nil {
 				fmt.Printf("Unable to plan cluster upgrade: %s\n", err)
 				os.Exit(1)
 			}

--- a/cmd/skuba/node/remove.go
+++ b/cmd/skuba/node/remove.go
@@ -18,6 +18,7 @@
 package node
 
 import (
+	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -38,17 +39,16 @@ func NewRemoveCmd() *cobra.Command {
 		Use:   "remove <node-name>",
 		Short: "Removes a node from the cluster",
 		Run: func(cmd *cobra.Command, nodenames []string) {
-			client, err := kubernetes.GetAdminClientSet()
-			if err != nil {
-				klog.Fatalf("unable to get admin client set: %s", err)
-			}
-
 			if removeOptions.drainTimeout < 0 {
 				klog.Infof("the passed duration was negative and will be ignored")
 				removeOptions.drainTimeout = 0
 			}
-
-			if err := node.Remove(client, nodenames[0], removeOptions.drainTimeout); err != nil {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := node.Remove(clientSet, nodenames[0], removeOptions.drainTimeout); err != nil {
 				klog.Fatalf("error removing node %s: %s", nodenames[0], err)
 			}
 		},

--- a/cmd/skuba/node/upgrade.go
+++ b/cmd/skuba/node/upgrade.go
@@ -22,8 +22,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba/actions/node/upgrade"
 )
 
@@ -47,7 +49,12 @@ func newUpgradePlanCmd() *cobra.Command {
 		Use:   "plan <node-name>",
 		Short: "Plan node upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := upgrade.Plan(args[0]); err != nil {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := upgrade.Plan(clientSet, args[0]); err != nil {
 				fmt.Printf("Unable to plan node upgrade: %s\n", err)
 				os.Exit(1)
 			}
@@ -62,7 +69,12 @@ func newUpgradeApplyCmd() *cobra.Command {
 		Use:   "apply",
 		Short: "Apply node upgrade",
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := upgrade.Apply(target.GetDeployment("")); err != nil {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := upgrade.Apply(clientSet, target.GetDeployment("")); err != nil {
 				fmt.Printf("Unable to apply node upgrade: %s\n", err)
 				os.Exit(1)
 			}

--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba"
 	"github.com/SUSE/skuba/pkg/skuba/actions/node/join"
 )
@@ -66,12 +67,16 @@ func kubeadmInit(t *Target, data interface{}) error {
 }
 
 func kubeadmJoin(t *Target, data interface{}) error {
+	api, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return errors.Wrap(err, "could not retrieve the clientset from kubernetes")
+	}
 	joinConfiguration, ok := data.(deployments.JoinConfiguration)
 	if !ok {
 		return errors.New("couldn't access join configuration")
 	}
 
-	configPath, err := join.ConfigPath(joinConfiguration.Role, t.target)
+	configPath, err := join.ConfigPath(api, joinConfiguration.Role, t.target)
 	if err != nil {
 		return errors.Wrap(err, "unable to configure path")
 	}

--- a/internal/pkg/skuba/kubernetes/clientset.go
+++ b/internal/pkg/skuba/kubernetes/clientset.go
@@ -24,7 +24,7 @@ import (
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func GetAdminClientSet() (*clientset.Clientset, error) {
+func GetAdminClientSet() (clientset.Interface, error) {
 	client, err := kubeconfigutil.ClientSetFromFile(skuba.KubeConfigAdminFile())
 	if err != nil {
 		return nil, err

--- a/internal/pkg/skuba/kubernetes/nodes.go
+++ b/internal/pkg/skuba/kubernetes/nodes.go
@@ -25,13 +25,13 @@ import (
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubectldrain "k8s.io/kubernetes/pkg/kubectl/drain"
 )
 
-func GetControlPlaneNodes(client kubernetes.Interface) (*v1.NodeList, error) {
+func GetControlPlaneNodes(client clientset.Interface) (*v1.NodeList, error) {
 	return client.CoreV1().Nodes().List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=", kubeadmconstants.LabelNodeRoleMaster),
 	})
@@ -59,7 +59,7 @@ func IsControlPlane(node *v1.Node) bool {
 	return isControlPlane
 }
 
-func DrainNode(client kubernetes.Interface, node *v1.Node, drainTimeout time.Duration) error {
+func DrainNode(client clientset.Interface, node *v1.Node, drainTimeout time.Duration) error {
 	policyGroupVersion, err := kubectldrain.CheckEvictionSupport(client)
 	if err != nil {
 		return errors.Wrap(err, "could not get policy group version")
@@ -106,7 +106,7 @@ func DrainNode(client kubernetes.Interface, node *v1.Node, drainTimeout time.Dur
 	return nil
 }
 
-func getPodContainerImageTag(client kubernetes.Interface, namespace string, podName string) (string, error) {
+func getPodContainerImageTag(client clientset.Interface, namespace string, podName string) (string, error) {
 	podObject, err := client.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrap(err, "could not retrieve pod object")

--- a/internal/pkg/skuba/upgrade/cluster/drift.go
+++ b/internal/pkg/skuba/upgrade/cluster/drift.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
@@ -42,16 +43,12 @@ func driftedNodesWithVersions(currentClusterVersion *version.Version, nodesVersi
 // major version than the current cluster version are considered. If the difference on
 // the node version with regards to the current cluster version is only the patch level
 // version, the node won't be included in the list.
-func DriftedNodes() ([]kubernetes.NodeVersionInfo, error) {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return nil, err
-	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+func DriftedNodes(clientSet clientset.Interface) ([]kubernetes.NodeVersionInfo, error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return []kubernetes.NodeVersionInfo{}, err
 	}
-	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(client)
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(clientSet)
 	if err != nil {
 		return []kubernetes.NodeVersionInfo{}, err
 	}

--- a/internal/pkg/skuba/upgrade/cluster/versions.go
+++ b/internal/pkg/skuba/upgrade/cluster/versions.go
@@ -19,6 +19,7 @@ package cluster
 
 import (
 	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
@@ -54,12 +55,8 @@ func nextAvailableVersionsForVersion(currentClusterVersion *version.Version, ava
 // NextAvailableVersions return the next patch version available (if any) for
 // the current minor version, the next minor version (if any) for the current
 // major version, and the next major version (if any)
-func NextAvailableVersions() (nextPatch *version.Version, nextMinor *version.Version, nextMajor *version.Version, err error) {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+func NextAvailableVersions(clientSet clientset.Interface) (nextPatch *version.Version, nextMinor *version.Version, nextMajor *version.Version, err error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -105,12 +102,8 @@ func UpgradePathWithAvailableVersions(currentClusterVersion *version.Version, av
 
 // UpgradePath returns the list of versions the cluster needs to go through
 // in order to upgrade to the latest available version
-func UpgradePath() ([]*version.Version, error) {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return nil, err
-	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+func UpgradePath(clientSet clientset.Interface) ([]*version.Version, error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return []*version.Version{}, err
 	}

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -88,20 +88,16 @@ func (nviu NodeVersionInfoUpdate) IsFirstControlPlaneNodeToBeUpgraded(client cli
 	return isControlPlane && allControlPlanesMatchVersion && matchesClusterVersion, nil
 }
 
-func UpdateStatus(nodeName string) (NodeVersionInfoUpdate, error) {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return NodeVersionInfoUpdate{}, errors.Wrap(err, "unable to get admin client set")
-	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+func UpdateStatus(clientSet clientset.Interface, nodeName string) (NodeVersionInfoUpdate, error) {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return NodeVersionInfoUpdate{}, err
 	}
-	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(client)
+	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(clientSet)
 	if err != nil {
 		return NodeVersionInfoUpdate{}, err
 	}
-	node, err := client.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	node, err := clientSet.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
 	if err != nil {
 		return NodeVersionInfoUpdate{}, errors.Wrapf(err, "could not find node %s", nodeName)
 	}

--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
@@ -29,11 +30,7 @@ import (
 )
 
 // Apply implements the `skuba addon upgrade apply` command.
-func Apply() error {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return err
-	}
+func Apply(client clientset.Interface) error {
 	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/addon/upgrade/plan.go
+++ b/pkg/skuba/actions/addon/upgrade/plan.go
@@ -21,17 +21,14 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
 )
 
-func Plan() error {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return err
-	}
+func Plan(client clientset.Interface) error {
 	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/cluster/status/status.go
+++ b/pkg/skuba/actions/cluster/status/status.go
@@ -22,9 +22,8 @@ import (
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	kubectlget "k8s.io/kubernetes/pkg/kubectl/cmd/get"
-
-	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 )
 
 // Status prints the status of the cluster on the standard output by reading the
@@ -32,14 +31,8 @@ import (
 //
 // FIXME: being this a part of the go API accept a io.Writer parameter instead of
 //        using os.Stdout
-func Status() error {
-	client, err := kubernetes.GetAdminClientSet()
-
-	if err != nil {
-		return errors.Wrap(err, "unable to get admin client set")
-	}
-
-	nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
+func Status(clientSet clientset.Interface) error {
+	nodeList, err := clientSet.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve node list")
 	}

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
@@ -28,12 +29,8 @@ import (
 	upgradecluster "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/cluster"
 )
 
-func Plan() error {
-	client, err := kubernetes.GetAdminClientSet()
-	if err != nil {
-		return err
-	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+func Plan(clientSet clientset.Interface) error {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return err
 	}
@@ -48,7 +45,7 @@ func Plan() error {
 		return nil
 	}
 
-	upgradePath, err := upgradecluster.UpgradePath()
+	upgradePath, err := upgradecluster.UpgradePath(clientSet)
 	if err != nil {
 		return err
 	}
@@ -64,7 +61,7 @@ func Plan() error {
 		tmpVersion = version.String()
 	}
 
-	driftedNodes, err := upgradecluster.DriftedNodes()
+	driftedNodes, err := upgradecluster.DriftedNodes(clientSet)
 	if err != nil {
 		return err
 	}
@@ -78,7 +75,7 @@ func Plan() error {
 
 	// fetch addon upgrades for the next available cluster version
 	nextClusterVersion := upgradePath[0]
-	updatedAddons, err := addon.UpdatedAddons(client, nextClusterVersion)
+	updatedAddons, err := addon.UpdatedAddons(clientSet, nextClusterVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -46,7 +46,7 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 	coreBootstrapDone := false
 
 	if clientSet, err := kubernetes.GetAdminClientSet(); err == nil {
-		_, err := clientSet.ServerVersion()
+		_, err := clientSet.Discovery().ServerVersion()
 		if err == nil {
 			fmt.Printf("[bootstrap] node %q has already the core components bootstrapped\n", target.Target)
 			coreBootstrapDone = true

--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -23,18 +23,15 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
+	clientset "k8s.io/client-go/kubernetes"
 )
 
-func Plan(nodeName string) error {
-	client, err := kubernetes.GetAdminClientSet()
+func Plan(clientSet clientset.Interface, nodeName string) error {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(clientSet)
 	if err != nil {
 		return err
 	}
-	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
-	if err != nil {
-		return err
-	}
-	nodeVersionInfoUpdate, err := upgradenode.UpdateStatus(nodeName)
+	nodeVersionInfoUpdate, err := upgradenode.UpdateStatus(clientSet, nodeName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why is this PR needed?

Adding an interface between GetAdminClientSet & Skuba allows substituting a mock implementation that can return a fake ClientSet.

This interface is also passed as an explicit parameter to all functions that need access to the GetAdminClientSet function so that functions can be used to write unit tests for our code.

Fixes #

https://github.com/SUSE/avant-garde/issues/989

## What does this PR do?

This PR makes our code more testable, by untangling the explicit dependency on ClientSetFromFile implemented in kubeadm.

## Info for QA

This PR should not introduce any regression. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
