### PR TITLE
CI: Implement checks for master node readiness

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -428,6 +428,8 @@ optional arguments:
                         kubernetes version
   -c, --cloud-provider
                         Use cloud provider integration for the platform
+  -t TIMEOUT, --timeout TIMEOUT
+                        timeout for waiting the master nodes to become ready (seconds)
 
 ```
 
@@ -449,9 +451,8 @@ optional arguments:
                         Specify how many masters to join. Default is all
   -w WORKERS, --workers WORKERS
                         Specify how many workers to join. Default is all
-  -d DELAY, --delay DELAY
-                        Delay between joining masters to allow etcd to
-                        stabilize
+  -t TIMEOUT, --timeout TIMEOUT
+                        timeout for waiting the master nodes to become ready (seconds)
 ```
 #### Node Upgrade command
 

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -36,8 +36,15 @@ def provision(options):
 
 def bootstrap(options):
     skuba = Skuba(options.conf, options.platform)
-    skuba.cluster_init(kubernetes_version=options.kubernetes_version, cloud_provider=options.cloud_provider)
-    skuba.node_bootstrap(cloud_provider=options.cloud_provider)
+    skuba.cluster_init(
+        kubernetes_version=options.kubernetes_version,
+        cloud_provider=options.cloud_provider
+    )
+    skuba.node_bootstrap(
+        cloud_provider=options.cloud_provider,
+        timeout=options.timeout
+    ) 
+
 
 
 def cluster_status(options):
@@ -63,7 +70,11 @@ def join_node(options):
 
 def join_nodes(options):
     skuba = Skuba(options.conf, options.platform)
-    skuba.join_nodes(masters=options.masters, workers=options.workers, delay=options.delay)
+    skuba.join_nodes(
+        masters=options.masters,
+        workers=options.workers,
+        timeout=options.timeout
+    )
 
 
 def remove_node(options):
@@ -134,6 +145,8 @@ def main():
                                dest="kubernetes_version", default=None)
     cmd_bootstrap.add_argument("-c", "--cloud-provider", action="store_true",
                                help="Use cloud provider integration")
+    cmd_bootstrap.add_argument("-t", "--timeout", type=int, default=180,
+                                help="timeout for waiting the master node to become ready (seconds)")
     cmd_bootstrap.set_defaults(func=bootstrap)
 
     cmd_status = commands.add_parser("status", help="check K8s cluster status")
@@ -171,8 +184,8 @@ def main():
                                 help="Specify how many masters to join. Default is all")
     cmd_join_nodes.add_argument("-w", "--workers", type=int,
                                 help="Specify how many workers to join. Default is all")
-    cmd_join_nodes.add_argument("-d", "--delay", type=int, default=180,
-                                help="Delay between joining masters to allow etcd to stabilize")
+    cmd_join_nodes.add_argument("-t", "--timeout", type=int, default=180,
+                                help="timeout for waiting the master nodes to become ready (seconds)")
     cmd_join_nodes.set_defaults(func=join_nodes)
     # End Join Nodes
 


### PR DESCRIPTION
## Why is this PR needed?

When joining master nodes to a cluster two kind of issues has been detected:
- etcd is not ready
- accessing API server returns EOF

Fixes https://github.com/SUSE/avant-garde/issues/1076

## What does this PR do?
Implement checks after the master node joins the cluster to ensure etcd is ready and apiserver is ready before performing other actions in the cluster.


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
