### PR TITLE
CI: Gather logs in upgrade e2e tests

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -9,6 +9,7 @@ CURRENT_VERSION = "1.16.2"
 @pytest.fixture
 def setup(request, platform, skuba):
     def cleanup():
+        platform.gather_logs()
         platform.cleanup()
 
     request.addfinalizer(cleanup)


### PR DESCRIPTION
## Why is this PR needed?

Some logs were not gathered in the e2e tests.

## What does this PR do?

Gather more logs with testrunner function

## Anything else a reviewer needs to know?

In the long term we will switch to supportconfig
