### PR TITLE
Release: check tags from multiple branches

### DIFF
--- a/ci/packaging/suse/changelog_maker.sh
+++ b/ci/packaging/suse/changelog_maker.sh
@@ -7,13 +7,13 @@ changes=${1:-skuba.changes.append}
 
 [ -f "${changes}" ] && rm "${changes}"
 
-mapfile -t tags < <( git tag --merged | sort -rV | head -n2 )
-scope="${tags[1]}..${tags[0]}"
+mapfile -t tags < <( git tag | sort -rV | head -n2 )
+scope="${tags[1]}...${tags[0]}"
 
 {
     git show --format="${header}%n%n- Update to ${tags[0]}:" \
         --date="format-local:${datef}" -s "${tags[0]}^{commit}"
-    git log -s --format="%w(77,2,12)* %h %s" --no-merges "${scope}"
+    git log -s --cherry-pick --format="%w(77,2,12)* %h %s" --no-merges "${scope}"
     # Add empty line
     echo
 } >> "${changes}"


### PR DESCRIPTION

## Why is this PR needed?

Initially we were releasing only from master branch.
However, in order not to block master branch, we are now also releasing
from branches called release-caasp-x.y.z

The script that was creating the changelog was taking commits that have
been merged into the master branch and so it was including entries that
have already been released.

Removing the "--merge" option from the git command will take into
account all versions.

Given we are not maintaining more than one version, this will work.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>


Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.



## What does this PR do?

See above

## Anything else a reviewer needs to know?

Nothing else

## Info for QA

N/A

### Status **BEFORE** applying the patch

The generated changelog was including commits from previous releases.

### Status **AFTER** applying the patch

Include only commits that are new since the last release.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
