### PR TITLE
Add version relate unit-tests

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -18,13 +18,275 @@
 package kubernetes
 
 import (
+	"encoding/json"
+	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+
+	"github.com/SUSE/skuba/pkg/skuba"
 )
 
-func TestAvailableVersionsForMap(t *testing.T) {
+type componentTestData struct {
+	name           string
+	clusterVersion *version.Version
+	component      Component
+	imageName      string
+	expectVersion  string
+	expectErr      bool
+}
+
+type addonTestData struct {
+	name                  string
+	clusterVersion        *version.Version
+	addon                 Addon
+	expectVersion         string
+	expectManifestVersion uint
+	expectErr             bool
+}
+
+type versionTestData struct {
+	hostComponent      []componentTestData
+	containerComponent []componentTestData
+	addon              []addonTestData
+}
+
+func getComponentTestData(component Component, version *version.Version, info *KubernetesVersion) componentTestData {
+	var name string
+	var expectVersion string
+	var imageName string
+	switch component {
+	case Kubelet:
+		name = fmt.Sprintf("get %s version when cluster version is %s", component, version)
+		expectVersion = info.ComponentHostVersion.KubeletVersion
+	case ContainerRuntime:
+		name = fmt.Sprintf("get %s version when cluster version is %s", component, version)
+		expectVersion = info.ComponentHostVersion.ContainerRuntimeVersion
+	case Hyperkube, Etcd, CoreDNS, Pause, Tooling:
+		name = fmt.Sprintf("get %s image when cluster version is %s", component, version)
+		imageName = info.ComponentContainerVersion[component].Name
+		expectVersion = info.ComponentContainerVersion[component].Tag
+	}
+	return componentTestData{
+		name:           name,
+		clusterVersion: version,
+		component:      component,
+		imageName:      imageName,
+		expectVersion:  expectVersion,
+	}
+}
+
+func getAddonTestData(addon Addon, version *version.Version, info *KubernetesVersion) addonTestData {
+	return addonTestData{
+		name:                  fmt.Sprintf("get %s version when cluster version is %s", addon, version),
+		clusterVersion:        version,
+		addon:                 addon,
+		expectVersion:         info.AddonsVersion[addon].Version,
+		expectManifestVersion: info.AddonsVersion[addon].ManifestVersion,
+	}
+}
+
+func getVersionTestData() versionTestData {
+	var addonTestData []addonTestData
+	var clusterVersion *version.Version
+	var containerComponentTestData []componentTestData
+	var hostComponentTestData []componentTestData
+	for ver, verInfo := range supportedVersions {
+		clusterVersion = version.MustParseSemantic(ver)
+		hostComponentTestData = append(
+			hostComponentTestData,
+			getComponentTestData(Kubelet, clusterVersion, &verInfo),
+			getComponentTestData(ContainerRuntime, clusterVersion, &verInfo),
+		)
+
+		for cc := range verInfo.ComponentContainerVersion {
+			containerComponentTestData = append(
+				containerComponentTestData,
+				getComponentTestData(cc, clusterVersion, &verInfo),
+			)
+		}
+
+		for addon := range verInfo.AddonsVersion {
+			addonTestData = append(
+				addonTestData,
+				getAddonTestData(addon, clusterVersion, &verInfo),
+			)
+		}
+	}
+
+	return versionTestData{
+		hostComponent:      hostComponentTestData,
+		containerComponent: containerComponentTestData,
+		addon:              addonTestData,
+	}
+}
+
+var vtd = getVersionTestData()
+
+func Test_ComponentVersionForClusterVersion(t *testing.T) {
+	var tests = vtd.hostComponent
+	tests = append(
+		tests,
+		componentTestData{
+			name:           "invalid component",
+			clusterVersion: version.MustParseSemantic("1.16.2"),
+			component:      "not-exist",
+			expectVersion:  "",
+		},
+	)
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			actualVersion := ComponentVersionForClusterVersion(tt.component, tt.clusterVersion)
+			if actualVersion != tt.expectVersion {
+				t.Errorf("returned version (%s) does not match the expected one (%s)", actualVersion, tt.expectVersion)
+				return
+			}
+		})
+	}
+}
+
+func Test_AllComponentContainerImagesForClusterVersion(t *testing.T) {
+	var clusterVersion *version.Version
+	for ver := range supportedVersions {
+		clusterVersion = version.MustParseSemantic(ver)
+		t.Run(fmt.Sprintf("get all component container images when cluster version is %s", ver), func(t *testing.T) {
+			actual := AllComponentContainerImagesForClusterVersion(clusterVersion)
+			sort.Slice(actual, func(i int, j int) bool {
+				return actual[i] < actual[j]
+			})
+			expect := []Component{Hyperkube, Etcd, CoreDNS, Pause, Tooling}
+			sort.Slice(expect, func(i int, j int) bool {
+				return expect[i] < expect[j]
+			})
+
+			if !reflect.DeepEqual(actual, expect) {
+				t.Errorf("returned result (%s) does not match the expected one (%s)", actual, expect)
+				return
+			}
+		})
+	}
+}
+
+func Test_ComponentContainerImageForClusterVersion(t *testing.T) {
+	var tests = vtd.containerComponent
+	tests = append(
+		tests,
+		componentTestData{
+			name:           "invalid component",
+			clusterVersion: version.MustParseSemantic("1.16.2"),
+			component:      "not-exist",
+			expectErr:      true,
+		},
+	)
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			actual := ComponentContainerImageForClusterVersion(tt.component, tt.clusterVersion)
+			if tt.expectErr {
+				if actual != "" {
+					t.Errorf("image not expected. but a result was returned (%s)", actual)
+					return
+				}
+			} else {
+				expect := images.GetGenericImage(skuba.ImageRepository, tt.imageName, tt.expectVersion)
+				if actual != expect {
+					t.Errorf("returned image (%s) does not match the expected one (%s)", actual, expect)
+					return
+				}
+			}
+		})
+	}
+}
+
+func Test_AddonVersionForClusterVersion(t *testing.T) {
+	var tests = vtd.addon
+	tests = append(
+		tests,
+		addonTestData{
+			name:           "invalid addon",
+			clusterVersion: version.MustParseSemantic("1.16.2"),
+			addon:          "not-exist",
+			expectErr:      true,
+		},
+	)
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			actual := AddonVersionForClusterVersion(tt.addon, tt.clusterVersion)
+			if tt.expectErr {
+				if actual != nil {
+					t.Errorf("addon version not expected. but a result was returned (%v)", *actual)
+					return
+				}
+			} else {
+				if actual.Version != tt.expectVersion {
+					t.Errorf("returned addon version (%s) does not match the expected one (%s)", actual.Version, tt.expectVersion)
+					return
+				}
+				if actual.ManifestVersion != tt.expectManifestVersion {
+					t.Errorf("returned addon version (%v) does not match the expected one (%v)", actual.ManifestVersion, tt.expectManifestVersion)
+					return
+				}
+			}
+		})
+	}
+}
+
+func Test_AllAddonVersionsForClusterVersion(t *testing.T) {
+	type test struct {
+		name           string
+		clusterVersion *version.Version
+	}
+	var tests []test
+	for ver := range supportedVersions {
+		tests = append(
+			tests,
+			test{
+				name:           fmt.Sprintf("get all addon versions when cluster version is %s", ver),
+				clusterVersion: version.MustParseSemantic(ver),
+			},
+		)
+	}
+	tests = append(
+		tests,
+		test{
+			name:           "invalid cluster version",
+			clusterVersion: version.MustParseSemantic("0.0.0"),
+		},
+	)
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			actual := AllAddonVersionsForClusterVersion(tt.clusterVersion)
+			expect := supportedVersions[tt.clusterVersion.String()].AddonsVersion
+
+			if !reflect.DeepEqual(actual, expect) {
+				actualData, err := json.Marshal(actual)
+				if err != nil {
+					t.Errorf("error not expected while convert returned result to json data (%v)", err)
+					return
+				}
+				expectData, err := json.Marshal(expect)
+				if err != nil {
+					t.Errorf("error not expected while convert returned result to json data (%v)", err)
+					return
+				}
+				t.Errorf("returned result (%s) does not match the expected one (%s)", actualData, expectData)
+				return
+			}
+		})
+	}
+}
+
+func Test_AvailableVersionsForMap(t *testing.T) {
 	var versions = []struct {
 		name                      string
 		kubernetesVersions        KubernetesVersions
@@ -66,19 +328,19 @@ func TestAvailableVersionsForMap(t *testing.T) {
 	}
 }
 
-func TestLatestVersion(t *testing.T) {
+func Test_LatestVersion(t *testing.T) {
 	if _, ok := supportedVersions[LatestVersion().String()]; !ok {
 		t.Errorf("Versions map --authoritative version mapping-- does not include version %q", LatestVersion().String())
 	}
 }
 
-func TestIsVersionAvailable(t *testing.T) {
+func Test_IsVersionAvailable(t *testing.T) {
 	if !IsVersionAvailable(LatestVersion()) {
 		t.Errorf("Versions map does not include version %q", LatestVersion().String())
 	}
 }
 
-func TestMajorMinorVersion(t *testing.T) {
+func Test_MajorMinorVersion(t *testing.T) {
 	tests := []struct {
 		name                      string
 		version                   *version.Version


### PR DESCRIPTION
## Why is this PR needed?

Increase unit test code coverage.
Ref: https://github.com/SUSE/avant-garde/issues/744

## What does this PR do?

Tests include:
* ComponentVersionForClusterVersion
    * invalid component.
    * get host component version of supported cluster versions.
<br/>

* AllComponentContainerImagesForClusterVersion
    * get all container component images of supported cluster versions.
<br/>

* ComponentContainerImageForClusterVersion
    * invalid component.
    * get container component image with supported cluster versions.
<br/>

* AddonVersionForClusterVersion
    * invalid addon.
    * get addon versions of supported cluster versions.
<br/>

* AllAddonVersionsForClusterVersion
    * invalid cluster version
    * get all addon versions of supported cluster versions.
<br/>

## Anything else a reviewer needs to know?

## Info for QA

### Related info

### Status **BEFORE** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes/versions.go (30.0%)
```

### Status **AFTER** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes/versions.go (100.0%)
```

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
