### PR TITLE
CI: drop monitoring validation test

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -82,7 +82,6 @@
     name: caasp-jobs/validation/caasp-v4
     jobs:
         - '{name}-devel-base-nightly'
-        - '{name}-devel-monitoring-nightly'
         - '{name}-release-staging-on-demand'
 
 - job:

--- a/ci/jenkins/templates/validation-nightly-template.yaml
+++ b/ci/jenkins/templates/validation-nightly-template.yaml
@@ -22,29 +22,6 @@
         script-path: scripts/jenkins/validator_caasp-devel-nightly.Jenkinsfile
 
 - job-template:
-    name: '{name}-devel-monitoring-nightly'
-    project-type: pipeline
-    number-to-keep: 30
-    days-to-keep: 30
-    branch: master
-    wrappers:
-      - timeout:
-          timeout: 120
-          fail: true
-    triggers:
-        - timed: 'H H(3-5) * * *'
-    pipeline-scm:
-        scm:
-            - git:
-                url: 'https://gitlab.suse.de/mkravec/scripts.git'
-                branches:
-                    - 'master'
-                browser: auto
-                suppress-automatic-scm-triggering: true
-                basedir: scripts
-        script-path: scripts/jenkins/validator_caasp-devel-nightly.Jenkinsfile
-
-- job-template:
     name: '{name}-release-staging-on-demand'
     project-type: pipeline
     number-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

monitoring test is now run as part of the base test
https://gitlab.suse.de/mkravec/scripts/merge_requests/34

## What does this PR do?

drop moniotoring job for validator
