### PR TITLE
Kubernetes 1.16

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -3,8 +3,8 @@ import pytest
 
 from tests.utils import (check_nodes_ready, wait)
 
-PREVIOUS_VERSION = "1.14.1"
-CURRENT_VERSION = "1.15.2"
+PREVIOUS_VERSION = "1.15.2"
+CURRENT_VERSION = "1.16.2"
 
 @pytest.fixture
 def setup(request, platform, skuba):

--- a/internal/pkg/skuba/addons/kured.go
+++ b/internal/pkg/skuba/addons/kured.go
@@ -58,7 +58,7 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs:     ["list","delete","get"]
-- apiGroups: ["extensions","apps"]
+- apiGroups: ["apps"]
   resources: ["daemonsets"]
   verbs:     ["get"]
 - apiGroups: [""]
@@ -85,7 +85,7 @@ metadata:
   name: kured
 rules:
 # Allow kured to lock/unlock itself
-- apiGroups:     ["extensions"]
+- apiGroups:     ["apps"]
   resources:     ["daemonsets"]
   resourceNames: ["kured"]
   verbs:         ["update"]

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -118,46 +118,6 @@ var (
 				PSP:     &AddonVersion{"", 0},
 			},
 		},
-		"1.15.0": KubernetesVersion{
-			ComponentHostVersion: ComponentHostVersion{
-				KubeletVersion:          "1.15.0",
-				ContainerRuntimeVersion: "1.15.0",
-			},
-			ComponentContainerVersion: ComponentContainerVersion{
-				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.0"},
-				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.3.11"},
-				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.3.1"},
-				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
-				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
-			},
-			AddonsVersion: AddonsVersion{
-				Cilium:  &AddonVersion{"1.5.3", 1},
-				Kured:   &AddonVersion{"1.2.0", 0},
-				Dex:     &AddonVersion{"2.16.0", 3},
-				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"", 0},
-			},
-		},
-		"1.14.1": KubernetesVersion{
-			ComponentHostVersion: ComponentHostVersion{
-				KubeletVersion:          "1.14.1",
-				ContainerRuntimeVersion: "1.14.1",
-			},
-			ComponentContainerVersion: ComponentContainerVersion{
-				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.14.1"},
-				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.3.11"},
-				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.2.6"},
-				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
-				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
-			},
-			AddonsVersion: AddonsVersion{
-				Cilium:  &AddonVersion{"1.5.3", 1},
-				Kured:   &AddonVersion{"1.2.0", 0},
-				Dex:     &AddonVersion{"2.16.0", 3},
-				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"", 0},
-			},
-		},
 	}
 )
 

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -101,7 +101,7 @@ var (
 		"1.15.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.15.2",
-				ContainerRuntimeVersion: "1.15.0",
+				ContainerRuntimeVersion: "1.15.2",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
 				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.2"},

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -78,6 +78,26 @@ type KubernetesVersions map[string]KubernetesVersion
 
 var (
 	supportedVersions = KubernetesVersions{
+		"1.16.2": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.16.2",
+				ContainerRuntimeVersion: "1.16.0",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},
+				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.3.15"},
+				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.6.2"},
+				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:  &AddonVersion{"1.5.3", 1},
+				Kured:   &AddonVersion{"1.2.0-rev4", 1},
+				Dex:     &AddonVersion{"2.16.0", 3},
+				Gangway: &AddonVersion{"3.1.0-rev4", 3},
+				PSP:     &AddonVersion{"", 0},
+			},
+		},
 		"1.15.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.15.2",
@@ -92,7 +112,7 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 1},
-				Kured:   &AddonVersion{"1.2.0", 0},
+				Kured:   &AddonVersion{"1.2.0-rev4", 1},
 				Dex:     &AddonVersion{"2.16.0", 3},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
 				PSP:     &AddonVersion{"", 0},

--- a/pkg/skuba/actions/cluster/images/images.go
+++ b/pkg/skuba/actions/cluster/images/images.go
@@ -28,16 +28,17 @@ import (
 // This can be used as input to skopeo for mirroring in air-gapped scenarios
 func Images() error {
 	fmt.Printf("VERSION    IMAGE\n")
-	cv := kubernetes.LatestVersion()
-	for _, component := range kubernetes.AllComponentContainerImagesForClusterVersion(cv) {
-		fmt.Printf("%-10v %v\n", cv, kubernetes.ComponentContainerImageForClusterVersion(component, cv))
-	}
+	for _, version := range kubernetes.AvailableVersions() {
+		for _, component := range kubernetes.AllComponentContainerImagesForClusterVersion(version) {
+			fmt.Printf("%-10v %v\n", version, kubernetes.ComponentContainerImageForClusterVersion(component, version))
+		}
 
-	for addonName, addon := range addons.Addons {
-		addonVersion := kubernetes.AddonVersionForClusterVersion(addonName, cv)
-		imageList := addon.Images(addonVersion.Version)
-		for _, image := range imageList {
-			fmt.Printf("%-10v %v\n", cv, image)
+		for addonName, addon := range addons.Addons {
+			addonVersion := kubernetes.AddonVersionForClusterVersion(addonName, version)
+			imageList := addon.Images(addonVersion.Version)
+			for _, image := range imageList {
+				fmt.Printf("%-10v %v\n", version, image)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
## Why is this PR needed?

This PR includes Kubernetes 1.16 into the supported versions map.

Fixes https://github.com/SUSE/avant-garde/issues/1023

**WIP** because I'm testing it at the moment.

## Info for QA

It's necessary to check that it's possible to bootstrap a cluster with 1.15, 1.16 and that the migration works without any issues.

## Docs

Tracked in https://github.com/SUSE/avant-garde/issues/934

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
