### PR TITLE
CI: Collect logs after e2e tests

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -32,7 +32,16 @@ pipeline {
    }
 
    post {
-       cleanup {
+        always {
+            archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
+            sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
+            archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
+            junit('skuba/ci/infra/testrunner/*.xml')
+        }
+        cleanup {
             dir("${WORKSPACE}@tmp") {
                 deleteDir()
             }


### PR DESCRIPTION
## Why is this PR needed?

The e2e jobs is not archiving the logs from nodes (cloud-init, pods) so it is hard to diagnose failures.

Fixes https://github.com/SUSE/avant-garde/issues/1051

## What does this PR do?

Adds a stage for collecting logs using testrunner's get_logs command as is done in other pipelines.

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
