### PR TITLE
Improve message about addons for `skuba cluster upgrade plan`

### DIFF
--- a/internal/pkg/skuba/upgrade/addon/versions.go
+++ b/internal/pkg/skuba/upgrade/addon/versions.go
@@ -85,6 +85,8 @@ func PrintAddonUpdates(updatedAddons AddonVersionInfoUpdate) {
 				updatedAddons.Current[addon].ManifestVersion, updatedAddons.Updated[addon].ManifestVersion)
 		}
 	}
+	fmt.Println()
+	fmt.Println("Please, run `skuba addon upgrade apply` in order to upgrade addons.")
 }
 
 func HasAddonUpdate(aviu AddonVersionInfoUpdate) bool {

--- a/internal/pkg/skuba/upgrade/addon/versions_test.go
+++ b/internal/pkg/skuba/upgrade/addon/versions_test.go
@@ -177,4 +177,6 @@ func ExamplePrintAddonUpdates() {
 	//   - cilium: 1.5.3 -> 1.5.3 (manifest version from 0 to 1)
 	//   - dex: 2.16.0 -> 2.17.0
 	//   - gangway: 3.1.0 (new addon)
+	//
+	// Please, run `skuba addon upgrade apply` in order to upgrade addons.
 }

--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -81,10 +81,14 @@ func Plan(client clientset.Interface) error {
 	}
 	fmt.Println()
 	if addon.HasAddonUpdate(updatedAddons) {
-		fmt.Printf("Addon upgrades for %s:\n", nextClusterVersion.String())
+		fmt.Println("After you have completed the platform upgrade, there are new addon versions available:")
+		fmt.Println()
+		fmt.Printf("Addon upgrades from %s to %s:\n", currentVersion, nextClusterVersion.String())
 		addon.PrintAddonUpdates(updatedAddons)
 	} else {
-		fmt.Printf("Congratulations! Addons for %s are already at the latest version available\n", nextClusterVersion.String())
+		fmt.Printf("Addons for next cluster version %s are already up to date.\n", nextClusterVersion.String())
+		fmt.Println()
+		fmt.Println("There is no need to run `skuba addon upgrade apply` after you have completed the platform upgrade.")
 	}
 
 	return nil


### PR DESCRIPTION
## Why is this PR needed?

If addons are already at the latest version available (and match the
addon version for the next cluster version to be upgraded), make
explicit to the user that there is no need to run `skuba addon upgrade
apply` after the platform has been upgraded.

Fixes https://github.com/SUSE/avant-garde/issues/1083

Output:

With addon upgrades available:
```
~ > skuba cluster upgrade plan
** This is an UNTAGGED version and NOT intended for production usage. **
Current Kubernetes cluster version: 1.15.2
Latest Kubernetes version: 1.16.2

Upgrade path to update from 1.15.2 to 1.16.2:
 - 1.15.2 -> 1.16.2

After you have completed the platform upgrade, there are new addon versions available:

Addon upgrades from 1.15.2 to 1.16.2:
  - kured: 1.2.0-rev4 -> 1.2.0-rev4 (manifest version from 0 to 1)

Please, run `skuba addon upgrade apply` in order to upgrade addons.
```

Without addon upgrades available:
```
~ > skuba cluster upgrade plan
** This is an UNTAGGED version and NOT intended for production usage. **
Current Kubernetes cluster version: 1.15.2
Latest Kubernetes version: 1.16.2

Upgrade path to update from 1.15.2 to 1.16.2:
 - 1.15.2 -> 1.16.2

Addons for next cluster version 1.16.2 are already up to date.

There is no need to run `skuba addon upgrade apply` after you have completed the platform upgrade.
```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
