### PR TITLE
Simplify cpi test

### DIFF
--- a/ci/infra/testrunner/tests/test_cpi_openstack.py
+++ b/ci/infra/testrunner/tests/test_cpi_openstack.py
@@ -1,154 +1,11 @@
-import json
 import pytest
-import time
 import os
 import platforms
 from skuba import Skuba
 from utils import BaseConfig
-from tests.utils import wait
+from tests.utils import (check_pods_ready, wait)
 
-@pytest.fixture(autouse=True, scope='module')
-def conf(request):
-    """Builds a conf object from a yaml file"""
-    path = request.config.getoption("vars")
-    return BaseConfig(path)
-
-@pytest.fixture(autouse=True, scope='module')
-def target(request):
-    """Returns the target platform"""
-    platform = request.config.getoption("platform")
-    return platform
-
-@pytest.fixture(autouse=True, scope='module')
-def platform(conf, target):
-    platform = platforms.get_platform(conf, target)
-    return platform
-
-@pytest.fixture(autouse=True, scope='module')
-def skuba(conf, target):
-    return Skuba(conf, target)
-
-@pytest.fixture(autouse=True, scope='module')
-def setup(request, platform, skuba, conf):
-    def cleanup():
-        platform.cleanup()
-        skuba.cleanup(conf)
-
-    request.addfinalizer(cleanup)
-    platform.provision(num_master=1, num_worker=3)
-
-@pytest.mark.disruptive
-@pytest.mark.openstack
-@pytest.mark.run(order=1)
-def test_init_cpi_openstack_cluster(skuba, kubernetes_version=None):
-    """
-    Initialize the cluster with the openstack cpi
-    """
-    try:
-        skuba.cluster_init(kubernetes_version, cloud_provider="openstack")
-    except:
-        pytest.fail("Failure on initializing cpi optionstack init  ...")
-
-@pytest.mark.disruptive
-@pytest.mark.openstack
-@pytest.mark.run(order=2)
-def test_bootstrap_cpi_openstack_cluster(skuba):
-    """
-    Bootstrap the cluster with the openstack cpi
-    """
-    try:
-        skuba.node_bootstrap(cloud_provider="openstack")
-    except:
-        pytest.fail("Failure on bootstrapping a cluster with cpi optionstack  ...")
-
-def check_system_pods_ready(kubectl):
-    pods = json.loads(kubectl.run_kubectl('get pods --namespace=kube-system -o json'))['items']
-    for pod in pods:
-        pod_status = pod['status']['phase']
-        pod_name   = pod['metadata']['name']
-        assert pod_status in ['Running', 'Completed'], f'Pod {pod_name} status {pod_status} != Running or Completed'
-
-@pytest.mark.disruptive
-@pytest.mark.openstack
-@pytest.mark.run(order=3)
-def test_node_join_cpi_openstack_cluster(skuba, kubectl):
-    """
-    Join nodes to the cluster with the openstack cpi enabled
-    """
-    try:
-        skuba.join_nodes(masters=1, workers=3)
-    except:
-        pytest.fail("Failure on joinning nodes to the cluster with cpi optionstack  ...")
-
-    wait(check_system_pods_ready,
-         kubectl, 
-         wait_delay=60,
-         wait_timeout=10,
-         wait_backoff=30,
-         wait_elapsed=300,
-         wait_allow=(AssertionError))
-
-
-@pytest.mark.disruptive
-@pytest.mark.openstack
-@pytest.mark.run(order=4)
-def test_create_cinder_storage(kubectl, skuba):
-    create_yamlfiles(skuba)
-    try:
-        file_path = os.path.join(skuba.cwd, "cinder.yaml")
-        cmd = f" apply -f {file_path}"
-        kubectl.run_kubectl(cmd)
-    except:
-        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
-
-@pytest.mark.disruptive
-@pytest.mark.openstack
-@pytest.mark.run(order=5)
-def test_wrtite_cinder_storage(kubectl, skuba):
-    try:
-        file_path = os.path.join(skuba.cwd, "test_write.yaml")
-        cmd = f" apply -f {file_path}"
-        kubectl.run_kubectl(cmd)
-    except:
-        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
-    time.sleep(60)
-    try:
-        cmd = " get pod | grep write-pod "
-        out = kubectl.run_kubectl(cmd)
-        assert "Completed" in out
-    except:
-        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
-
-@pytest.mark.disruptive
-@pytest.mark.openstack
-@pytest.mark.run(order=6)
-def test_read_cinder_storage(kubectl, skuba):
-    try:
-        file_path = os.path.join(skuba.cwd, "test_read.yaml")
-        cmd = f" apply -f {file_path}"
-        kubectl.run_kubectl(cmd)
-    except:
-        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
-    time.sleep(60)
-    try:
-        cmd = " get pod | grep read-pod"
-        out = kubectl.run_kubectl(cmd)
-        assert "Completed" in out
-    except:
-        pytest.fail(f"Failure on 'kubectl {cmd}' ...")
-
-def create_yamlfiles(skuba):
-    filenames = {"cinder.yaml":get_cinder_yaml,
-                 "test_write.yaml":get_test_write_pod_yaml,
-                 "test_read.yaml":get_test_read_pod_yaml}
-    for filename, _function in filenames.items():
-        contents = _function()
-        with open(os.path.join(skuba.cwd, filename), mode='wt') as yaml_file:
-            for line in contents:
-                yaml_file.write(line)
-
-def get_cinder_yaml():
-    yaml = '''
+CINDER_YAML = '''
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -171,10 +28,8 @@ spec:
       storage: 1Gi
   storageClassName: gold
 '''
-    return yaml
 
-def get_test_read_pod_yaml():
-    test_read_pod = '''
+TEST_READ_POD = '''
 apiVersion: v1
 kind: Pod
 metadata:
@@ -197,10 +52,8 @@ spec:
       persistentVolumeClaim:
         claimName: cinder-claim
 '''
