### PR TITLE
CI: Remove junit log collection from e2e tests

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -37,7 +37,6 @@ pipeline {
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
-            junit('skuba/ci/infra/testrunner/*.xml')
         }
         cleanup {
             sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')


### PR DESCRIPTION
## Why is this PR needed?

e2e test are not configured to generated junit output.
This causes the pipeline to fail when trying to collect
this log.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
