### PR TITLE
Dex and Gangway replica off-balanced (bsc#1157337)

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/internal/pkg/skuba/replica"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
 	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
 )
@@ -257,6 +258,15 @@ func (addon Addon) Apply(client clientset.Interface, addonConfiguration AddonCon
 		klog.Errorf("failed to run kubectl apply: %s", combinedOutput)
 		return err
 	}
+
+	replicaHelper, err := replica.NewHelper(client)
+	if err != nil {
+		return err
+	}
+	if err := replicaHelper.UpdateNodes(); err != nil {
+		return err
+	}
+
 	if addon.callbacks != nil {
 		if err := addon.callbacks.afterApply(addonConfiguration, skubaConfiguration); err != nil {
 			// TODO: should we rollback here?

--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -161,8 +161,12 @@ kind: Deployment
 metadata:
   name: oidc-dex
   namespace: kube-system
+  labels:
+    app: oidc-dex
+    caasp.suse.com/skuba-replica-ha: "true"
 spec:
   replicas: 3
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: oidc-dex

--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -124,8 +124,10 @@ metadata:
   namespace: kube-system
   labels:
     app: oidc-gangway
+    caasp.suse.com/skuba-replica-ha: "true"
 spec:
   replicas: 3
+  revisionHistoryLimit: 0
   selector:
     matchLabels:
       app: oidc-gangway

--- a/internal/pkg/skuba/kubernetes/nodes.go
+++ b/internal/pkg/skuba/kubernetes/nodes.go
@@ -30,6 +30,11 @@ import (
 	kubectldrain "k8s.io/kubernetes/pkg/kubectl/drain"
 )
 
+// GetAllNodes returns the list of nodes
+func GetAllNodes(client clientset.Interface) (*corev1.NodeList, error) {
+	return client.CoreV1().Nodes().List(metav1.ListOptions{})
+}
+
 // GetControlPlaneNodes returns the list of master nodes by matching
 // "node-role.kubernetes.io/master" label.
 func GetControlPlaneNodes(client clientset.Interface) (*corev1.NodeList, error) {

--- a/internal/pkg/skuba/kubernetes/nodes_test.go
+++ b/internal/pkg/skuba/kubernetes/nodes_test.go
@@ -82,6 +82,62 @@ func createNode(name string, isControlPlane bool, machineID string) corev1.Node 
 	}
 }
 
+func Test_GetAllNodes(t *testing.T) {
+	tests := []struct {
+		name          string
+		fakeClientset *fake.Clientset
+		expect        int
+	}{
+		{
+			name: "get nodes when cluster has 1 master",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1,
+					},
+				},
+			),
+			expect: 1,
+		},
+		{
+			name: "get control plane node when cluster has 1 master, 1 worker",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1,
+						w1,
+					},
+				},
+			),
+			expect: 2,
+		},
+		{
+			name: "get all node when cluster has 2 master, 2 worker",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2,
+						w1, w2,
+					},
+				},
+			),
+			expect: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			actual, _ := GetAllNodes(tt.fakeClientset)
+			actualSize := len(actual.Items)
+			if actualSize != tt.expect {
+				t.Errorf("returned node number (%d) does not match the expected one (%d)", actualSize, tt.expect)
+				return
+			}
+		})
+	}
+}
+
 func Test_GetControlPlaneNodes(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -93,8 +93,8 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 1},
 				Kured:   &AddonVersion{"1.2.0-rev4", 1},
-				Dex:     &AddonVersion{"2.16.0", 3},
-				Gangway: &AddonVersion{"3.1.0-rev4", 3},
+				Dex:     &AddonVersion{"2.16.0", 4},
+				Gangway: &AddonVersion{"3.1.0-rev4", 4},
 				PSP:     &AddonVersion{"", 1},
 			},
 		},
@@ -113,8 +113,8 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 1},
 				Kured:   &AddonVersion{"1.2.0-rev4", 1},
