### PR TITLE
Add release packages for autoyast

### DIFF
--- a/ci/infra/bare-metal/autoyast.xml
+++ b/ci/infra/bare-metal/autoyast.xml
@@ -154,6 +154,12 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
       <pattern>minimal_base</pattern>
       <pattern>basesystem</pattern>
     </patterns>
+    <packages config:type="list">
+      <package>sles-release</package>
+      <package>sle-module-containers-release</package>
+      <package>sle-module-basesystem-release</package>
+      <package>caasp-release</package>
+    </packages>
   </software>
 
   <services-manager>


### PR DESCRIPTION
## Why is this PR needed?

When using autoyast, release packages do not get installed. Because of
that, we cannot know which caasp version the user is running, cause the
caasp-release package version is the one we check to know this.

fixes issue#1013

## What does this PR do?

Make sure caasp-release package and other release packages are installed. This is important to know which caasp version a customer that is requesting support is.

## Anything else a reviewer needs to know?

## Info for QA

see https://github.com/SUSE/avant-garde/issues/1024 reported by QA

### Related info

### Status **BEFORE** applying the patch

When installing with autoyast https://github.com/SUSE/doc-caasp/blob/master/adoc/deployment-bare-metal.adoc the caasp-release package is not installed. Neither are sles-release, sle-module-containers-release, sle-module-basesystem-release

### Status **AFTER** applying the patch

caasp-release package is installed and also  sles-release, sle-module-containers-release, sle-module-basesystem-release

## Docs

No need to update docs.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
