### PR TITLE
CI: Remove duplicated output when test fails

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -488,7 +488,7 @@ optional arguments:
                         test file name
   -t TEST, --test TEST  test to execute
   -l, --list            only list tests to be executed
-  -v, --verbose         show all output
+  -v, --verbose         show all output from testrunner libraries
   --skip-setup {provisioned,bootstrapped,deployed}
                         Skip the given setup step. 'provisioned' For when you
                         have already provisioned the nodes. 'bootstrapped' For

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -190,7 +190,7 @@ def main():
     test_args.add_argument("-l", "--list", dest="collect", action="store_true", default=False,
                            help="only list tests to be executed")
     test_args.add_argument("-v", "--verbose", dest="verbose", action="store_true", default=False,
-                           help="show all output")
+                           help="show all output from testrunner libraries")
     test_args.add_argument("--skip-setup",
                            choices=['provisioned', 'bootstrapped', 'deployed'],
                            help="Skip the given setup step.\n"

--- a/ci/infra/testrunner/tests/driver.py
+++ b/ci/infra/testrunner/tests/driver.py
@@ -7,6 +7,9 @@ TESTRUNNER_DIR = os.path.dirname(os.path.dirname(FILEPATH))
 
 
 class PyTestOpts:
+
+    NO_CAPTURE_LOGS = "--show-capture=no"
+
     SHOW_OUTPUT = "-s"
 
     VERBOSE = "-v"
@@ -32,7 +35,12 @@ class TestDriver:
 
         if verbose:
             opts.append(PyTestOpts.SHOW_OUTPUT)
-            opts.append(PyTestOpts.VERBOSE)
+
+        # Dont capture logs
+        opts.append(PyTestOpts.NO_CAPTURE_LOGS)
+
+        # generete detailed test results
+        opts.append(PyTestOpts.VERBOSE)
 
         if collect:
             opts.append(PyTestOpts.COLLECT_TESTS)


### PR DESCRIPTION
## Why is this PR needed?

Testrunner libraries used in tests generate execution logs. In case of a test failure, pytest by default prints this logsto stderr, duplication these logs.

## What does this PR do?

This changeset adds an option to pytest to suppress the log output in case of error.

Additionally, it sets pytest's verbose option to generate a detailed test result output indicating successful and failed tests.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
