### PR TITLE
CI: Fix upgrade apply user lock

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -212,7 +212,7 @@ def test_upgrade_apply_user_lock(setup, platform, kubectl, skuba):
             ssh_cmd = "sudo systemctl is-enabled skuba-update.timer || :"
             assert platform.ssh_run(role, n, ssh_cmd).find("disabled") != -1
 
-    kubeclt_cmd = (r"-n kube-system get ds/kured -o jsonpath="
+    kubectl_cmd = (r"-n kube-system get ds/kured -o jsonpath="
                    r"'{.metadata.annotations.weave\.works/kured-node-lock}'")
     result = wait(kubectl.run_kubectl,
                   kubectl_cmd,


### PR DESCRIPTION
## Why is this PR needed?

Variable shadowing was not working because of a typo, so we were
trying to annotate twice instead of the intended action of annotating
and getting the result.

Fixes https://github.com/SUSE/avant-garde/issues/1040