### PR TITLE
Fix long hostnames when running in ci

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -82,8 +82,8 @@ class Terraform(Platform):
         return len(self.get_nodes_ipaddrs(role))
 
     def get_nodes_names(self, role):
-        stack_name = self.conf.terraform.stack_name
-        return [f'caasp-{role}-{stack_name.lower()}-{i}' for i in range(self.get_num_nodes(role))] 
+        stack_name = self.stack_name()
+        return [f'caasp-{role}-{stack_name}-{i}' for i in range(self.get_num_nodes(role))] 
 
     def get_nodes_ipaddrs(self, role):
         self._load_tfstate()
@@ -115,10 +115,16 @@ class Terraform(Platform):
             with open(tfvars_final, "w") as f:
                 json.dump(tfvars, f)
 
+    #take up to 50 characters from stackname to give room to the fixed part
+    # in the node name: caasp-[master|worker]-xxx (total length must be <= 63)
+    def stack_name(self):
+         stack_name = self.conf.terraform.stack_name
+         return stack_name[:45].lower()
+
     def _update_tfvars(self, tfvars):
         new_vars = {
             "internal_net": self.conf.terraform.internal_net,
-            "stack_name": self.conf.terraform.stack_name,
+            "stack_name": self.stack_name(),
             "username": self.conf.nodeuser,
             "masters": self.conf.master.count,
             "workers": self.conf.worker.count,


### PR DESCRIPTION
## Why is this PR needed?

In ci, the hostnames assigned to the nodes include the
stackname, which is taken from the ci jobname. In some
cases this name exceeds the maximum of 63 characters.

Fixes https://github.com/SUSE/avant-garde/issues/1021

## What does this PR do?

This fix ensures the name is valid by truncating the
stack name passed to testrunner.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