-				Dex:     &AddonVersion{"2.16.0", 3},
-				Gangway: &AddonVersion{"3.1.0-rev4", 3},
+				Dex:     &AddonVersion{"2.16.0", 4},
+				Gangway: &AddonVersion{"3.1.0-rev4", 4},
 				PSP:     &AddonVersion{"", 1},
 			},
 		},

--- a/internal/pkg/skuba/replica/replica.go
+++ b/internal/pkg/skuba/replica/replica.go
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package replica
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+)
+
+type affinity int
+
+const (
+	preferred affinity = iota
+	required
+)
+
+const (
+	highAvailabilitylabel = "caasp.suse.com/skuba-replica-ha"
+	minSize               = 2
+	patchAffinityRemove   = `[
+		{
+			"op":"remove",
+			"path":"/spec/template/spec/affinity"
+		}
+	]`
+	patchAffinityRequired = `{
+		"spec": {
+			"template": {
+				"spec": {
+					"affinity": {
+						"podAntiAffinity": {
+							"requiredDuringSchedulingIgnoredDuringExecution": [
+								{
+									"labelSelector": {
+										"matchExpressions": [
+											{
+												"key": "app",
+												"operator": "In",
+												"values": [
+													"%s"
+												]
+											}
+										]
+									},
+									"topologyKey": "kubernetes.io/hostname"
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}`
+	patchAffinityPreferred = `{
+		"spec": {
+			"template": {
+				"spec": {
+					"affinity": {
+						"podAntiAffinity": {
+							"preferredDuringSchedulingIgnoredDuringExecution": [
+								{
+									"weight": 100,
+									"podAffinityTerm": {
+										"labelSelector": {
+											"matchExpressions": [
+												{
+													"key": "app",
+													"operator": "In",
+													"values": [
+														"%s"
+													]
+												}
+											]
+										},
+										"topologyKey": "kubernetes.io/hostname"
+									}
+								}
+							]
+						}
+					}
+				}
+			}
+		}
+	}`
+	patchReplicas = `{
+		"spec": {
+			"replicas": %v
+		}
+	}`
+)
+
+// Helper provide methods for replica update of deployment
+// resource that has highAvailabilitylabel.
+type Helper struct {
+	Client            clientset.Interface
+	ClusterSize       int
+	SelectDeployments appsv1.DeploymentList
+	Deployment        appsv1.Deployment
+	ReplicaSize       int
+	MinSize           int
+}
+
+// NewHelper creates a helper to update deployment replicas.
+func NewHelper(client clientset.Interface) (*Helper, error) {
+	fromSelectors, err := client.AppsV1().Deployments(metav1.NamespaceSystem).List(
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=true", highAvailabilitylabel),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := kubernetes.GetAllNodes(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Helper{
+		Client:            client,
+		ClusterSize:       len(node.Items),
+		MinSize:           minSize,
+		SelectDeployments: *fromSelectors,
+	}, nil
+}
+
+func (r *Helper) replaceAffinity(remove affinity, create affinity) (bool, error) {
+	// doRemove will remove only when affinity path exists
+	doRemove := false
+	affinity := r.Deployment.Spec.Template.Spec.Affinity
+	if affinity != nil && affinity.PodAntiAffinity != nil {
+		preferredList := len(r.Deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+		requiredList := len(r.Deployment.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+		switch remove {
+		case preferred:
+			if preferredList != 0 {
+				doRemove = true
+				break
+			}
+			if requiredList != 0 {
+				return false, nil
+			}
+		case required:
+			if requiredList != 0 {
+				doRemove = true
+				break
+			}
+			if preferredList != 0 {
+				return false, nil
+			}
+		}
+	}
+	if doRemove {
+		if err := r.removeAffinity(); err != nil {
+			return false, err
+		}
+	}
+
+	var affinityJSON string
+	switch create {
+	case required:
+		affinityJSON = fmt.Sprintf(patchAffinityRequired, r.Deployment.ObjectMeta.Name)
+	default:
+		affinityJSON = fmt.Sprintf(patchAffinityPreferred, r.Deployment.ObjectMeta.Name)
+	}
+
+	_, err := r.Client.AppsV1().Deployments(metav1.NamespaceSystem).Patch(r.Deployment.ObjectMeta.Name, types.StrategicMergePatchType, []byte(affinityJSON))
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (r *Helper) removeAffinity() error {
+	_, err := r.Client.AppsV1().Deployments(metav1.NamespaceSystem).Patch(r.Deployment.ObjectMeta.Name, types.JSONPatchType, []byte(patchAffinityRemove))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Helper) updateDeploymentReplica(size int) (*appsv1.Deployment, error) {
+	replicaJSON := fmt.Sprintf(patchReplicas, size)
+	return r.Client.AppsV1().Deployments(metav1.NamespaceSystem).Patch(r.Deployment.ObjectMeta.Name, types.StrategicMergePatchType, []byte(replicaJSON))
+}
+
+func (r *Helper) refreshReplicas() error {
+	// At least one node needs to be free of the affinity rules for pods to re-distribute.
+	// Sizing down replicas would make room for new pod resource.
+	// For example, during rolling upgrade if all node already has `required`, scheduler will `Pend`
+	// when tries to create a new deployment with `preferred`. This is due to the conflict to its original rule.
+	// But this ends up with less of replicas. So need the following patch to bring the replicas to the right size.
+	if _, err := r.updateDeploymentReplica(r.ClusterSize - 1); err != nil {
+		return err
+	}
+	if _, err := r.updateDeploymentReplica(r.ReplicaSize); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateNodes patches for replicas affinity rules after adding of nodes.
+// This updates affinity rule to preferredDuringSchedulingIgnoredDuringExecution of
+// cluster size less then replica size,
+// And updates affinity rule to requiredDuringSchedulingIgnoredDuringExecution when
+// cluster size is equal or greater to replicas.
+func (r *Helper) UpdateNodes() error {
+	for _, deployment := range r.SelectDeployments.Items {
+		r.Deployment = deployment
+		r.ReplicaSize = int(*r.Deployment.Spec.Replicas)
+		if r.ReplicaSize == 0 {
+			r.ReplicaSize = r.MinSize
+		}
+
+		nodes := r.ClusterSize
+		isAffinityReplaced := false
+		var err error
+		switch {
+		case nodes >= r.ReplicaSize:
+			isAffinityReplaced, err = r.replaceAffinity(preferred, required)
+			if err != nil {
+				return err
+			}
+		case nodes >= r.MinSize:
+			isAffinityReplaced, err = r.replaceAffinity(required, preferred)
+			if err != nil {
+				return err
+			}
+		}
+		if !isAffinityReplaced && nodes <= r.ReplicaSize {
+			if err := r.refreshReplicas(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// UpdateDrainNodes patches for replicas affinity rules before removing of nodes.
+// This updates affinity rule to preferredDuringSchedulingIgnoredDuringExecution when
+// cluster size equal or less then replicas.
+func (r *Helper) UpdateDrainNodes() error {
+	for _, deployment := range r.SelectDeployments.Items {
+		r.Deployment = deployment
+		r.ReplicaSize = int(*r.Deployment.Spec.Replicas)
+		if r.ClusterSize > r.ReplicaSize {
+			continue
+		}
+
+		if _, err := r.replaceAffinity(required, preferred); err != nil {
+			return err
+		}
+		if err := r.refreshReplicas(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/pkg/skuba/replica/replica_test.go
+++ b/internal/pkg/skuba/replica/replica_test.go
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package replica
+
+import (
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+)
+
+func TestNewHelper(t *testing.T) {
+	t.Run("create new helper", func(t *testing.T) {
+		fakeClientset := fake.NewSimpleClientset(
+			&corev1.NodeList{
+				Items: []corev1.Node{
+					m1, m2,
+				},
+			},
+			&appsv1.DeploymentList{
+				Items: []appsv1.Deployment{
+					d1R2,
+				},
+			},
+		)
+
+		newReplica, err := NewHelper(fakeClientset)
+		if err != nil {
+			t.Errorf("error not expected, but an error was reported (%v)", err.Error())
+		}
+
+		nodes, err := kubernetes.GetAllNodes(fakeClientset)
+		if err != nil {
+			t.Errorf("error not expected, but an error was reported (%v)", err.Error())
+		}
+		expect := len(nodes.Items)
+		if newReplica.ClusterSize != expect {
+			t.Errorf("returned cluster size (%v) does not match the expected one (%v)", newReplica.ClusterSize, expect)
+		}
+
+		deployments, err := fakeClientset.AppsV1().Deployments(metav1.NamespaceSystem).List(
+			metav1.ListOptions{
+				LabelSelector: fmt.Sprintf("%s=true", highAvailabilitylabel),
+			},
+		)
+		if err != nil {
+			t.Errorf("error not expected, but an error was reported (%v)", err.Error())
+		}
+		actual := len(newReplica.SelectDeployments.Items)
+		expect = len(deployments.Items)
+		if actual != expect {
+			t.Errorf("returned deployment size (%v) does not match the expected one (%v)", actual, expect)
+		}
+	})
+}
+
+func TestUpdateNodes(t *testing.T) {
+	tests := []struct {
+		name          string
+		fakeClientset *fake.Clientset
+	}{
+		{
+			name: "2nd master nodes joins cluster, deployments: [replica-0]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1R0,
+					},
+				},
+			),
+		},
+		{
+			name: "2nd master nodes joins cluster, deployments: [replica-2]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1R2,
+					},
+				},
+			),
+		},
+		{
+			name: "2nd master node joins cluster, deployments: [replica-2, replica-3]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1R2, d1R3,
+					},
+				},
+			),
+		},
+		{
+			name: "3rd master node joins cluster, deployments: [replica-2]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR2,
+					},
+				},
+			),
+		},
+		{
+			name: "3rd master node joins cluster, deployments: [replica-2, replica-3]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR2, d1PreferredR3,
+					},
+				},
+			),
+		},
+		{
+			name: "4th master node joins cluster",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3, m4,
+					},
+				},
+			),
+		},
+		{
+			name: "5th master node joins cluster",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3, m4, m5,
+					},
+				},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			replicaHelper, _ := NewHelper(tt.fakeClientset)
+			err := replicaHelper.UpdateNodes()
+			if err != nil {
+				t.Errorf("error not expected when (%s), but an error was reported (%v)", tt.name, err.Error())
+			}
+
+			deployments, _ := tt.fakeClientset.AppsV1().Deployments(metav1.NamespaceSystem).List(
+				metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=true", highAvailabilitylabel),
+				},
+			)
+			for _, d := range deployments.Items {
+				replicaSize := int(*d.Spec.Replicas)
+				switch nodes := replicaHelper.ClusterSize; {
+				case nodes >= replicaSize:
+					if len(d.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) == 0 {
+						t.Error("expect affinity \"requiredDuringSchedulingIgnoredDuringExecution\", but affinity not exist")
+					}
+				case nodes >= replicaHelper.MinSize:
+					if len(d.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) == 0 {
+						t.Error("expect affinity \"preferredDuringSchedulingIgnoredDuringExecution\", but affinity not exist")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateDrainNodes(t *testing.T) {
+	tests := []struct {
+		name          string
+		fakeClientset *fake.Clientset
+	}{
+		{
+			name: "5 master in cluster",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3, m4, m5,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR3,
+					},
+				},
+			),
+		},
+		{
+			name: "4 master in cluster",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3, m4,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR3,
+					},
+				},
+			),
+		},
+		{
+			name: "3 master in cluster, deployments: [replica-3]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR3,
+					},
+				},
+			),
+		},
+		{
+			name: "3 master in cluster, deployments: [replica-3, replica-3]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2, m3,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR3, d2RequiredR3,
+					},
+				},
+			),
+		},
+		{
+			name: "2 master in cluster, deployments: [replica-2]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1PreferredR2,
+					},
+				},
+			),
+		},
+		{
+			name: "2 master in cluster, 2 labeled deployment: [replica-2, replica-3]",
+			fakeClientset: fake.NewSimpleClientset(
+				&corev1.NodeList{
+					Items: []corev1.Node{
+						m1, m2,
+					},
+				},
+				&appsv1.DeploymentList{
+					Items: []appsv1.Deployment{
+						d1RequiredR2, d2PreferredR3,
+					},
+				},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			replicaHelper, _ := NewHelper(tt.fakeClientset)
+			err := replicaHelper.UpdateDrainNodes()
+			if err != nil {
+				t.Errorf("error not expected when (%s), but an error was reported (%v)", tt.name, err.Error())
+			}
+
+			deployments, _ := tt.fakeClientset.AppsV1().Deployments(metav1.NamespaceSystem).List(
+				metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=true", highAvailabilitylabel),
+				},
+			)
+			for _, d := range deployments.Items {
+				replicaSize := int(*d.Spec.Replicas)
+				preferredList := len(d.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution)
+				requiredList := len(d.Spec.Template.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+				switch nodes := replicaHelper.ClusterSize; {
+				case nodes > replicaSize:
+					if requiredList == 0 {
+						t.Error("expect affinity \"requiredDuringSchedulingIgnoredDuringExecution\", but affinity not exist")
+					}
+				case nodes <= replicaSize:
+					if preferredList == 0 {
+						t.Error("expect affinity \"preferredDuringSchedulingIgnoredDuringExecution\" but affinity not exist")
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/pkg/skuba/replica/testing.go
+++ b/internal/pkg/skuba/replica/testing.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package replica
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var m1 = createNode("master1")
+var m2 = createNode("master2")
+var m3 = createNode("master3")
+var m4 = createNode("master4")
+var m5 = createNode("master5")
+
+func createNode(name string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{"node-role.kubernetes.io/master": ""},
+		},
+	}
+}
+
+var d1R0 = createDeployment("deployment1", 0)
+var d1R2 = createDeployment("deployment1", 2)
+var d1R3 = createDeployment("deployment2", 3)
+
+func createDeployment(deployment string, replica int) appsv1.Deployment {
+	return appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{"caasp.suse.com/skuba-replica-ha": "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func() *int32 { i := int32(replica); return &i }(),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "t-1",
+							Image: "t-1",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+var d1RequiredR2 = createDeploymentWithAffinityRequired("deployment1-withRequired", 2)
+var d1RequiredR3 = createDeploymentWithAffinityRequired("deployment1-withRequired", 3)
+var d2RequiredR3 = createDeploymentWithAffinityRequired("deployment2-withRequired", 3)
+
+func createDeploymentWithAffinityRequired(deployment string, replica int) appsv1.Deployment {
+	return appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{"caasp.suse.com/skuba-replica-ha": "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func() *int32 { i := int32(replica); return &i }(),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "t-1",
+							Image: "t-1",
+						},
+					},
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key: "test",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+var d1PreferredR2 = createDeploymentWithAffinityPreferred("deployment1-Preferred-2", 2)
+var d1PreferredR3 = createDeploymentWithAffinityPreferred("deployment1-Preferred-3", 3)
+var d2PreferredR3 = createDeploymentWithAffinityPreferred("deployment2-Preferred-3", 3)
+
+func createDeploymentWithAffinityPreferred(deployment string, replica int) appsv1.Deployment {
+	return appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment,
+			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{"caasp.suse.com/skuba-replica-ha": "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: func() *int32 { i := int32(replica); return &i }(),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "t-1",
+							Image: "t-1",
+						},
+					},
+					Affinity: &corev1.Affinity{
+						PodAntiAffinity: &corev1.PodAntiAffinity{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												{
+													Key: "test",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -39,6 +39,7 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
+	"github.com/SUSE/skuba/internal/pkg/skuba/replica"
 	"github.com/SUSE/skuba/pkg/skuba"
 )
 
@@ -98,6 +99,14 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		if err := cni.CiliumUpdateConfigMap(client); err != nil {
 			return err
 		}
+	}
+
+	replicaHelper, err := replica.NewHelper(client)
+	if err != nil {
+		return err
+	}
+	if err := replicaHelper.UpdateNodes(); err != nil {
+		return err
 	}
 
 	fmt.Println("[join] node successfully joined the cluster")


### PR DESCRIPTION
## Why is this PR needed?

Currently the configuration is causing `dex` and `gangway`  replica pods to be deployed on bootstrapped host at initial deployment of CaaSP cluster. Having running all three instances on the same host will cause downtime in case this server goes down.

Adding podAntiAffinity will make requirement rule to restrict duplicated deployments on one host.

Fixes [#1157337](https://bugzilla.suse.com/show_bug.cgi?id=1157337)
Ref https://github.com/SUSE/avant-garde/issues/1093

## What does this PR do?
RFC: https://github.com/SUSE/caasp-rfc/pull/50
Introducing
* caasp.suse.com/skuba-replica-ha label
* podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution for cluster with insufficient nodes for replica - during deployment.
* podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution for cluster with sufficient nodes for replica - complete deployment.

Version Bump:
* manifest
* apply affinity with skuba addon upgrade.

Unit-test:
* replica

Other Changes:
* Move "last master node check" to remove duplicate calls for `kubernetes.IsControlPlane`.

## Anything else a reviewer needs to know?
-

## Info for QA
```
github.com/SUSE/skuba/internal/pkg/skuba/replica        0.015s  coverage: 81.7% of statements
```

### Related info

Similar issue discussed [here](https://bugzilla.suse.com/show_bug.cgi?id=1157426).

### Status **BEFORE** applying the patch

```
oidc-dex-5566f77f89-4g5w2               1/1     Running   0       25m     10.244.0.155   caasp-master-cyh-cluster-0   <none>           <none>
oidc-dex-5566f77f89-gxqrk               1/1     Running   0       25m     10.244.0.205   caasp-master-cyh-cluster-0   <none>           <none>
oidc-dex-5566f77f89-tq7p9               1/1     Running   1       25m     10.244.0.189   caasp-master-cyh-cluster-0   <none>           <none>
oidc-gangway-79447879fb-772gj           1/1     Running   0       25m     10.244.0.47    caasp-master-cyh-cluster-0   <none>           <none>
oidc-gangway-79447879fb-j8dmt           1/1     Running   0       25m     10.244.0.146   caasp-master-cyh-cluster-0   <none>           <none>
oidc-gangway-79447879fb-mqphq           1/1     Running   0       25m     10.244.0.195   caasp-master-cyh-cluster-0   <none>           <none>
```

### Status **AFTER** applying the patch

#### Join
```
---1*MASTER
oidc-dex-5566f77f89-jcss4               1/1     Running   0       3m23s   10.244.0.117   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-5566f77f89-l2bxt               1/1     Running   1       3m23s   10.244.0.251   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-79447879fb-49wmz           1/1     Running   0       3m45s   10.244.0.145   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-79447879fb-frjxh           1/1     Running   0       3m45s   10.244.0.9     caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-79447879fb-wwk48           1/1     Running   0       3m45s   10.244.0.224   caasp-master-c3y1-cluster-0   <none>           <none>
---2*MASTER
oidc-dex-768b4f4778-f479g               1/1     Running   0       97s     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       98s     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-788b4c5696-4r6mc           1/1     Running   0       98s     10.12.3.79     caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-788b4c5696-s99mk           1/1     Running   0       21s     10.244.1.199   caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-788b4c5696-x9bfv           1/1     Running   0       98s     10.244.1.101   caasp-master-c3y1-cluster-1   <none>           <none>
---2*MASTER,1*WORKER
oidc-dex-768b4f4778-f479g               1/1     Running   0       11m     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       11m     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-9v6d6            1/1     Running   0       6m25s   10.244.2.135   caasp-worker-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-cxnn6            1/1     Running   0       6m25s   10.12.74.227   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-d776d65dd-mf5jc            1/1     Running   0       32s     10.244.1.132   caasp-master-c3y1-cluster-1   <none>           <none>
---2*MASTER,2*WORKER
oidc-dex-768b4f4778-f479g               1/1     Running   0       12m     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       12m     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-9v6d6            1/1     Running   0       7m56s   10.244.2.135   caasp-worker-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-cxnn6            1/1     Running   0       7m56s   10.12.74.227   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-d776d65dd-mf5jc            1/1     Running   0       2m3s    10.244.1.132   caasp-master-c3y1-cluster-1   <none>           <none>
---3*MASTER,2*WORKER
oidc-dex-768b4f4778-f479g               1/1     Running   0       14m     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       14m     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-9v6d6            1/1     Running   0       9m40s   10.244.2.135   caasp-worker-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-cxnn6            1/1     Running   0       9m40s   10.12.74.227   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-d776d65dd-mf5jc            1/1     Running   0       3m47s   10.244.1.132   caasp-master-c3y1-cluster-1   <none>           <none>
```
#### Remove
```
---3*MASTER,2*WORKER
oidc-dex-768b4f4778-f479g               1/1     Running   0       14m     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       14m     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-9v6d6            1/1     Running   0       9m40s   10.244.2.135   caasp-worker-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-cxnn6            1/1     Running   0       9m40s   10.12.74.227   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-d776d65dd-mf5jc            1/1     Running   0       3m47s   10.244.1.132   caasp-master-c3y1-cluster-1   <none>           <none>
---2*MASTER,2*WORKER
oidc-dex-768b4f4778-f479g               1/1     Running   0       17m     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       18m     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-9v6d6            1/1     Running   0       13m     10.244.2.135   caasp-worker-c3y1-cluster-1   <none>           <none>
oidc-gangway-d776d65dd-cxnn6            1/1     Running   0       13m     10.12.74.227   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-d776d65dd-mf5jc            1/1     Running   0       7m16s   10.244.1.132   caasp-master-c3y1-cluster-1   <none>           <none>
---2*MASTER,1*WORKER
oidc-dex-768b4f4778-f479g               1/1     Running   0       19m     10.12.148.16   caasp-master-c3y1-cluster-0   <none>           <none> 
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       19m     10.244.1.59    caasp-master-c3y1-cluster-1   <none>           <none>                                   
oidc-gangway-d776d65dd-9v6d6            1/1     Running   0       14m     10.244.2.135   caasp-worker-c3y1-cluster-1   <none>           <none>                                   
oidc-gangway-d776d65dd-cxnn6            1/1     Running   0       14m     10.12.74.227   caasp-master-c3y1-cluster-0   <none>           <none>                                   
oidc-gangway-d776d65dd-mf5jc            1/1     Running   0       8m17s   10.244.1.132   caasp-master-c3y1-cluster-1   <none>           <none>
---2*MASTER
oidc-dex-768b4f4778-f479g               1/1     Running   0       22m     10.12.148.16    caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-768b4f4778-n7q9r               1/1     Running   0       22m     10.244.1.59     caasp-master-c3y1-cluster-1   <none>           <none>
oidc-gangway-788b4c5696-5jm76           1/1     Running   0       78s     10.12.96.60     caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-788b4c5696-9cp55           1/1     Running   0       52s     10.12.85.175    caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-788b4c5696-b7bqb           1/1     Running   0       77s     10.12.133.100   caasp-master-c3y1-cluster-0   <none>           <none>
---1*MASTER
oidc-dex-7755744d84-kp9l7               1/1     Running   0       2m9s    10.12.45.54     caasp-master-c3y1-cluster-0   <none>           <none>
oidc-dex-7755744d84-wb8s9               1/1     Running   0       2m8s    10.12.197.137   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-788b4c5696-5jm76           1/1     Running   0       4m28s   10.12.96.60     caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-788b4c5696-qrdt8           1/1     Running   0       2m5s    10.12.130.120   caasp-master-c3y1-cluster-0   <none>           <none>
oidc-gangway-788b4c5696-v5x2f           1/1     Running   0       2m4s    10.12.175.212   caasp-master-c3y1-cluster-0   <none>           <none>
```

## Docs
https://github.com/SUSE/doc-caasp/pull/617

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
