### PR TITLE
Add dex/gangway unit tests on public interface

### DIFF
--- a/internal/pkg/skuba/dex/dex_test.go
+++ b/internal/pkg/skuba/dex/dex_test.go
@@ -21,6 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -89,6 +92,104 @@ func Test_CreateCert(t *testing.T) {
 				t.Errorf("error expected on %s, but no error reported", tt.name)
 				return
 			} else if !tt.expectedError && err != nil {
+				t.Errorf("error not expected on %s, but an error was reported (%v)", tt.name, err)
+				return
+			}
+		})
+	}
+}
+
+func Test_DexCertExists(t *testing.T) {
+	tests := []struct {
+		name          string
+		client        clientset.Interface
+		expectedExist bool
+		expectedError bool
+	}{
+		{
+			name: "certificate exists",
+			client: fake.NewSimpleClientset(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oidc-dex-cert",
+					Namespace: metav1.NamespaceSystem,
+				},
+			}),
+			expectedExist: true,
+			expectedError: false,
+		},
+		{
+			name:          "certificate not exists",
+			client:        fake.NewSimpleClientset(),
+			expectedExist: false,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DexCertExists(tt.client)
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("error expected on %s, but no error reported", tt.name)
+				}
+				return
+			} else if err != nil {
+				t.Errorf("error not expected on %s, but an error was reported (%v)", tt.name, err)
+				return
+			}
+
+			if got != tt.expectedExist {
+				t.Errorf("expect %t, got %t\n", tt.expectedExist, got)
+			}
+		})
+	}
+}
+
+func Test_RestartPods(t *testing.T) {
+	tests := []struct {
+		name          string
+		client        clientset.Interface
+		expectedError bool
+	}{
+		{
+			name: "restart pod successfully",
+			client: fake.NewSimpleClientset(&corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "dex-pod-1",
+							Labels: map[string]string{"app": "oidc-dex"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "dex-pod-2",
+							Labels: map[string]string{"app": "oidc-dex"},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:   "dex-pod-3",
+							Labels: map[string]string{"app": "oidc-dex"},
+						},
+					},
+				},
+			}),
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := RestartPods(tt.client)
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("error expected on %s, but no error reported", tt.name)
+				}
+				return
+			} else if err != nil {
 				t.Errorf("error not expected on %s, but an error was reported (%v)", tt.name, err)
 				return
 			}


### PR DESCRIPTION
## Why is this PR needed?

Add unit test on dex and gangway public interface.

Fixes https://github.com/SUSE/avant-garde/issues/742

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Add unit tests to cover all public interfaces on dex/gangway packages.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

N/A

### Status **AFTER** applying the patch

N/A

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>