### PR TITLE
Add unit tests for internal/pkg/skuba/addons/cilium

### DIFF
--- a/internal/pkg/skuba/addons/cilium_test.go
+++ b/internal/pkg/skuba/addons/cilium_test.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
+	img "github.com/SUSE/skuba/pkg/skuba"
+)
+
+func TestGetCiliumInitImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageTag string
+		want     string
+	}{
+		{
+			name:     "get cilium init image without revision",
+			imageTag: "1.5.3",
+			want:     img.ImageRepository + "/cilium-init:1.5.3",
+		},
+		{
+			name:     "get cilium init image with revision",
+			imageTag: "1.5.3-rev2",
+			want:     img.ImageRepository + "/cilium-init:1.5.3-rev2",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetCiliumInitImage(tt.imageTag); got != tt.want {
+				t.Errorf("GetCiliumInitImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCiliumOperatorImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageTag string
+		want     string
+	}{
+		{
+			name:     "get cilium operator image without revision",
+			imageTag: "1.5.3",
+			want:     img.ImageRepository + "/cilium-operator:1.5.3",
+		},
+		{
+			name:     "get cilium operator image with revision",
+			imageTag: "1.5.3-rev2",
+			want:     img.ImageRepository + "/cilium-operator:1.5.3-rev2",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetCiliumOperatorImage(tt.imageTag); got != tt.want {
+				t.Errorf("GetCiliumOperatorImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetCiliumImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageTag string
+		want     string
+	}{
+		{
+			name:     "get cilium image without revision",
+			imageTag: "1.5.3",
+			want:     img.ImageRepository + "/cilium:1.5.3",
+		},
+		{
+			name:     "get cilium image with revision",
+			imageTag: "1.5.3-rev2",
+			want:     img.ImageRepository + "/cilium:1.5.3-rev2",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetCiliumImage(tt.imageTag); got != tt.want {
+				t.Errorf("GetCiliumImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_renderContext_CiliumInitImage(t *testing.T) {
+	type test struct {
+		name          string
+		renderContext renderContext
+		want          string
+	}
+	for _, ver := range kubernetes.AvailableVersions() {
+		tt := test{
+			name: "render Cilium Init Image URL when cluster version is " + ver.String(),
+			renderContext: renderContext{
+				config: AddonConfiguration{
+					ClusterVersion: ver,
+					ControlPlane:   "",
+					ClusterName:    "",
+				},
+			},
+			want: img.ImageRepository + "/cilium-init:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.renderContext.CiliumInitImage()
+			matched, err := regexp.Match(tt.want, []byte(got))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if !matched {
+				t.Errorf("renderContext.CiliumInitImage() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func Test_renderContext_CiliumOperatorImage(t *testing.T) {
+	type test struct {
+		name          string
+		renderContext renderContext
+		want          string
+	}
+	for _, ver := range kubernetes.AvailableVersions() {
+		tt := test{
+			name: "render Cilium Operator Image URL when cluster version is " + ver.String(),
+			renderContext: renderContext{
+				config: AddonConfiguration{
+					ClusterVersion: ver,
+					ControlPlane:   "",
+					ClusterName:    "",
+				},
+			},
+			want: img.ImageRepository + "/cilium-operator:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.renderContext.CiliumOperatorImage()
+			matched, err := regexp.Match(tt.want, []byte(got))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if !matched {
+				t.Errorf("renderContext.CiliumOperatorImage() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func Test_renderContext_CiliumImage(t *testing.T) {
+	type test struct {
+		name          string
+		renderContext renderContext
+		want          string
+	}
+	for _, ver := range kubernetes.AvailableVersions() {
+		tt := test{
+			name: "render Cilium Image URL when cluster version is " + ver.String(),
+			renderContext: renderContext{
+				config: AddonConfiguration{
+					ClusterVersion: ver,
+					ControlPlane:   "",
+					ClusterName:    "",
+				},
+			},
+			want: img.ImageRepository + "/cilium:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.renderContext.CiliumImage()
+			matched, err := regexp.Match(tt.want, []byte(got))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if !matched {
+				t.Errorf("renderContext.CiliumImage() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func Test_ciliumCallbacks_beforeApply(t *testing.T) {
+	type test struct {
+		name               string
+		addonConfiguration AddonConfiguration
+		skubaConfiguration *skuba.SkubaConfiguration
+		wantErr            bool
+	}
+	for _, ver := range kubernetes.AvailableVersions() {
+		tt := test{
+			name:               "Test Cilium callbacks beforeApply when cluster version is " + ver.String(),
+			addonConfiguration: AddonConfiguration{},
+			wantErr:            true,
+		}
+		t.Run(tt.name, func(t *testing.T) {
+			c := ciliumCallbacks{}
+			if err := c.beforeApply(tt.addonConfiguration, tt.skubaConfiguration); (err != nil) != tt.wantErr {
+				t.Errorf("ciliumCallbacks.beforeApply() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why is this PR needed?

Increase unit test coverage for "./internal/pkg/skuba/addons/cilium.go"

## What does this PR do?

Add unit test to increase coverage getting addon's image and template.

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

### Related info

N/A

### Status **BEFORE** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:29:	init					0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:33:	GetCiliumInitImage			0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:37:	GetCiliumOperatorImage			0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:41:	GetCiliumImage				0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:45:	CiliumInitImage				0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:49:	CiliumOperatorImage			0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:53:	CiliumImage				0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:57:	renderCiliumTemplate			0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:63:	beforeApply				0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:84:	afterApply				0.0%
```

### Status **AFTER** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:29:	init					100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:33:	GetCiliumInitImage			100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:37:	GetCiliumOperatorImage			100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:41:	GetCiliumImage				100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:45:	CiliumInitImage				100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:49:	CiliumOperatorImage			100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:53:	CiliumImage				100.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:57:	renderCiliumTemplate			0.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:63:	beforeApply				25.0%
github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium.go:84:	afterApply				0.0%
```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
