### PR TITLE
Quickfix: Update VMware template used in ci

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -3,7 +3,7 @@
     "vsphere_datacenter": "PROVO",
     "vsphere_network": "VM Network",
     "vsphere_resource_pool": "CaaSP_RP",
-    "template_name": "SLES15-SP1-GM-guestinfo",
+    "template_name": "SLES15-SP1-GM-up190905-guestinfo",
     "firmware": "bios",
     "stack_name": "caasp-jenkins-v4",
     "masters": 1,


### PR DESCRIPTION
## Why is this PR needed?

The tfvars used in ci for VMware jobs is outdated and is using a VMware template with known issues with cloud-init which may cause problems when rebooting machines.

## What does this PR do?

Updates the VMware template in the tfvars file used for ci jobs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
