### PR TITLE
CI: Add release job for validator

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -79,11 +79,11 @@
         - '{name}-test_remove_worker'
 
 - project:
-    name: caasp-jobs/validation/caasp-v4-openstack
-    platform: openstack
+    name: caasp-jobs/validation/caasp-v4
     jobs:
         - '{name}-devel-base-nightly'
         - '{name}-devel-monitoring-nightly'
+        - '{name}-release-base-on-demand'
 
 - job:
     name: caasp-jobs/caasp-jjb

--- a/ci/jenkins/templates/validation-nightly-template.yaml
+++ b/ci/jenkins/templates/validation-nightly-template.yaml
@@ -13,7 +13,7 @@
     parameters:
         - string:
             name: VALIDATOR_ARGS
-            default: '-p openstack -t base -n 3:2 -c'
+            default: '-p openstack -t base -n 3:2'
             description: The arguments for validator_caasp
     pipeline-scm:
         scm:
@@ -41,7 +41,7 @@
     parameters:
         - string:
             name: VALIDATOR_ARGS
-            default: '-p openstack -t monitoring -n 3:2 -c'
+            default: '-p openstack -t monitoring -n 3:2'
             description: The arguments for validator_caasp
     pipeline-scm:
         scm:

--- a/ci/jenkins/templates/validation-nightly-template.yaml
+++ b/ci/jenkins/templates/validation-nightly-template.yaml
@@ -13,7 +13,7 @@
     parameters:
         - string:
             name: VALIDATOR_ARGS
-            default: '-p {platform} -t base -n 3:2 -c'
+            default: '-p openstack -t base -n 3:2 -c'
             description: The arguments for validator_caasp
     pipeline-scm:
         scm:
@@ -41,7 +41,7 @@
     parameters:
         - string:
             name: VALIDATOR_ARGS
-            default: '-p {platform} -t monitoring -n 3:2 -c'
+            default: '-p openstack -t monitoring -n 3:2 -c'
             description: The arguments for validator_caasp
     pipeline-scm:
         scm:
@@ -53,3 +53,37 @@
                 suppress-automatic-scm-triggering: true
                 basedir: scripts
         script-path: scripts/jenkins/validator_caasp-nightly.Jenkinsfile
+
+- job-template:
+    name: '{name}-release-base-on-demand'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    branch: master
+    wrappers:
+      - timeout:
+          timeout: 120
+          fail: true
+    parameters:
+        - string:
+            name: INCIDENT_RPM
+            default: ''
+            description: Maintenance incident repo e.g. http://download.suse.de/ibs/Devel:/CaaSP:/4.0:/Staging:/4.0.3/SUSE_SLE-15-SP1_Update_Products_CASP40_Update_standard/
+        - string:
+            name: INCIDENT_REG
+            default: ''
+            description: Incident registry e.g. registry.suse.de/devel/caasp/4.0/staging/4.0.3/suse_sle-15-sp1_update_products_casp40_update_containers/caasp/v4
+        - string:
+            name: VALIDATOR_ARGS
+            default: '-t base'
+            description: The arguments for validator_caasp
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://gitlab.suse.de/mkravec/scripts.git'
+                branches:
+                    - 'master'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+                basedir: scripts
+        script-path: scripts/jenkins/validator_caasp-release.Jenkinsfile


### PR DESCRIPTION
## What does this PR do?

* Add a new job to run a few validator test scenarios in parallel to validate staging
* Remove platform passing from the outside, as we are using pipelines with mixed platform scenarios now
* Remove validator flag `-c` that doesn't exist anymore

## Anything else a reviewer needs to know?

Pipeline is here https://gitlab.suse.de/mkravec/scripts/merge_requests/26
