### PR TITLE
Do not create kubelet sysconfig file

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/assets/assets.go
+++ b/internal/pkg/skuba/deployments/ssh/assets/assets.go
@@ -42,6 +42,4 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 EnvironmentFile=-/etc/sysconfig/kubelet
 ExecStart=
 ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS`
-
-	KubeletSysconfig = "KUBELET_EXTRA_ARGS="
 )

--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -141,9 +141,6 @@ func kubeletConfigure(t *Target, data interface{}) error {
 		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
 			return err
 		}
-		if err := t.UploadFileContents("/etc/sysconfig/kubelet", assets.KubeletSysconfig); err != nil {
-			return err
-		}
 	} else {
 		if err := t.UploadFileContents("/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
 			return err


### PR DESCRIPTION
## Why is this PR needed?

skuba always overwrite `/etc/sysconfig/kubelet` with an empty file when a node is joined/bootstrapped.

This can lead user's customization to be lost.

For example: user can specify node labels at infrastructure creation time by providing a properly crafted `/etc/sysconfig/kubelet`. The file should not be overwritten by skuba when the node is added to a cluster.

## What does this PR do?

Our empty `/etc/sysconfig/kubelet` file is **never** created ~only when the file doesn't exist on the target node~.

## Anything else a reviewer needs to know?

Nothing special.

## Info for QA

How to verify the feature.

Ensure new regression:
  * Create a new node
  * Do not create the `/etc/sysconfig/kubelet` file
  * Use the node via skuba during a bootstrap/join operation
  * At the end of the process the `/etc/sysconfig/kubelet` file exists won't exist ~and contains a boilerplate created by skuba~

Ensure new behaviour works as expected:
  * Create a new node
  * Create a `/etc/sysconfig/kubelet` file with some custom comments
  * Use the node via skuba during a bootstrap/join operation
  * At the end of the process the `/etc/sysconfig/kubelet` file exists and is still the same one created by the user

## Docs

No need to change docs.