### PR TITLE
Enhance skuba auth login help message

### DIFF
--- a/cmd/skuba/auth/login.go
+++ b/cmd/skuba/auth/login.go
@@ -96,7 +96,7 @@ func NewLoginCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&cfg.DexServer, "server", "s", "", "OIDC dex server url https://<IP/FQDN>:<Port> (default port 32000)")
+	cmd.Flags().StringVarP(&cfg.DexServer, "server", "s", "", "OIDC dex server url https://<IP/FQDN>:<Port> (specify port 32000 for standard CaaSP deployments) (required)")
 	cmd.Flags().StringVarP(&cfg.Username, "username", "u", "", "Username")
 	cmd.Flags().StringVarP(&cfg.Password, "password", "p", "", "Password")
 	cmd.Flags().StringVarP(&cfg.AuthConnector, "auth-connector", "a", "", "Authentication connector ID")

--- a/docs/man/skuba-auth-login.1.md
+++ b/docs/man/skuba-auth-login.1.md
@@ -8,7 +8,7 @@ login - Authenticate to a cluster and authorized with kubeconfig
 [**--help**|**-h**] [**--server|-s**] [**--username|-u**]
 [**--password|-p**] [**--auth-connector|-a**] [**--root-ca**|**-r**]
 [**--insecure**|**-k**] [**--cluster-name**|**-n**] [**--kubeconfig**|**-c**]
-*login* [--server https://<ip/fqdn>:<port>] [--username username] [--password password]
+*login* [--server https://<IP/FQDN>:<Port>] [--username username] [--password password]
 
 # DESCRIPTION
 **login** lets you login to a cluster and authorized with kubeconfig
@@ -19,7 +19,7 @@ login - Authenticate to a cluster and authorized with kubeconfig
   Print usage statement.
 
 **--server, -s**
-  (Required) The OIDC dex server url (https://<controller plane IP/FQDN>:<port>)
+  (Required) The OIDC dex server url https://<IP/FQDN>:<Port> (specify port 32000 for standard CaaSP deployments)
 
 **--username, -u**
   The authentication username

--- a/scripts/go-vet.sh
+++ b/scripts/go-vet.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
 set -e
-for file in "$@"; do
-    go vet "$file"
-done
+go vet ./...


### PR DESCRIPTION
## Why is this PR needed?

The user might specify the wrong port number, enhance `skuba auth login` help message.

## What does this PR do?

Enhance `skuba auth login` help message.

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

### Related info

N/A

### Status **BEFORE** applying the patch

N/A

### Status **AFTER** applying the patch

N/A

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>