### PR TITLE
Add unit test for jobs.Delete, jobs.CreateAndWaitForJob

### DIFF
--- a/internal/pkg/skuba/etcd/member.go
+++ b/internal/pkg/skuba/etcd/member.go
@@ -57,6 +57,7 @@ func RemoveMemberFrom(client clientset.Interface, node, executorNode *v1.Node, c
 		client,
 		removeMemberFromJobName(node, executorNode),
 		removeMemberFromJobSpec(node, executorNode, clusterVersion),
+		kubernetes.TimeoutWaitForJob,
 	)
 }
 

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -33,6 +33,7 @@ func DisarmKubelet(client clientset.Interface, node *v1.Node, clusterVersion *ve
 		client,
 		disarmKubeletJobName(node),
 		disarmKubeletJobSpec(node, clusterVersion),
+		TimeoutWaitForJob,
 	)
 }
 


### PR DESCRIPTION
## Why is this PR needed?

Increase unit test code coverage.

Ref: https://github.com/SUSE/avant-garde/issues/744

## What does this PR do?

New Tests Include:
* delete job.
* delete job when job exist in other namespace.
* delete job when job not exist.
* create and wait for job.
* create and wait for job when job pend active.
* create and wait for job when job failed.
* create and wait for job when failed to get job.

## Anything else a reviewer needs to know?

Other Changes:
* comment function description.
* expose timeout for CreateAndWaitForJob to suit unit-testing.

## Info for QA
N/A

### Related info
N/A

### Status **BEFORE** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes/jobs.go (10.0%)
```

### Status **AFTER** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes/jobs.go (84.2%)
```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
