### PR TITLE
Retry on errors checking node joined

### DIFF
--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -117,15 +117,17 @@ class Skuba:
         node_name = self.platform.get_nodes_names(role)[node]
         deadline = int(time.time()) + timeout
         while True:
+            last_error = None
             try:
                 status = self.cluster_status()
                 if status.find(node_name) > -1:
                     return
             except Exception as ex:
-                raise Exception("Exception retrieving cluster status") from ex
+                last_error = ex
 
             if int(time.time()) >= deadline:
-                raise Exception(f'Node {node_name} not shown ready after {timeout} seconds')
+                raise Exception((f'Node {node_name} not shown ready after {timeout} seconds'
+                                 f'{". Last error:"+str(last_error) if last_error else ""}'))
             time.sleep(backoff)
         
         


### PR DESCRIPTION
## Why is this PR needed?
While joining a node node (mostly masters) the skuba cluster status
command can fail generating an exception which should be retried.

Fixes https://github.com/SUSE/avant-garde/issues/1022

## What does this PR do?


## Anything else a reviewer needs to know?

This PR is a continuation to PR https://github.com/SUSE/skuba/pull/808


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
