### PR TITLE
CI: Increase delay after joining masters

### DIFF
--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -171,7 +171,7 @@ def main():
                                 help="Specify how many masters to join. Default is all")
     cmd_join_nodes.add_argument("-w", "--workers", type=int,
                                 help="Specify how many workers to join. Default is all")
-    cmd_join_nodes.add_argument("-d", "--delay", type=int, default=120,
+    cmd_join_nodes.add_argument("-d", "--delay", type=int, default=180,
                                 help="Delay between joining masters to allow etcd to stabilize")
     cmd_join_nodes.set_defaults(func=join_nodes)
     # End Join Nodes


### PR DESCRIPTION
## Why is this PR needed?

Several e2e tests fail due to problems derived from etcd not ready after joining a master node. 

## What does this PR do?

Increase the time between joining a master and joining
another node, to allow etcd to stabilize.


## Anything else a reviewer needs to know?

It is a followup of https://github.com/SUSE/skuba/pull/844 where the delay was introduced, increasing its value.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
