### PR TITLE
CI: Fix logs collected after cluster teardown in e2e pipeline

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -26,7 +26,6 @@ pipeline {
         stage('Run Skuba e2e Test') {
             steps {
                 sh(script: "make -f skuba/ci/Makefile ${E2E_MAKE_TARGET_NAME}", label: "${E2E_MAKE_TARGET_NAME}")
-                sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')
             }
         }
    }
@@ -37,11 +36,11 @@ pipeline {
             archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
-            sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
             archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
             junit('skuba/ci/infra/testrunner/*.xml')
         }
         cleanup {
+            sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')
             dir("${WORKSPACE}@tmp") {
                 deleteDir()
             }


### PR DESCRIPTION
## Why is this PR needed?

In e2e test pipeline, tests use the provision fixture which automatically retrieves logs and deletes cluster after test.

The pipeline is trying to retrieve the logs after the test has ended and this is making the pipeline to fail. 

## What does this PR do?
e2e pipeline is adapted to just archive logs after the test is completed and then cleanup workspace.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
