### PR TITLE
Quick Fix: Revert change in cloud-provider flag in testrunner

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -426,7 +426,8 @@ optional arguments:
   -k KUBERNETES_VERSION, --kubernetes-version KUBERNETES_VERSION
                         kubernetes version
   -c, --cloud-provider
-                        The cloud provider will be offered
+                        Use cloud provider integration for the platform
+
 ```
 
 ### Node commands

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -132,8 +132,8 @@ def main():
                         deployed nodes in your platform")
     cmd_bootstrap.add_argument("-k", "--kubernetes-version", help="kubernetes version",
                                dest="kubernetes_version", default=None)
-    cmd_bootstrap.add_argument("-c", "--cloud-provider", dest="cloud_provider",
-                               help="The cloud provider you're targeting. Default is openstack")
+    cmd_bootstrap.add_argument("-c", "--cloud-provider", action="store_true",
+                               help="Use cloud provider integration")
     cmd_bootstrap.set_defaults(func=bootstrap)
 
     cmd_status = commands.add_parser("status", help="check K8s cluster status")


### PR DESCRIPTION
## Why is this PR needed?

The cloud-provider parameter for testrunner bootstrap is intended
to be a boolean flag. It was mistakenly changed to expect a value
(the name of the cloud provider) but this is redundant as the cloud
provider must be the same value as the -platform argument.

## What does this PR do?

Reverts change made in https://github.com/SUSE/skuba/pull/804/commits/cb0fd007933e4158e1b4a855171f4b97d342cdc6

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
