### PR TITLE
Revert "Enable defaut recommended admission plugins"

### DIFF
--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -183,12 +183,7 @@ func setApiserverAdmissionPlugins(initConfiguration *kubeadmapi.InitConfiguratio
 	if initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs == nil {
 		initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs = map[string]string{}
 	}
-	// List of recommended plugins: https://git.io/JemEu
-	defaultAdmissionPlugins := "NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota"
-	// Update the variable when updating kubeadm if needed: https://git.io/Jem4z
-	kubeadmAdmissionPlugins := "NodeRestriction"
-	skubaAdmissionPlugins := "PodSecurityPolicy"
-	initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = fmt.Sprintf("%s,%s,%s", kubeadmAdmissionPlugins, skubaAdmissionPlugins, defaultAdmissionPlugins)
+	initConfiguration.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = "NodeRestriction,PodSecurityPolicy"
 }
 
 func setCloudConfigurationPath(initConfiguration *kubeadmapi.InitConfiguration) {


### PR DESCRIPTION
This reverts commit b27e5171c5522ce996ab2bb8a3f95b2f1630b905.

[Reason](https://github.com/SUSE/avant-garde/issues/1016#issuecomment-552483120):
> In the release coord meeting, we decided with QA that we better remove this feature from 4.0.2. > We will create a branch, release-caasp-4.0.2 and a commit that removes this.
> Please @drpaneas remove this from master branch as well to be in sync.

Fixes #https://github.com/SUSE/avant-garde/issues/1016

