### PR TITLE
Enhance skuba auth login error message (bsc#1157802)

### DIFF
--- a/cmd/skuba/auth/login.go
+++ b/cmd/skuba/auth/login.go
@@ -96,7 +96,7 @@ func NewLoginCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&cfg.DexServer, "server", "s", "", "OIDC dex server url https://<IP/FQDN>:<Port> (required)")
+	cmd.Flags().StringVarP(&cfg.DexServer, "server", "s", "", "OIDC dex server url https://<IP/FQDN>:<Port> (default port 32000)")
 	cmd.Flags().StringVarP(&cfg.Username, "username", "u", "", "Username")
 	cmd.Flags().StringVarP(&cfg.Password, "password", "p", "", "Password")
 	cmd.Flags().StringVarP(&cfg.AuthConnector, "auth-connector", "a", "", "Authentication connector ID")

--- a/pkg/skuba/actions/auth/login.go
+++ b/pkg/skuba/actions/auth/login.go
@@ -63,13 +63,13 @@ func Login(cfg LoginConfig) (*clientcmdapi.Config, error) {
 	if !cfg.InsecureSkipVerify && cfg.RootCAPath != "" {
 		rootCAData, err = ioutil.ReadFile(cfg.RootCAPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "read root CA failed: %s", err)
+			return nil, errors.Wrap(err, "read CA failed")
 		}
 	}
 
 	url, err := url.Parse(cfg.DexServer)
 	if err != nil {
-		return nil, errors.Wrapf(err, "parse url")
+		return nil, errors.Wrap(err, "parse url")
 	}
 
 	authResp, err := doAuth(request{
@@ -84,7 +84,7 @@ func Login(cfg LoginConfig) (*clientcmdapi.Config, error) {
 		Debug:              cfg.Debug,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "auth failed")
+		return nil, errors.Wrap(err, "auth failed")
 	}
 
 	// fill out clusters
@@ -123,14 +123,14 @@ func Login(cfg LoginConfig) (*clientcmdapi.Config, error) {
 func SaveKubeconfig(filename string, kubeConfig *clientcmdapi.Config) error {
 	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return errors.Wrapf(err, "open file")
+		return errors.Wrap(err, "open file")
 	}
 	defer f.Close()
 	w := bufio.NewWriter(f)
 
 	err = clientcmdlatest.Codec.Encode(kubeConfig, w)
 	if err != nil {
-		return errors.Wrapf(err, "encode kubeconfig")
+		return errors.Wrap(err, "encode kubeconfig")
 	}
 
 	w.Flush()


### PR DESCRIPTION
## Why is this PR needed?

Enhance error message when the user inputs incorrect OIDC dex server URL.

Fixes https://github.com/SUSE/avant-garde/issues/1092

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Function `oidc.NewProvider` will do HTTP Get method to OIDC dex URL `.well-known/openid-configuration`  to scrapes the basic OIDC dex server information. We could check on this URL is accessible or not to verify the user inputs the correct OIDC dex server URL.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

The user inputs the OIDC dex server URL to gangway URL
```
skuba auth login -s https://10.86.3.10:32001 --insecure
Enter your username:
Enter your password:
```

Output error message:
```
F1127 15:06:34.778465   13400 login.go:88] error on login: auth failed: failed to query provider "https://10.86.3.10:32001": oidc: failed to decode provider discovery object: expected Content-Type = application/json, got "text/html; charset=utf-8": invalid character '<' looking for beginning of value
```

### Status **AFTER** applying the patch

The user inputs the OIDC dex server URL to gangway URL
```
skuba auth login -s https://10.86.3.10:32001 --insecure
Enter your username:
Enter your password:
```

Output error message:
```
F1127 15:06:56.026300   13428 login.go:88] error on login: auth failed: failed to query provider https://10.86.3.10:32001 (is this the right URL? maybe missing --root-ca or --insecure, or incorrect port number?)
```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>