-    return test_read_pod
 
-def get_test_write_pod_yaml():
-    test_write_pod = '''
+TEST_WRITE_POD = '''
 apiVersion: v1
 kind: Pod
 metadata:
@@ -223,4 +76,115 @@ spec:
       persistentVolumeClaim:
         claimName: cinder-claim
 '''
-    return test_write_pod
+
+
+@pytest.fixture(autouse=True, scope='module')
+def conf(request):
+    """Builds a conf object from a yaml file"""
+    path = request.config.getoption("vars")
+    return BaseConfig(path)
+
+
+@pytest.fixture(autouse=True, scope='module')
+def target(request):
+    """Returns the target platform"""
+    platform = request.config.getoption("platform")
+    return platform
+
+
+@pytest.fixture(autouse=True, scope='module')
+def platform(conf, target):
+    platform = platforms.get_platform(conf, target)
+    return platform
+
+
+@pytest.fixture(autouse=True, scope='module')
+def skuba(conf, target):
+    return Skuba(conf, target)
+
+
+@pytest.fixture(autouse=True, scope='module')
+def setup(request, platform, skuba, conf):
+    def cleanup():
+        platform.cleanup()
+        skuba.cleanup(conf)
+
+    request.addfinalizer(cleanup)
+    platform.provision(num_master=1, num_worker=3)
+
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=1)
+def test_init_cpi_openstack_cluster(skuba, kubernetes_version=None):
+    """
+    Initialize the cluster with the openstack cpi
+    """
+    skuba.cluster_init(kubernetes_version, cloud_provider="openstack")
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=2)
+def test_bootstrap_cpi_openstack_cluster(skuba):
+    """
+    Bootstrap the cluster with the openstack cpi
+    """
+    skuba.node_bootstrap(cloud_provider="openstack")
+
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=3)
+def test_node_join_cpi_openstack_cluster(skuba, kubectl):
+    """
+    Join nodes to the cluster with the openstack cpi enabled
+    """
+    skuba.join_nodes(masters=1, workers=3)
+
+    wait(check_pods_ready,
+         kubectl,
+         namespace="kube-system",
+         wait_delay=60,
+         wait_timeout=10,
+         wait_backoff=30,
+         wait_elapsed=300,
+         wait_allow=(AssertionError))
+
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=4)
+def test_create_cinder_storage(kubectl, skuba):
+        # TODO: result of action is successful  
+        kubectl.run_kubectl(" apply -f -", stdin=CINDER_YAML.encode())
+
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=5)
+def test_wrtite_cinder_storage(kubectl, skuba):
+    kubectl.run_kubectl("apply -f -", stdin=TEST_WRITE_POD.encode())
+
+    wait(
+        check_pods_ready,
+        kubectl,
+        pods=["write-pod"],
+        statuses=["Succeeded"],
+        wait_delay=60,
+        wait_retries=1,
+        wait_allow=(AssertionError))
+
+@pytest.mark.disruptive
+@pytest.mark.openstack
+@pytest.mark.run(order=6)
+def test_read_cinder_storage(kubectl, skuba):
+    kubectl.run_kubectl(" apply -f -", stdin=TEST_READ_POD.encode())
+
+    wait(
+        check_pods_ready,
+        kubectl,
+        pods=["read-pod"],
+        statuses=["Succeeded"],
+        wait_delay=60,
+        wait_retries=1,
+        wait_allow=(AssertionError))


### PR DESCRIPTION
## Why is this PR needed?


Test for cpi integration don't use the facilities provided by the testrunner test library. Reimplement the tests to simplify code.

Fixes https://github.com/SUSE/avant-garde/issues/999

## What does this PR do?

Uses the functions provided by testrunner and the test library to 
1. Check pod readiness more reliably
2. Pass inline manifests as stdin to kubectl without using external files

Also fixes the way completed pods are checked using the correct 'Succeeded' phase instead of 'Completed' 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
