### PR TITLE
CI: Add delay between joining masters

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -380,7 +380,7 @@ usage:
        ...
 
 positional arguments:
-  {info,get_logs,cleanup,provision,bootstrap,status,cluster-upgrade-plan,join-node,remove-node,node-upgrade,ssh,test}
+  {info,get_logs,cleanup,provision,bootstrap,status,cluster-upgrade-plan,join-node,remove-node,node-upgrade,join-nodes,ssh,test}
                           command
     info                  ip info
     get_logs              gather logs from nodes
@@ -394,6 +394,7 @@ positional arguments:
     join-node             add node in k8s cluster with the given role.
     remove-node           remove node from k8s cluster.
     node-upgrade          plan or apply kubernetes version upgrade in node
+    join-nodes            add multiple provisioned nodes k8s.
     ssh                   Execute command in node via ssh.
     test                  execute tests
 
@@ -440,7 +441,18 @@ optional arguments:
   -n NODE, --node NODE  node to be added or deleted. eg: -n 0
 
 ```
+### Join nodes
 
+```
+  -h, --help            show this help message and exit
+  -m MASTERS, --masters MASTERS
+                        Specify how many masters to join. Default is all
+  -w WORKERS, --workers WORKERS
+                        Specify how many workers to join. Default is all
+  -d DELAY, --delay DELAY
+                        Delay between joining masters to allow etcd to
+                        stabilize
+```
 #### Node Upgrade command
 
 ```

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -63,7 +63,7 @@ def join_node(options):
 
 def join_nodes(options):
     skuba = Skuba(options.conf, options.platform)
-    skuba.join_nodes(masters=options.masters, workers=options.workers)
+    skuba.join_nodes(masters=options.masters, workers=options.workers, delay=options.delay)
 
 
 def remove_node(options):
@@ -166,13 +166,13 @@ def main():
 
     # Start Join Nodes
     cmd_join_nodes = commands.add_parser("join-nodes",
-                                         help="add node in k8s cluster with the given role.")
-    cmd_join_nodes.add_argument("-m", "--masters",
-                                type=int,
+                                         help="add multiple provisioned nodes k8s.")
+    cmd_join_nodes.add_argument("-m", "--masters", type=int,
                                 help="Specify how many masters to join. Default is all")
-    cmd_join_nodes.add_argument("-w", "--workers",
-                                type=int,
+    cmd_join_nodes.add_argument("-w", "--workers", type=int,
                                 help="Specify how many workers to join. Default is all")
+    cmd_join_nodes.add_argument("-d", "--delay", type=int, default=120,
+                                help="Delay between joining masters to allow etcd to stabilize")
     cmd_join_nodes.set_defaults(func=join_nodes)
     # End Join Nodes
 


### PR DESCRIPTION
## Why is this PR needed?

After joining a master, some time is required to allow etcd to become stable. Trying to join another node may fail with diverse errors depending on the status of etcd at the moment of the join. For example:
```
E1120 04:33:15.495795   21470 ssh.go:192] error execution phase control-plane-join/update-status: error uploading configuration: etcdserver: request timed out
I1120 04:33:15.500262   21470 ssh.go:167] running command: "sudo sh -c 'rm /tmp/kubeadm-init.conf'"
[join] failed to apply join to node failed to apply state kubeadm.join: Process exited with status 1
F1120 04:33:15.677530   21470 join.go:62] error joining node caasp-master-101-caasp-jobs-e2e-caasp-v4-openstack-test-ci-1: failed to apply state kubeadm.join: Process exited with status 1
```

This is a [well-known issue upstream](https://github.com/kubernetes-sigs/kind/issues/588) and the only reliable way to walk around it is to force a wait (checking node status or etcd status is not reliable as may give false positives)

Fixes https://github.com/SUSE/avant-garde/issues/1061

## What does this PR do?
Forces a delay after joining master nodes and exposes this delay as a testrunner argument.
 
# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
