### PR TITLE
CI: Remove retry logic in platform provisioning

### DIFF
--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -98,7 +98,7 @@ class Platform:
         pass
 
     @step
-    def provision(self, num_master=-1, num_worker=-1, retries=4):
+    def provision(self, num_master=-1, num_worker=-1):
         """Provision a cluster"""
         if num_master > -1 or num_worker > -1:
             logger.warning("Overriding number of nodes")
@@ -110,17 +110,8 @@ class Platform:
                 self.conf.worker.count = num_worker
                 logger.warning("   Workers:{} ".format(num_worker))
 
-        # TODO: define the number of retries as a configuration parameter
-        for i in range(0, retries):
-            retry = i + 1
 
-            try:
-                self._provision_platform()
-                break
-            except Exception as ex:
-                logger.warning(f"Provision attempt {retry}/{retries} failed")
-                if retry == retries:
-                    raise Exception(f"Failed {self.__class__.__name__} provisioning: {ex}") from ex
+        self._provision_platform()
 
     def ssh_run(self, role, nr, cmd):
         ip_addrs = self.get_nodes_ipaddrs(role)


### PR DESCRIPTION
## Why is this PR needed?
The provision function has a cycle for retrying in case of errors. In practice, most errors are not retriable and retrying the provisioning creates noise in the output and in some cases, even hides the original failure. Therefore the provision function should try once and fail fast in case of errors.

Fixes https://github.com/SUSE/avant-garde/issues/1060

## What does this PR do?

Removes the logic for retrying platform provisioning.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
