### PR TITLE
QuickFIX: Enable ibs mirrors in ci

### DIFF
--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -19,8 +19,7 @@ terraform:
   tfvars: "" # terraform vars
 
 packages:
-# disable mirrors
-# mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
+  mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
   additional_pkgs:
   - "ca-certificates-suse"
 


### PR DESCRIPTION
# Why is this PR needed?

Testrunner can use a mirror for installing packages if specified in its configuration. This mirror was disable due to some recurrent failures. The mirrors seems to work correctly now, so it is preferable to re-enable the mirrors.

## What does this PR do?

enables the ibs mirror in testrunner configuration

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
