### PR TITLE
CI: Update cilium examples manifest to v1.6

### DIFF
--- a/ci/infra/testrunner/tests/test_cilium.py
+++ b/ci/infra/testrunner/tests/test_cilium.py
@@ -14,7 +14,7 @@ def test_cillium(deployment, kubectl):
     landing_req = 'curl -sm10 -XPOST deathstar.default.svc.cluster.local/v1/request-landing'
 
     logger.info("Deploy deathstar")
-    kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/minikube/http-sw-app.yaml")
+    kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.6/examples/minikube/http-sw-app.yaml")
 
     # FIXME: This check should be only get the star wars application's pods
     wait(kubectl.run_kubectl,
@@ -28,7 +28,7 @@ def test_cillium(deployment, kubectl):
     time.sleep(100)
 
     logger.info("Check with L3/L4 policy")
-    kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.5/examples/minikube/sw_l3_l4_policy.yaml")
+    kubectl.run_kubectl("create -f https://raw.githubusercontent.com/cilium/cilium/v1.6/examples/minikube/sw_l3_l4_policy.yaml")
     tie_out = kubectl.run_kubectl("exec tiefighter -- {}".format(landing_req))
     assert 'Ship landed' in tie_out
 


### PR DESCRIPTION
## Why is this PR needed?

Clium example manifests used in tests use API groups deprecated in k8s 1.16.1.

Fixes https://github.com/SUSE/avant-garde/issues/1068

## What does this PR do?

Upgrade to version 1.6 which supports k8s 1.16.1

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
