### PR TITLE
Use datastore cluster instead of datastore

### DIFF
--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -53,6 +53,7 @@ Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable
 ## Variables
 
 `vsphere_datastore` - Provide the datastore to use in vSphere\
+`vsphere_datastore_cluster` - Provide the datastore cluster to use on the vSphere server\
 `vsphere_datacenter` - Provide the datacenter to use in vSphere\
 `vsphere_network` - Provide the network to use in vSphere - this network must be able to access the ntp servers and the nodes must be able to reach each other\
 `vsphere_resource_pool` - Provide the resource pool the machines will be running in\

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -114,15 +114,15 @@ data "template_file" "lb_cloud_init_userdata" {
 }
 
 resource "vsphere_virtual_machine" "lb" {
-  count            = "${var.lbs}"
-  name             = "${var.stack_name}-lb-${count.index}"
-  num_cpus         = "${var.lb_cpus}"
-  memory           = "${var.lb_memory}"
-  guest_id         = "${var.guest_id}"
-  firmware         = "${var.firmware}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  count                = "${var.lbs}"
+  name                 = "${var.stack_name}-lb-${count.index}"
+  num_cpus             = "${var.lb_cpus}"
+  memory               = "${var.lb_memory}"
+  guest_id             = "${var.guest_id}"
+  firmware             = "${var.firmware}"
+  scsi_type            = "${data.vsphere_virtual_machine.template.scsi_type}"
+  resource_pool_id     = "${data.vsphere_resource_pool.pool.id}"
+  datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
 
   clone {
     template_uuid = "${data.vsphere_virtual_machine.template.id}"

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -58,15 +58,15 @@ data "template_file" "master_cloud_init_userdata" {
 }
 
 resource "vsphere_virtual_machine" "master" {
-  count            = "${var.masters}"
-  name             = "${var.stack_name}-master-${count.index}"
-  num_cpus         = "${var.master_cpus}"
-  memory           = "${var.master_memory}"
-  guest_id         = "${var.guest_id}"
-  firmware         = "${var.firmware}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  count                = "${var.masters}"
+  name                 = "${var.stack_name}-master-${count.index}"
+  num_cpus             = "${var.master_cpus}"
+  memory               = "${var.master_memory}"
+  guest_id             = "${var.guest_id}"
+  firmware             = "${var.firmware}"
+  scsi_type            = "${data.vsphere_virtual_machine.template.scsi_type}"
+  resource_pool_id     = "${data.vsphere_resource_pool.pool.id}"
+  datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
 
   clone {
     template_uuid = "${data.vsphere_virtual_machine.template.id}"

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -1,6 +1,7 @@
 {
     "vsphere_datastore": "3PAR",
     "vsphere_datacenter": "PROVO",
+    "vsphere_datastore_cluster": "LOCAL-DISKS-CLUSTER",
     "vsphere_network": "VM Network",
     "vsphere_resource_pool": "CaaSP_RP",
     "template_name": "SLES15-SP1-GM-guestinfo",

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -1,6 +1,6 @@
 variable "template_name" {}
 variable "stack_name" {}
-variable "vsphere_datastore" {}
+variable "vsphere_datastore_cluster" {}
 variable "vsphere_datacenter" {}
 variable "vsphere_network" {}
 variable "vsphere_resource_pool" {}
@@ -103,8 +103,8 @@ data "vsphere_resource_pool" "pool" {
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 
-data "vsphere_datastore" "datastore" {
-  name          = "${var.vsphere_datastore}"
+data "vsphere_datastore_cluster" "datastore_cluster" {
+  name          = "${var.vsphere_datastore_cluster}"
   datacenter_id = "${data.vsphere_datacenter.dc.id}"
 }
 

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -58,15 +58,15 @@ data "template_file" "worker_cloud_init_userdata" {
 }
 
 resource "vsphere_virtual_machine" "worker" {
-  count            = "${var.workers}"
-  name             = "${var.stack_name}-worker-${count.index}"
-  num_cpus         = "${var.worker_cpus}"
-  memory           = "${var.worker_memory}"
-  guest_id         = "${var.guest_id}"
-  firmware         = "${var.firmware}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  count                = "${var.workers}"
+  name                 = "${var.stack_name}-worker-${count.index}"
+  num_cpus             = "${var.worker_cpus}"
+  memory               = "${var.worker_memory}"
+  guest_id             = "${var.guest_id}"
+  firmware             = "${var.firmware}"
+  scsi_type            = "${data.vsphere_virtual_machine.template.scsi_type}"
+  resource_pool_id     = "${data.vsphere_resource_pool.pool.id}"
+  datastore_cluster_id = "${data.vsphere_datastore_cluster.datastore_cluster.id}"
 
   clone {
     template_uuid = "${data.vsphere_virtual_machine.template.id}"


### PR DESCRIPTION
## Why is this PR needed?

We're facing performance issues with the datastore
backed by iSCSI storage (3PAR). Using the new
datastore cluster (LOCAL-DISKS-CLUSTER) backed
by local disks should improve the performances.

Signed-off-by: lcavajani <lcavajani@suse.com>

fixes issue#1034


## What does this PR do?

Fix vmware ci flakiness regarding accessing storage

## Anything else a reviewer needs to know?

## Info for QA

This PR is for CI, nothing for QA.

## Docs

This PR is for CI, nothing for Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
