### PR TITLE
Update terraform files for tf 0.12

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -101,7 +101,7 @@ resource "libvirt_domain" "lb" {
     network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-lb"
     addresses      = [cidrhost(var.network_cidr, 256)]
-    wait_for_lease = 1
+    wait_for_lease = true
   }
 
   graphics {

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -1,97 +1,106 @@
 data "template_file" "lb_repositories" {
-  count    = "${length(var.lb_repositories)}"
-  template = "${file("cloud-init/repository.tpl")}"
+  count    = length(var.lb_repositories)
+  template = file("cloud-init/repository.tpl")
 
-  vars {
-    repository_url  = "${element(values(var.lb_repositories), count.index)}"
-    repository_name = "${element(keys(var.lb_repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.lb_repositories), count.index)
+    repository_name = element(keys(var.lb_repositories), count.index)
   }
 }
 
 data "template_file" "haproxy_apiserver_backends_master" {
-  count    = "${var.masters}"
+  count    = var.masters
   template = "server $${fqdn} $${ip}:6443\n"
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
-    ip   = "${cidrhost(var.network_cidr, 512 + count.index)}"
+    ip   = cidrhost(var.network_cidr, 512 + count.index)
   }
 }
 
 data "template_file" "haproxy_gangway_backends_master" {
-  count    = "${var.masters}"
+  count    = var.masters
   template = "server $${fqdn} $${ip}:32001\n"
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
-    ip   = "${cidrhost(var.network_cidr, 512 + count.index)}"
+    ip   = cidrhost(var.network_cidr, 512 + count.index)
   }
 }
 
 data "template_file" "haproxy_dex_backends_master" {
-  count    = "${var.masters}"
+  count    = var.masters
   template = "server $${fqdn} $${ip}:32000\n"
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
-    ip   = "${cidrhost(var.network_cidr, 512 + count.index)}"
+    ip   = cidrhost(var.network_cidr, 512 + count.index)
   }
 }
 
 data "template_file" "lb_haproxy_cfg" {
-  template = "${file("cloud-init/haproxy.cfg.tpl")}"
+  template = file("cloud-init/haproxy.cfg.tpl")
 
-  vars {
-    apiserver_backends = "${join("  ", data.template_file.haproxy_apiserver_backends_master.*.rendered)}"
-    gangway_backends   = "${join("  ", data.template_file.haproxy_gangway_backends_master.*.rendered)}"
-    dex_backends       = "${join("  ", data.template_file.haproxy_dex_backends_master.*.rendered)}"
+  vars = {
+    apiserver_backends = join(
+      "  ",
+      data.template_file.haproxy_apiserver_backends_master.*.rendered,
+    )
+    gangway_backends = join(
+      "  ",
+      data.template_file.haproxy_gangway_backends_master.*.rendered,
+    )
+    dex_backends = join(
+      "  ",
+      data.template_file.haproxy_dex_backends_master.*.rendered,
+    )
   }
 }
 
 data "template_file" "lb_cloud_init_userdata" {
-  template = "${file("cloud-init/lb.tpl")}"
+  template = file("cloud-init/lb.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.lb_repositories.*.rendered)}"
-    username        = "${var.username}"
-    password        = "${var.password}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.lb_repositories.*.rendered)
+    username        = var.username
+    password        = var.password
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "libvirt_volume" "lb" {
   name           = "${var.stack_name}-lb-volume"
-  pool           = "${var.pool}"
-  size           = "${var.disk_size}"
-  base_volume_id = "${libvirt_volume.img.id}"
+  pool           = var.pool
+  size           = var.disk_size
+  base_volume_id = libvirt_volume.img.id
 }
 
 resource "libvirt_cloudinit_disk" "lb" {
   name = "${var.stack_name}-lb-cloudinit-disk"
-  pool = "${var.pool}"
+  pool = var.pool
 
-  user_data = "${data.template_file.lb_cloud_init_userdata.rendered}"
+  user_data = data.template_file.lb_cloud_init_userdata.rendered
 }
 
 resource "libvirt_domain" "lb" {
   name      = "${var.stack_name}-lb-domain"
-  memory    = "${var.lb_memory}"
-  vcpu      = "${var.lb_vcpu}"
-  cloudinit = "${libvirt_cloudinit_disk.lb.id}"
+  memory    = var.lb_memory
+  vcpu      = var.lb_vcpu
+  cloudinit = libvirt_cloudinit_disk.lb.id
 
-  cpu {
+  cpu = {
     mode = "host-passthrough"
   }
 
   disk {
-    volume_id = "${libvirt_volume.lb.id}"
+    volume_id = libvirt_volume.lb.id
   }
 
   network_interface {
-    network_id     = "${libvirt_network.network.id}"
+    network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-lb"
-    addresses      = ["${cidrhost(var.network_cidr, 256)}"]
+    addresses      = [cidrhost(var.network_cidr, 256)]
     wait_for_lease = 1
   }
 
@@ -102,13 +111,16 @@ resource "libvirt_domain" "lb" {
 }
 
 resource "null_resource" "lb_wait_cloudinit" {
-  depends_on = ["libvirt_domain.lb"]
-  count      = "${var.lbs}"
+  depends_on = [libvirt_domain.lb]
+  count      = var.lbs
 
   connection {
-    host     = "${element(libvirt_domain.lb.*.network_interface.0.addresses.0, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
+    host = element(
+      libvirt_domain.lb.*.network_interface.0.addresses.0,
+      count.index,
+    )
+    user     = var.username
+    password = var.password
     type     = "ssh"
   }
 
@@ -120,22 +132,25 @@ resource "null_resource" "lb_wait_cloudinit" {
 }
 
 resource "null_resource" "lb_push_haproxy_cfg" {
-  depends_on = ["null_resource.lb_wait_cloudinit"]
-  count      = "${var.lbs}"
+  depends_on = [null_resource.lb_wait_cloudinit]
+  count      = var.lbs
 
   triggers = {
-    master_count = "${var.masters}"
+    master_count = var.masters
   }
 
   connection {
-    host  = "${element(libvirt_domain.lb.*.network_interface.0.addresses.0, count.index)}"
-    user  = "${var.username}"
+    host = element(
+      libvirt_domain.lb.*.network_interface.0.addresses.0,
+      count.index,
+    )
+    user  = var.username
     type  = "ssh"
     agent = true
   }
 
   provisioner "file" {
-    content     = "${data.template_file.lb_haproxy_cfg.rendered}"
+    content     = data.template_file.lb_haproxy_cfg.rendered
     destination = "/tmp/haproxy.cfg"
   }
 
@@ -146,3 +161,4 @@ resource "null_resource" "lb_push_haproxy_cfg" {
     ]
   }
 }
+

--- a/ci/infra/libvirt/main.tf
+++ b/ci/infra/libvirt/main.tf
@@ -1,9 +1,10 @@
 provider "libvirt" {
-  uri = "${var.libvirt_uri}"
+  uri = var.libvirt_uri
 }
 
 resource "libvirt_volume" "img" {
   name   = "${var.stack_name}-${basename(var.image_uri)}"
-  source = "${var.image_uri}"
-  pool   = "${var.pool}"
+  source = var.image_uri
+  pool   = var.pool
 }
+

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -86,7 +86,7 @@ resource "libvirt_domain" "master" {
     network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-master-${count.index}"
     addresses      = [cidrhost(var.network_cidr, 512 + count.index)]
-    wait_for_lease = 1
+    wait_for_lease = true
   }
 
   graphics {

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -1,91 +1,91 @@
 data "template_file" "master_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "master_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "master_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "master_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "master-cloud-init" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.master_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
-    commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
-    username        = "${var.username}"
-    password        = "${var.password}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.master_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.master_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.master_register_rmt.*.rendered)
+    commands        = join("\n", data.template_file.master_commands.*.rendered)
+    username        = var.username
+    password        = var.password
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "libvirt_volume" "master" {
   name           = "${var.stack_name}-master-volume-${count.index}"
-  pool           = "${var.pool}"
-  size           = "${var.disk_size}"
-  base_volume_id = "${libvirt_volume.img.id}"
-  count          = "${var.masters}"
+  pool           = var.pool
+  size           = var.disk_size
+  base_volume_id = libvirt_volume.img.id
+  count          = var.masters
 }
 
 resource "libvirt_cloudinit_disk" "master" {
   # needed when 0 master nodes are defined
-  count     = "${var.masters}"
+  count     = var.masters
   name      = "${var.stack_name}-master-cloudinit-disk-${count.index}"
-  pool      = "${var.pool}"
-  user_data = "${data.template_file.master-cloud-init.rendered}"
+  pool      = var.pool
+  user_data = data.template_file.master-cloud-init.rendered
 }
 
 resource "libvirt_domain" "master" {
-  count      = "${var.masters}"
+  count      = var.masters
   name       = "${var.stack_name}-master-domain-${count.index}"
-  memory     = "${var.master_memory}"
-  vcpu       = "${var.master_vcpu}"
-  cloudinit  = "${element(libvirt_cloudinit_disk.master.*.id, count.index)}"
-  depends_on = ["libvirt_domain.lb"]
+  memory     = var.master_memory
+  vcpu       = var.master_vcpu
+  cloudinit  = element(libvirt_cloudinit_disk.master.*.id, count.index)
+  depends_on = [libvirt_domain.lb]
 
-  cpu {
+  cpu = {
     mode = "host-passthrough"
   }
 
   disk {
-    volume_id = "${element(libvirt_volume.master.*.id, count.index)}"
+    volume_id = element(libvirt_volume.master.*.id, count.index)
   }
 
   network_interface {
-    network_id     = "${libvirt_network.network.id}"
+    network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-master-${count.index}"
-    addresses      = ["${cidrhost(var.network_cidr, 512 + count.index)}"]
+    addresses      = [cidrhost(var.network_cidr, 512 + count.index)]
     wait_for_lease = 1
   }
 
@@ -96,13 +96,16 @@ resource "libvirt_domain" "master" {
 }
 
 resource "null_resource" "master_wait_cloudinit" {
-  depends_on = ["libvirt_domain.master"]
-  count      = "${var.masters}"
+  depends_on = [libvirt_domain.master]
+  count      = var.masters
 
   connection {
-    host     = "${element(libvirt_domain.master.*.network_interface.0.addresses.0, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
+    host = element(
+      libvirt_domain.master.*.network_interface.0.addresses.0,
+      count.index,
+    )
+    user     = var.username
+    password = var.password
     type     = "ssh"
   }
 
@@ -114,13 +117,16 @@ resource "null_resource" "master_wait_cloudinit" {
 }
 
 resource "null_resource" "master_reboot" {
-  depends_on = ["null_resource.master_wait_cloudinit"]
-  count      = "${var.masters}"
+  depends_on = [null_resource.master_wait_cloudinit]
+  count      = var.masters
 
   provisioner "local-exec" {
     environment = {
-      user = "${var.username}"
-      host = "${element(libvirt_domain.master.*.network_interface.0.addresses.0, count.index)}"
+      user = var.username
+      host = element(
+        libvirt_domain.master.*.network_interface.0.addresses.0,
+        count.index,
+      )
     }
 
     command = <<EOT
@@ -129,5 +135,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo
 until nc -zv $host 22; do sleep 5; done
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
+
   }
 }
+

--- a/ci/infra/libvirt/network.tf
+++ b/ci/infra/libvirt/network.tf
@@ -1,11 +1,12 @@
 resource "libvirt_network" "network" {
   name   = "${var.stack_name}-network"
-  mode   = "${var.network_mode}"
-  domain = "${var.dns_domain}"
+  mode   = var.network_mode
+  domain = var.dns_domain
 
-  dns = {
+  dns {
     enabled = true
   }
 
-  addresses = ["${var.network_cidr}"]
+  addresses = [var.network_cidr]
 }
+

--- a/ci/infra/libvirt/output.tf
+++ b/ci/infra/libvirt/output.tf
@@ -1,11 +1,21 @@
 output "ip_load_balancer" {
-  value = "${zipmap(libvirt_domain.lb.*.network_interface.0.hostname, libvirt_domain.lb.*.network_interface.0.addresses.0)}"
+  value = zipmap(
+    libvirt_domain.lb.*.network_interface.0.hostname,
+    libvirt_domain.lb.*.network_interface.0.addresses.0,
+  )
 }
 
 output "ip_masters" {
-  value = "${zipmap(libvirt_domain.master.*.network_interface.0.hostname, libvirt_domain.master.*.network_interface.0.addresses.0)}"
+  value = zipmap(
+    libvirt_domain.master.*.network_interface.0.hostname,
+    libvirt_domain.master.*.network_interface.0.addresses.0,
+  )
 }
 
 output "ip_workers" {
-  value = "${zipmap(libvirt_domain.worker.*.network_interface.0.hostname, libvirt_domain.worker.*.network_interface.0.addresses.0)}"
+  value = zipmap(
+    libvirt_domain.worker.*.network_interface.0.hostname,
+    libvirt_domain.worker.*.network_interface.0.addresses.0,
+  )
 }
+

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -14,7 +14,7 @@ variable "image_uri" {
 }
 
 variable "repositories" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Urls of the repositories to mount via cloud-init"
 }
@@ -25,19 +25,19 @@ variable "stack_name" {
 }
 
 variable "authorized_keys" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "SSH keys to inject into all the nodes"
 }
 
 variable "ntp_servers" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of NTP servers to configure"
 }
 
 variable "packages" {
-  type = "list"
+  type = list(string)
 
   default = [
     "kernel-default",
@@ -78,19 +78,19 @@ variable "disk_size" {
 }
 
 variable "dns_domain" {
-  type        = "string"
+  type        = string
   default     = "caasp.local"
   description = "Name of DNS Domain"
 }
 
 variable "network_cidr" {
-  type        = "string"
+  type        = string
   default     = "10.17.0.0/22"
   description = "Network used by the cluster"
 }
 
 variable "network_mode" {
-  type        = "string"
+  type        = string
   default     = "nat"
   description = "Network mode used by the cluster"
 }
@@ -111,7 +111,7 @@ variable "lb_vcpu" {
 }
 
 variable "lb_repositories" {
-  type = "map"
+  type = map(string)
 
   default = {
     sle_server_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
@@ -152,3 +152,4 @@ variable "worker_vcpu" {
   default     = 2
   description = "Amount of virtual CPUs for a worker"
 }
+

--- a/ci/infra/libvirt/versions.tf
+++ b/ci/infra/libvirt/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -1,91 +1,91 @@
 data "template_file" "worker_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "worker_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "worker_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "worker_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "worker-cloud-init" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.worker_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
-    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
-    username        = "${var.username}"
-    password        = "${var.password}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.worker_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.worker_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.worker_register_rmt.*.rendered)
+    commands        = join("\n", data.template_file.worker_commands.*.rendered)
+    username        = var.username
+    password        = var.password
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "libvirt_volume" "worker" {
   name           = "${var.stack_name}-worker-volume-${count.index}"
-  pool           = "${var.pool}"
-  size           = "${var.disk_size}"
-  base_volume_id = "${libvirt_volume.img.id}"
-  count          = "${var.workers}"
+  pool           = var.pool
+  size           = var.disk_size
+  base_volume_id = libvirt_volume.img.id
+  count          = var.workers
 }
 
 resource "libvirt_cloudinit_disk" "worker" {
   # needed when 0 worker nodes are defined
-  count     = "${var.workers}"
+  count     = var.workers
   name      = "${var.stack_name}-worker-cloudinit-disk-${count.index}"
-  pool      = "${var.pool}"
-  user_data = "${data.template_file.worker-cloud-init.rendered}"
+  pool      = var.pool
+  user_data = data.template_file.worker-cloud-init.rendered
 }
 
 resource "libvirt_domain" "worker" {
-  count      = "${var.workers}"
+  count      = var.workers
   name       = "${var.stack_name}-worker-domain-${count.index}"
-  memory     = "${var.worker_memory}"
-  vcpu       = "${var.worker_vcpu}"
-  cloudinit  = "${element(libvirt_cloudinit_disk.worker.*.id, count.index)}"
-  depends_on = ["libvirt_domain.lb"]
+  memory     = var.worker_memory
+  vcpu       = var.worker_vcpu
+  cloudinit  = element(libvirt_cloudinit_disk.worker.*.id, count.index)
+  depends_on = [libvirt_domain.lb]
 
-  cpu {
+  cpu = {
     mode = "host-passthrough"
   }
 
   disk {
-    volume_id = "${element(libvirt_volume.worker.*.id, count.index)}"
+    volume_id = element(libvirt_volume.worker.*.id, count.index)
   }
 
   network_interface {
-    network_id     = "${libvirt_network.network.id}"
+    network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-worker-${count.index}"
-    addresses      = ["${cidrhost(var.network_cidr, 768 + count.index)}"]
+    addresses      = [cidrhost(var.network_cidr, 768 + count.index)]
     wait_for_lease = 1
   }
 
@@ -96,13 +96,16 @@ resource "libvirt_domain" "worker" {
 }
 
 resource "null_resource" "worker_wait_cloudinit" {
-  depends_on = ["libvirt_domain.worker"]
-  count      = "${var.workers}"
+  depends_on = [libvirt_domain.worker]
+  count      = var.workers
 
   connection {
-    host     = "${element(libvirt_domain.worker.*.network_interface.0.addresses.0, count.index)}"
-    user     = "${var.username}"
-    password = "${var.password}"
+    host = element(
+      libvirt_domain.worker.*.network_interface.0.addresses.0,
+      count.index,
+    )
+    user     = var.username
+    password = var.password
     type     = "ssh"
   }
 
@@ -114,13 +117,16 @@ resource "null_resource" "worker_wait_cloudinit" {
 }
 
 resource "null_resource" "worker_reboot" {
-  depends_on = ["null_resource.worker_wait_cloudinit"]
-  count      = "${var.workers}"
+  depends_on = [null_resource.worker_wait_cloudinit]
+  count      = var.workers
 
   provisioner "local-exec" {
     environment = {
-      user = "${var.username}"
-      host = "${element(libvirt_domain.worker.*.network_interface.0.addresses.0, count.index)}"
+      user = var.username
+      host = element(
+        libvirt_domain.worker.*.network_interface.0.addresses.0,
+        count.index,
+      )
     }
 
     command = <<EOT
@@ -129,5 +135,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo
 until nc -zv $host 22; do sleep 5; done
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
+
   }
 }
+

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -86,7 +86,7 @@ resource "libvirt_domain" "worker" {
     network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-worker-${count.index}"
     addresses      = [cidrhost(var.network_cidr, 768 + count.index)]
-    wait_for_lease = 1
+    wait_for_lease = true
   }
 
   graphics {

--- a/ci/infra/openstack/cloud-provider.tf
+++ b/ci/infra/openstack/cloud-provider.tf
@@ -1,19 +1,23 @@
 resource "null_resource" "generate_cloud_provider_conf" {
-  depends_on = ["null_resource.master_reboot", "null_resource.worker_reboot"]
-  count      = "${var.cpi_enable ? 1 : 0}"
+  depends_on = [
+    null_resource.master_reboot,
+    null_resource.worker_reboot,
+  ]
+  count = var.cpi_enable ? 1 : 0
 
   provisioner "local-exec" {
     environment = {
-      CA_FILE              = "${var.ca_file}"
-      TR_STACK             = "${var.stack_name}"
-      TR_USERNAME          = "${var.username}"
-      TR_LB_IP             = "${openstack_networking_floatingip_v2.lb_ext.address}"
-      TR_MASTER_IPS        = "${join(" ", openstack_networking_floatingip_v2.master_ext.*.address)}"
-      TR_WORKER_IPS        = "${join(" ", openstack_networking_floatingip_v2.worker_ext.*.address)}"
-      OS_PRIVATE_SUBNET_ID = "${openstack_networking_subnet_v2.subnet.id}"
-      OS_PUBLIC_NET_ID     = "${data.openstack_networking_network_v2.external_network.id}"
+      CA_FILE              = var.ca_file
+      TR_STACK             = var.stack_name
+      TR_USERNAME          = var.username
+      TR_LB_IP             = openstack_networking_floatingip_v2.lb_ext.address
+      TR_MASTER_IPS        = join(" ", openstack_networking_floatingip_v2.master_ext.*.address)
+      TR_WORKER_IPS        = join(" ", openstack_networking_floatingip_v2.worker_ext.*.address)
+      OS_PRIVATE_SUBNET_ID = openstack_networking_subnet_v2.subnet.id
+      OS_PUBLIC_NET_ID     = data.openstack_networking_network_v2.external_network.id
     }
 
     command = "bash generate-cpi-conf.sh"
   }
 }
+

--- a/ci/infra/openstack/dns.tf
+++ b/ci/infra/openstack/dns.tf
@@ -1,5 +1,5 @@
 resource "openstack_dns_zone_v2" "ag" {
-  count       = "${var.dnsentry ? 1 : 0}"
+  count       = var.dnsentry ? 1 : 0
   name        = "${var.dnsdomain}."
   email       = "email@example.com"
   description = "CAASP dns zone"
@@ -8,12 +8,23 @@ resource "openstack_dns_zone_v2" "ag" {
 }
 
 resource "openstack_dns_recordset_v2" "master" {
-  count       = "${var.dnsentry ? "${var.masters}" : 0}"
-  zone_id     = "${openstack_dns_zone_v2.ag.id}"
-  name        = "${format("%v.%v.", "${element(openstack_compute_instance_v2.master.*.name, count.index)}", "${var.dnsdomain}")}"
+  count   = var.dnsentry ? var.masters : 0
+  zone_id = openstack_dns_zone_v2.ag[0].id
+  name = format(
+    "%v.%v.",
+    element(openstack_compute_instance_v2.master.*.name, count.index),
+    var.dnsdomain,
+  )
   description = "master nodes A recordset"
   ttl         = 5
   type        = "A"
-  records     = ["${element(openstack_networking_floatingip_v2.master_ext.*.address, count.index)}"]
-  depends_on  = ["openstack_compute_instance_v2.master", "openstack_compute_floatingip_associate_v2.master_ext_ip"]
+  records = [element(
+    openstack_networking_floatingip_v2.master_ext.*.address,
+    count.index,
+  )]
+  depends_on = [
+    openstack_compute_instance_v2.master,
+    openstack_compute_floatingip_associate_v2.master_ext_ip,
+  ]
 }
+

--- a/ci/infra/openstack/load-balancer.tf
+++ b/ci/infra/openstack/load-balancer.tf
@@ -1,30 +1,30 @@
 resource "openstack_lb_loadbalancer_v2" "lb" {
   name          = "${var.stack_name}-lb"
-  vip_subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+  vip_subnet_id = openstack_networking_subnet_v2.subnet.id
 
   security_group_ids = [
-    "${openstack_networking_secgroup_v2.load_balancer.id}",
+    openstack_networking_secgroup_v2.load_balancer.id,
   ]
 }
 
 resource "openstack_lb_listener_v2" "kube_api_listener" {
   protocol        = "TCP"
   protocol_port   = "6443"
-  loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
+  loadbalancer_id = openstack_lb_loadbalancer_v2.lb.id
   name            = "${var.stack_name}-kube-api-listener"
 }
 
 resource "openstack_lb_listener_v2" "gangway_listener" {
   protocol        = "TCP"
   protocol_port   = "32001"
-  loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
+  loadbalancer_id = openstack_lb_loadbalancer_v2.lb.id
   name            = "${var.stack_name}-gangway-listener"
 }
 
 resource "openstack_lb_listener_v2" "dex_listener" {
   protocol        = "TCP"
   protocol_port   = "32000"
-  loadbalancer_id = "${openstack_lb_loadbalancer_v2.lb.id}"
+  loadbalancer_id = openstack_lb_loadbalancer_v2.lb.id
   name            = "${var.stack_name}-dex-listener"
 }
 
@@ -32,54 +32,63 @@ resource "openstack_lb_pool_v2" "kube_api_pool" {
   name        = "${var.stack_name}-kube-api-pool"
   protocol    = "TCP"
   lb_method   = "ROUND_ROBIN"
-  listener_id = "${openstack_lb_listener_v2.kube_api_listener.id}"
+  listener_id = openstack_lb_listener_v2.kube_api_listener.id
 }
 
 resource "openstack_lb_pool_v2" "gangway_pool" {
   name        = "${var.stack_name}-gangway-pool"
   protocol    = "TCP"
   lb_method   = "ROUND_ROBIN"
-  listener_id = "${openstack_lb_listener_v2.gangway_listener.id}"
+  listener_id = openstack_lb_listener_v2.gangway_listener.id
 }
 
 resource "openstack_lb_pool_v2" "dex_pool" {
   name        = "${var.stack_name}-dex-pool"
   protocol    = "TCP"
   lb_method   = "ROUND_ROBIN"
-  listener_id = "${openstack_lb_listener_v2.dex_listener.id}"
+  listener_id = openstack_lb_listener_v2.dex_listener.id
 }
 
 resource "openstack_lb_member_v2" "kube_api_member" {
-  count         = "${var.masters}"
-  pool_id       = "${openstack_lb_pool_v2.kube_api_pool.id}"
-  address       = "${element(openstack_compute_instance_v2.master.*.access_ip_v4, count.index)}"
-  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  count   = var.masters
+  pool_id = openstack_lb_pool_v2.kube_api_pool.id
+  address = element(
+    openstack_compute_instance_v2.master.*.access_ip_v4,
+    count.index,
+  )
+  subnet_id     = openstack_networking_subnet_v2.subnet.id
   protocol_port = 6443
 }
 
 resource "openstack_lb_member_v2" "gangway_member" {
-  count         = "${var.masters}"
-  pool_id       = "${openstack_lb_pool_v2.gangway_pool.id}"
-  address       = "${element(openstack_compute_instance_v2.master.*.access_ip_v4, count.index)}"
-  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  count   = var.masters
+  pool_id = openstack_lb_pool_v2.gangway_pool.id
+  address = element(
+    openstack_compute_instance_v2.master.*.access_ip_v4,
+    count.index,
+  )
+  subnet_id     = openstack_networking_subnet_v2.subnet.id
   protocol_port = 32001
 }
 
 resource "openstack_lb_member_v2" "dex_member" {
-  count         = "${var.masters}"
-  pool_id       = "${openstack_lb_pool_v2.dex_pool.id}"
-  address       = "${element(openstack_compute_instance_v2.master.*.access_ip_v4, count.index)}"
-  subnet_id     = "${openstack_networking_subnet_v2.subnet.id}"
+  count   = var.masters
+  pool_id = openstack_lb_pool_v2.dex_pool.id
+  address = element(
+    openstack_compute_instance_v2.master.*.access_ip_v4,
+    count.index,
+  )
+  subnet_id     = openstack_networking_subnet_v2.subnet.id
   protocol_port = 32000
 }
 
 resource "openstack_networking_floatingip_v2" "lb_ext" {
-  pool    = "${var.external_net}"
-  port_id = "${openstack_lb_loadbalancer_v2.lb.vip_port_id}"
+  pool    = var.external_net
+  port_id = openstack_lb_loadbalancer_v2.lb.vip_port_id
 }
 
 resource "openstack_lb_monitor_v2" "kube_api_monitor" {
-  pool_id        = "${openstack_lb_pool_v2.kube_api_pool.id}"
+  pool_id        = openstack_lb_pool_v2.kube_api_pool.id
   type           = "HTTPS"
   url_path       = "/healthz"
   expected_codes = 200
@@ -89,7 +98,7 @@ resource "openstack_lb_monitor_v2" "kube_api_monitor" {
 }
 
 resource "openstack_lb_monitor_v2" "gangway_monitor" {
-  pool_id        = "${openstack_lb_pool_v2.gangway_pool.id}"
+  pool_id        = openstack_lb_pool_v2.gangway_pool.id
   type           = "HTTPS"
   url_path       = "/"
   expected_codes = 200
@@ -99,7 +108,7 @@ resource "openstack_lb_monitor_v2" "gangway_monitor" {
 }
 
 resource "openstack_lb_monitor_v2" "dex_monitor" {
-  pool_id        = "${openstack_lb_pool_v2.dex_pool.id}"
+  pool_id        = openstack_lb_pool_v2.dex_pool.id
   type           = "HTTPS"
   url_path       = "/healthz"
   expected_codes = 200
@@ -107,3 +116,4 @@ resource "openstack_lb_monitor_v2" "dex_monitor" {
   timeout        = 1
   max_retries    = 3
 }
+

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -1,97 +1,103 @@
 data "template_file" "master_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "master_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "master_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "master_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "master-cloud-init" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.master_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
-    commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
-    username        = "${var.username}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.master_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.master_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.master_register_rmt.*.rendered)
+    commands        = join("\n", data.template_file.master_commands.*.rendered)
+    username        = var.username
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "openstack_compute_instance_v2" "master" {
-  count      = "${var.masters}"
+  count      = var.masters
   name       = "caasp-master-${var.stack_name}-${count.index}"
-  image_name = "${var.image_name}"
-  key_pair   = "${var.key_pair}"
+  image_name = var.image_name
+  key_pair   = var.key_pair
 
   depends_on = [
-    "openstack_networking_network_v2.network",
-    "openstack_networking_subnet_v2.subnet",
+    openstack_networking_network_v2.network,
+    openstack_networking_subnet_v2.subnet,
   ]
 
-  flavor_name = "${var.master_size}"
+  flavor_name = var.master_size
 
   network {
-    name = "${var.internal_net}"
+    name = var.internal_net
   }
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.common.name}",
-    "${openstack_networking_secgroup_v2.master_nodes.name}",
+    openstack_networking_secgroup_v2.common.name,
+    openstack_networking_secgroup_v2.master_nodes.name,
   ]
 
-  user_data = "${data.template_file.master-cloud-init.rendered}"
+  user_data = data.template_file.master-cloud-init.rendered
 }
 
 resource "openstack_networking_floatingip_v2" "master_ext" {
-  count = "${var.masters}"
-  pool  = "${var.external_net}"
+  count = var.masters
+  pool  = var.external_net
 }
 
 resource "openstack_compute_floatingip_associate_v2" "master_ext_ip" {
-  count       = "${var.masters}"
-  floating_ip = "${element(openstack_networking_floatingip_v2.master_ext.*.address, count.index)}"
-  instance_id = "${element(openstack_compute_instance_v2.master.*.id, count.index)}"
+  count = var.masters
+  floating_ip = element(
+    openstack_networking_floatingip_v2.master_ext.*.address,
+    count.index,
+  )
+  instance_id = element(openstack_compute_instance_v2.master.*.id, count.index)
 }
 
 resource "null_resource" "master_wait_cloudinit" {
-  depends_on = ["openstack_compute_instance_v2.master"]
-  count      = "${var.masters}"
+  depends_on = [openstack_compute_instance_v2.master]
+  count      = var.masters
 
   connection {
-    host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
-    user = "${var.username}"
+    host = element(
+      openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip,
+      count.index,
+    )
+    user = var.username
     type = "ssh"
   }
 
@@ -103,13 +109,16 @@ resource "null_resource" "master_wait_cloudinit" {
 }
 
 resource "null_resource" "master_reboot" {
-  depends_on = ["null_resource.master_wait_cloudinit"]
-  count      = "${var.masters}"
+  depends_on = [null_resource.master_wait_cloudinit]
+  count      = var.masters
 
   provisioner "local-exec" {
     environment = {
-      user = "${var.username}"
-      host = "${element(openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip, count.index)}"
+      user = var.username
+      host = element(
+        openstack_compute_floatingip_associate_v2.master_ext_ip.*.floating_ip,
+        count.index,
+      )
     }
 
     command = <<EOT
@@ -117,5 +126,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo
 # wait for ssh ready after reboot
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
+
   }
 }
+

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -80,6 +80,7 @@ resource "openstack_networking_floatingip_v2" "master_ext" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "master_ext_ip" {
+  depends_on = [openstack_compute_instance_v2.master]
   count = var.masters
   floating_ip = element(
     openstack_networking_floatingip_v2.master_ext.*.address,
@@ -89,7 +90,10 @@ resource "openstack_compute_floatingip_associate_v2" "master_ext_ip" {
 }
 
 resource "null_resource" "master_wait_cloudinit" {
-  depends_on = [openstack_compute_instance_v2.master]
+  depends_on = [
+    openstack_compute_instance_v2.master,
+    openstack_compute_floatingip_associate_v2.master_ext_ip
+  ]
   count      = var.masters
 
   connection {

--- a/ci/infra/openstack/network.tf
+++ b/ci/infra/openstack/network.tf
@@ -1,25 +1,26 @@
 resource "openstack_networking_network_v2" "network" {
-  name           = "${var.internal_net}"
+  name           = var.internal_net
   admin_state_up = "true"
 }
 
 resource "openstack_networking_subnet_v2" "subnet" {
-  name       = "${var.internal_subnet == "" ? "${var.internal_net}-subnet" : "${var.internal_subnet}"}"
-  network_id = "${openstack_networking_network_v2.network.id}"
-  cidr       = "${var.subnet_cidr}"
+  name       = var.internal_subnet == "" ? "${var.internal_net}-subnet" : var.internal_subnet
+  network_id = openstack_networking_network_v2.network.id
+  cidr       = var.subnet_cidr
   ip_version = 4
 }
 
 data "openstack_networking_network_v2" "external_network" {
-  name = "${var.external_net}"
+  name = var.external_net
 }
 
 resource "openstack_networking_router_v2" "router" {
-  name                = "${var.internal_router == "" ? "${var.internal_net}-router" : "${var.internal_router}"}"
-  external_network_id = "${data.openstack_networking_network_v2.external_network.id}"
+  name                = var.internal_router == "" ? "${var.internal_net}-router" : var.internal_router
+  external_network_id = data.openstack_networking_network_v2.external_network.id
 }
 
 resource "openstack_networking_router_interface_v2" "router_interface" {
-  router_id = "${openstack_networking_router_v2.router.id}"
-  subnet_id = "${openstack_networking_subnet_v2.subnet.id}"
+  router_id = openstack_networking_router_v2.router.id
+  subnet_id = openstack_networking_subnet_v2.subnet.id
 }
+

--- a/ci/infra/openstack/output.tf
+++ b/ci/infra/openstack/output.tf
@@ -1,19 +1,20 @@
 output "hostnames_masters" {
-  value = "${openstack_dns_recordset_v2.master.*.name}"
+  value = openstack_dns_recordset_v2.master.*.name
 }
 
 output "ip_masters" {
-  value = ["${openstack_networking_floatingip_v2.master_ext.*.address}"]
+  value = [openstack_networking_floatingip_v2.master_ext.*.address]
 }
 
 output "ip_workers" {
-  value = ["${openstack_networking_floatingip_v2.worker_ext.*.address}"]
+  value = [openstack_networking_floatingip_v2.worker_ext.*.address]
 }
 
 output "ip_internal_load_balancer" {
-  value = "${openstack_lb_loadbalancer_v2.lb.vip_address}"
+  value = openstack_lb_loadbalancer_v2.lb.vip_address
 }
 
 output "ip_load_balancer" {
-  value = "${openstack_networking_floatingip_v2.lb_ext.address}"
+  value = openstack_networking_floatingip_v2.lb_ext.address
 }
+

--- a/ci/infra/openstack/security-groups-common.tf
+++ b/ci/infra/openstack/security-groups-common.tf
@@ -11,7 +11,7 @@ resource "openstack_networking_secgroup_rule_v2" "icmp" {
   port_range_min    = 0
   port_range_max    = 0
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ssh" {
@@ -21,7 +21,7 @@ resource "openstack_networking_secgroup_rule_v2" "ssh" {
   port_range_min    = 22
   port_range_max    = 22
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "cilium_health_check" {
@@ -30,8 +30,8 @@ resource "openstack_networking_secgroup_rule_v2" "cilium_health_check" {
   protocol          = "tcp"
   port_range_min    = 4240
   port_range_max    = 4240
-  remote_ip_prefix  = "${var.subnet_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  remote_ip_prefix  = var.subnet_cidr
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "cilium_vxlan" {
@@ -40,8 +40,8 @@ resource "openstack_networking_secgroup_rule_v2" "cilium_vxlan" {
   protocol          = "udp"
   port_range_min    = 8472
   port_range_max    = 8472
-  remote_ip_prefix  = "${var.subnet_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  remote_ip_prefix  = var.subnet_cidr
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "api_server_to_kubelet_communication" {
@@ -50,8 +50,8 @@ resource "openstack_networking_secgroup_rule_v2" "api_server_to_kubelet_communic
   protocol          = "tcp"
   port_range_min    = 10250
   port_range_max    = 10250
-  remote_ip_prefix  = "${var.subnet_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  remote_ip_prefix  = var.subnet_cidr
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "kubeproxy_health_check" {
@@ -60,8 +60,8 @@ resource "openstack_networking_secgroup_rule_v2" "kubeproxy_health_check" {
   protocol          = "tcp"
   port_range_min    = 10256
   port_range_max    = 10256
-  remote_ip_prefix  = "${var.subnet_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  remote_ip_prefix  = var.subnet_cidr
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 # Range of ports used by kubernetes when allocating services of type `NodePort`
@@ -72,7 +72,7 @@ resource "openstack_networking_secgroup_rule_v2" "kubernetes_services_tcp" {
   port_range_min    = 30000
   port_range_max    = 32767
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "kubernetes_services_udp" {
@@ -82,5 +82,6 @@ resource "openstack_networking_secgroup_rule_v2" "kubernetes_services_udp" {
   port_range_min    = 30000
   port_range_max    = 32767
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.common.id}"
+  security_group_id = openstack_networking_secgroup_v2.common.id
 }
+

--- a/ci/infra/openstack/security-groups-load-balancer.tf
+++ b/ci/infra/openstack/security-groups-load-balancer.tf
@@ -10,7 +10,7 @@ resource "openstack_networking_secgroup_rule_v2" "lb_api_server" {
   port_range_min    = 6443
   port_range_max    = 6443
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.load_balancer.id}"
+  security_group_id = openstack_networking_secgroup_v2.load_balancer.id
 }
 
 # Needed to allow access from the LB to dex (32000) and gangway (32001)
@@ -21,5 +21,6 @@ resource "openstack_networking_secgroup_rule_v2" "lb_k8s_auth_svcs" {
   port_range_min    = 32000
   port_range_max    = 32001
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.load_balancer.id}"
+  security_group_id = openstack_networking_secgroup_v2.load_balancer.id
 }
+

--- a/ci/infra/openstack/security-groups-master.tf
+++ b/ci/infra/openstack/security-groups-master.tf
@@ -9,8 +9,8 @@ resource "openstack_networking_secgroup_rule_v2" "etcd_client_communication" {
   protocol          = "tcp"
   port_range_min    = 2379
   port_range_max    = 2379
-  remote_ip_prefix  = "${var.subnet_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.master_nodes.id}"
+  remote_ip_prefix  = var.subnet_cidr
+  security_group_id = openstack_networking_secgroup_v2.master_nodes.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "etcd_server_to_server" {
@@ -19,8 +19,8 @@ resource "openstack_networking_secgroup_rule_v2" "etcd_server_to_server" {
   protocol          = "tcp"
   port_range_min    = 2380
   port_range_max    = 2380
-  remote_ip_prefix  = "${var.subnet_cidr}"
-  security_group_id = "${openstack_networking_secgroup_v2.master_nodes.id}"
+  remote_ip_prefix  = var.subnet_cidr
+  security_group_id = openstack_networking_secgroup_v2.master_nodes.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "api_server" {
@@ -30,5 +30,6 @@ resource "openstack_networking_secgroup_rule_v2" "api_server" {
   port_range_min    = 6443
   port_range_max    = 6443
   remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = "${openstack_networking_secgroup_v2.master_nodes.id}"
+  security_group_id = openstack_networking_secgroup_v2.master_nodes.id
 }
+

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -55,7 +55,7 @@ variable "workers" {
 }
 
 variable "workers_vol_enabled" {
-  default     = 0
+  default     = false
   description = "Attach persistent volumes to workers"
 }
 
@@ -70,7 +70,7 @@ variable "dnsdomain" {
 }
 
 variable "dnsentry" {
-  default     = 0
+  default     = false
   description = "DNS Entry"
 }
 
@@ -110,6 +110,11 @@ variable "packages" {
 variable "username" {
   default     = "sles"
   description = "Default user for the cluster nodes created by cloud-init default configuration for all SUSE SLES systems"
+}
+
+variable "password" {
+  default     = "sles"
+  description = "Default password for the cluster nodes created by cloud-init default configuration for all SUSE SLES systems"
 }
 
 variable "caasp_registry_code" {

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -4,7 +4,7 @@ variable "image_name" {
 }
 
 variable "repositories" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Urls of the repositories to mount via cloud-init"
 }
@@ -80,7 +80,7 @@ variable "stack_name" {
 }
 
 variable "authorized_keys" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "SSH keys to inject into all the nodes"
 }
@@ -91,13 +91,13 @@ variable "key_pair" {
 }
 
 variable "ntp_servers" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of ntp servers to configure"
 }
 
 variable "packages" {
-  type = "list"
+  type = list(string)
 
   default = [
     "kernel-default",
@@ -131,3 +131,4 @@ variable "ca_file" {
   default     = ""
   description = "Used to specify the path to your custom CA file"
 }
+

--- a/ci/infra/openstack/versions.tf
+++ b/ci/infra/openstack/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -1,108 +1,117 @@
 data "template_file" "worker_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "worker_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "worker_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "worker_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "worker-cloud-init" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.worker_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
-    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
-    username        = "${var.username}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.worker_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.worker_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.worker_register_rmt.*.rendered)
+    commands        = join("\n", data.template_file.worker_commands.*.rendered)
+    username        = var.username
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "openstack_blockstorage_volume_v2" "worker_vol" {
-  count = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
-  size  = "${var.workers_vol_size}"
+  count = var.workers_vol_enabled ? var.workers : 0
+  size  = var.workers_vol_size
   name  = "vol_${element(openstack_compute_instance_v2.worker.*.name, count.index)}"
 }
 
 resource "openstack_compute_volume_attach_v2" "worker_vol_attach" {
-  count       = "${var.workers_vol_enabled ? "${var.workers}" : 0 }"
-  instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
-  volume_id   = "${element(openstack_blockstorage_volume_v2.worker_vol.*.id, count.index)}"
+  count       = var.workers_vol_enabled ? var.workers : 0
+  instance_id = element(openstack_compute_instance_v2.worker.*.id, count.index)
+  volume_id = element(
+    openstack_blockstorage_volume_v2.worker_vol.*.id,
+    count.index,
+  )
 }
 
 resource "openstack_compute_instance_v2" "worker" {
-  count      = "${var.workers}"
+  count      = var.workers
   name       = "caasp-worker-${var.stack_name}-${count.index}"
-  image_name = "${var.image_name}"
-  key_pair   = "${var.key_pair}"
+  image_name = var.image_name
+  key_pair   = var.key_pair
 
   depends_on = [
-    "openstack_networking_network_v2.network",
-    "openstack_networking_subnet_v2.subnet",
+    openstack_networking_network_v2.network,
+    openstack_networking_subnet_v2.subnet,
   ]
 
-  flavor_name = "${var.worker_size}"
+  flavor_name = var.worker_size
 
   network {
-    name = "${var.internal_net}"
+    name = var.internal_net
   }
 
   security_groups = [
-    "${openstack_networking_secgroup_v2.common.name}",
+    openstack_networking_secgroup_v2.common.name,
   ]
 
-  user_data = "${data.template_file.worker-cloud-init.rendered}"
+  user_data = data.template_file.worker-cloud-init.rendered
 }
 
 resource "openstack_networking_floatingip_v2" "worker_ext" {
-  count = "${var.workers}"
-  pool  = "${var.external_net}"
+  count = var.workers
+  pool  = var.external_net
 }
 
 resource "openstack_compute_floatingip_associate_v2" "worker_ext_ip" {
-  count       = "${var.workers}"
-  floating_ip = "${element(openstack_networking_floatingip_v2.worker_ext.*.address, count.index)}"
-  instance_id = "${element(openstack_compute_instance_v2.worker.*.id, count.index)}"
+  count = var.workers
+  floating_ip = element(
+    openstack_networking_floatingip_v2.worker_ext.*.address,
+    count.index,
+  )
+  instance_id = element(openstack_compute_instance_v2.worker.*.id, count.index)
 }
 
 resource "null_resource" "worker_wait_cloudinit" {
-  depends_on = ["openstack_compute_instance_v2.worker"]
-  count      = "${var.workers}"
+  depends_on = [openstack_compute_instance_v2.worker]
+  count      = var.workers
 
   connection {
-    host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
-    user = "${var.username}"
+    host = element(
+      openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip,
+      count.index,
+    )
+    user = var.username
     type = "ssh"
   }
 
@@ -114,13 +123,16 @@ resource "null_resource" "worker_wait_cloudinit" {
 }
 
 resource "null_resource" "worker_reboot" {
-  depends_on = ["null_resource.worker_wait_cloudinit"]
-  count      = "${var.workers}"
+  depends_on = [null_resource.worker_wait_cloudinit]
+  count      = var.workers
 
   provisioner "local-exec" {
     environment = {
-      user = "${var.username}"
-      host = "${element(openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip, count.index)}"
+      user = var.username
+      host = element(
+        openstack_compute_floatingip_associate_v2.worker_ext_ip.*.floating_ip,
+        count.index,
+      )
     }
 
     command = <<EOT
@@ -128,5 +140,7 @@ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo
 # wait for ssh ready after reboot
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
+
   }
 }
+

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -94,6 +94,7 @@ resource "openstack_networking_floatingip_v2" "worker_ext" {
 }
 
 resource "openstack_compute_floatingip_associate_v2" "worker_ext_ip" {
+  depends_on = [openstack_compute_instance_v2.worker]
   count = var.workers
   floating_ip = element(
     openstack_networking_floatingip_v2.worker_ext.*.address,
@@ -103,7 +104,10 @@ resource "openstack_compute_floatingip_associate_v2" "worker_ext_ip" {
 }
 
 resource "null_resource" "worker_wait_cloudinit" {
-  depends_on = [openstack_compute_instance_v2.worker]
+  depends_on = [
+    openstack_compute_instance_v2.worker,
+    openstack_compute_floatingip_associate_v2.worker_ext_ip,
+  ]
   count      = var.workers
 
   connection {

--- a/ci/infra/vmware/cloud-init.tf
+++ b/ci/infra/vmware/cloud-init.tf
@@ -1,3 +1,4 @@
 data "local_file" "network_cloud_init" {
   filename = "cloud-init/network-config.tpl"
 }
+

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -19,7 +19,7 @@ variable "lb_disk_size" {
 }
 
 variable "lb_repositories" {
-  type = "map"
+  type = map(string)
 
   default = {
     sle_server_pool    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
@@ -32,131 +32,143 @@ variable "lb_repositories" {
 }
 
 data "template_file" "lb_repositories_template" {
-  count    = "${length(var.lb_repositories)}"
-  template = "${file("cloud-init/repository.tpl")}"
+  count    = length(var.lb_repositories)
+  template = file("cloud-init/repository.tpl")
 
-  vars {
-    repository_url  = "${element(values(var.lb_repositories), count.index)}"
-    repository_name = "${element(keys(var.lb_repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.lb_repositories), count.index)
+    repository_name = element(keys(var.lb_repositories), count.index)
   }
 }
 
 data "template_file" "haproxy_apiserver_backends_master" {
-  count    = "${var.masters}"
+  count    = var.masters
   template = "server $${fqdn} $${ip}:6443\n"
 
   vars = {
-    fqdn = "${element(vsphere_virtual_machine.master.*.name, count.index)}"
-    ip   = "${element(vsphere_virtual_machine.master.*.default_ip_address, count.index)}"
+    fqdn = element(vsphere_virtual_machine.master.*.name, count.index)
+    ip = element(
+      vsphere_virtual_machine.master.*.default_ip_address,
+      count.index,
+    )
   }
 
-  depends_on = [
-    "vsphere_virtual_machine.master",
-  ]
+  depends_on = [vsphere_virtual_machine.master]
 }
 
 data "template_file" "haproxy_gangway_backends_master" {
-  count    = "${var.masters}"
+  count    = var.masters
   template = "server $${fqdn} $${ip}:32001\n"
 
   vars = {
-    fqdn = "${element(vsphere_virtual_machine.master.*.name, count.index)}"
-    ip   = "${element(vsphere_virtual_machine.master.*.default_ip_address, count.index)}"
+    fqdn = element(vsphere_virtual_machine.master.*.name, count.index)
+    ip = element(
+      vsphere_virtual_machine.master.*.default_ip_address,
+      count.index,
+    )
   }
 
-  depends_on = [
-    "vsphere_virtual_machine.master",
-  ]
+  depends_on = [vsphere_virtual_machine.master]
 }
 
 data "template_file" "haproxy_dex_backends_master" {
-  count    = "${var.masters}"
+  count    = var.masters
   template = "server $${fqdn} $${ip}:32000\n"
 
   vars = {
-    fqdn = "${element(vsphere_virtual_machine.master.*.name, count.index)}"
-    ip   = "${element(vsphere_virtual_machine.master.*.default_ip_address, count.index)}"
+    fqdn = element(vsphere_virtual_machine.master.*.name, count.index)
+    ip = element(
+      vsphere_virtual_machine.master.*.default_ip_address,
+      count.index,
+    )
   }
 
-  depends_on = [
-    "vsphere_virtual_machine.master",
-  ]
+  depends_on = [vsphere_virtual_machine.master]
 }
 
 data "template_file" "lb_cloud_init_metadata" {
-  template = "${file("cloud-init/metadata.tpl")}"
+  template = file("cloud-init/metadata.tpl")
 
-  vars {
-    network_config = "${base64gzip(data.local_file.network_cloud_init.content)}"
+  vars = {
+    network_config = base64gzip(data.local_file.network_cloud_init.content)
     instance_id    = "${var.stack_name}-lb"
   }
 }
 
 data "template_file" "lb_haproxy_cfg" {
-  template = "${file("cloud-init/haproxy.cfg.tpl")}"
+  template = file("cloud-init/haproxy.cfg.tpl")
 
-  vars {
-    apiserver_backends = "${join("  ", data.template_file.haproxy_apiserver_backends_master.*.rendered)}"
-    gangway_backends   = "${join("  ", data.template_file.haproxy_gangway_backends_master.*.rendered)}"
-    dex_backends       = "${join("  ", data.template_file.haproxy_dex_backends_master.*.rendered)}"
+  vars = {
+    apiserver_backends = join(
+      "  ",
+      data.template_file.haproxy_apiserver_backends_master.*.rendered,
+    )
+    gangway_backends = join(
+      "  ",
+      data.template_file.haproxy_gangway_backends_master.*.rendered,
+    )
+    dex_backends = join(
+      "  ",
+      data.template_file.haproxy_dex_backends_master.*.rendered,
+    )
   }
 }
 
 data "template_file" "lb_cloud_init_userdata" {
-  template = "${file("cloud-init/lb.tpl")}"
+  template = file("cloud-init/lb.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.lb_repositories_template.*.rendered)}"
-    packages        = "${join("\n", formatlist("  - %s", var.packages))}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.lb_repositories_template.*.rendered)
+    packages        = join("\n", formatlist("  - %s", var.packages))
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "vsphere_virtual_machine" "lb" {
-  count            = "${var.lbs}"
+  count            = var.lbs
   name             = "${var.stack_name}-lb-${count.index}"
-  num_cpus         = "${var.lb_cpus}"
-  memory           = "${var.lb_memory}"
-  guest_id         = "${var.guest_id}"
-  firmware         = "${var.firmware}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  num_cpus         = var.lb_cpus
+  memory           = var.lb_memory
+  guest_id         = var.guest_id
+  firmware         = var.firmware
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
+  resource_pool_id = data.vsphere_resource_pool.pool.id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
   }
 
   disk {
     label = "disk0"
-    size  = "${var.lb_disk_size}"
+    size  = var.lb_disk_size
   }
 
-  extra_config {
-    "guestinfo.metadata"          = "${base64gzip(data.template_file.lb_cloud_init_metadata.rendered)}"
+  extra_config = {
+    "guestinfo.metadata"          = base64gzip(data.template_file.lb_cloud_init_metadata.rendered)
     "guestinfo.metadata.encoding" = "gzip+base64"
-
-    "guestinfo.userdata"          = "${base64gzip(data.template_file.lb_cloud_init_userdata.rendered)}"
+    "guestinfo.userdata"          = base64gzip(data.template_file.lb_cloud_init_userdata.rendered)
     "guestinfo.userdata.encoding" = "gzip+base64"
   }
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 
-  depends_on = [
-    "vsphere_virtual_machine.master",
-  ]
+  depends_on = [vsphere_virtual_machine.master]
 }
 
 resource "null_resource" "lb_wait_cloudinit" {
-  depends_on = ["vsphere_virtual_machine.lb"]
-  count      = "${var.lbs}"
+  depends_on = [vsphere_virtual_machine.lb]
+  count      = var.lbs
 
   connection {
-    host  = "${element(vsphere_virtual_machine.lb.*.guest_ip_addresses.0, count.index)}"
-    user  = "${var.username}"
+    host = element(
+      vsphere_virtual_machine.lb.*.guest_ip_addresses.0,
+      count.index,
+    )
+    user  = var.username
     type  = "ssh"
     agent = true
   }
@@ -169,22 +181,25 @@ resource "null_resource" "lb_wait_cloudinit" {
 }
 
 resource "null_resource" "lb_push_haproxy_cfg" {
-  depends_on = ["null_resource.lb_wait_cloudinit"]
-  count      = "${var.lbs}"
+  depends_on = [null_resource.lb_wait_cloudinit]
+  count      = var.lbs
 
   triggers = {
-    master_count = "${var.masters}"
+    master_count = var.masters
   }
 
   connection {
-    host  = "${element(vsphere_virtual_machine.lb.*.guest_ip_addresses.0, count.index)}"
-    user  = "${var.username}"
+    host = element(
+      vsphere_virtual_machine.lb.*.guest_ip_addresses.0,
+      count.index,
+    )
+    user  = var.username
     type  = "ssh"
     agent = true
   }
 
   provisioner "file" {
-    content     = "${data.template_file.lb_haproxy_cfg.rendered}"
+    content     = data.template_file.lb_haproxy_cfg.rendered
     destination = "/tmp/haproxy.cfg"
   }
 
@@ -195,3 +210,4 @@ resource "null_resource" "lb_push_haproxy_cfg" {
     ]
   }
 }
+

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -1,101 +1,103 @@
 data "template_file" "master_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "master_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "master_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "master_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "master_cloud_init_metadata" {
-  template = "${file("cloud-init/metadata.tpl")}"
+  template = file("cloud-init/metadata.tpl")
 
-  vars {
-    network_config = "${base64gzip(data.local_file.network_cloud_init.content)}"
+  vars = {
+    network_config = base64gzip(data.local_file.network_cloud_init.content)
     instance_id    = "${var.stack_name}-master"
   }
 }
 
 data "template_file" "master_cloud_init_userdata" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.master_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.master_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.master_register_rmt.*.rendered)}"
-    commands        = "${join("\n", data.template_file.master_commands.*.rendered)}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.master_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.master_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.master_register_rmt.*.rendered)
+    commands        = join("\n", data.template_file.master_commands.*.rendered)
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "vsphere_virtual_machine" "master" {
-  count            = "${var.masters}"
+  count            = var.masters
   name             = "${var.stack_name}-master-${count.index}"
-  num_cpus         = "${var.master_cpus}"
-  memory           = "${var.master_memory}"
-  guest_id         = "${var.guest_id}"
-  firmware         = "${var.firmware}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  num_cpus         = var.master_cpus
+  memory           = var.master_memory
+  guest_id         = var.guest_id
+  firmware         = var.firmware
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
+  resource_pool_id = data.vsphere_resource_pool.pool.id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
   }
 
   disk {
     label = "disk0"
-    size  = "${var.master_disk_size}"
+    size  = var.master_disk_size
   }
 
-  extra_config {
-    "guestinfo.metadata"          = "${base64gzip(data.template_file.master_cloud_init_metadata.rendered)}"
+  extra_config = {
+    "guestinfo.metadata"          = base64gzip(data.template_file.master_cloud_init_metadata.rendered)
     "guestinfo.metadata.encoding" = "gzip+base64"
-
-    "guestinfo.userdata"          = "${base64gzip(data.template_file.master_cloud_init_userdata.rendered)}"
+    "guestinfo.userdata"          = base64gzip(data.template_file.master_cloud_init_userdata.rendered)
     "guestinfo.userdata.encoding" = "gzip+base64"
   }
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 }
 
 resource "null_resource" "master_wait_cloudinit" {
-  count = "${var.masters}"
+  count = var.masters
 
   connection {
-    host  = "${element(vsphere_virtual_machine.master.*.guest_ip_addresses.0, count.index)}"
-    user  = "${var.username}"
+    host = element(
+      vsphere_virtual_machine.master.*.guest_ip_addresses.0,
+      count.index,
+    )
+    user  = var.username
     type  = "ssh"
     agent = true
   }
@@ -106,3 +108,4 @@ resource "null_resource" "master_wait_cloudinit" {
     ]
   }
 }
+

--- a/ci/infra/vmware/output.tf
+++ b/ci/infra/vmware/output.tf
@@ -1,11 +1,12 @@
 output "ip_masters" {
-  value = ["${vsphere_virtual_machine.master.*.default_ip_address}"]
+  value = [vsphere_virtual_machine.master.*.default_ip_address]
 }
 
 output "ip_workers" {
-  value = ["${vsphere_virtual_machine.worker.*.default_ip_address}"]
+  value = [vsphere_virtual_machine.worker.*.default_ip_address]
 }
 
 output "ip_load_balancer" {
-  value = ["${vsphere_virtual_machine.lb.*.default_ip_address}"]
+  value = [vsphere_virtual_machine.lb.*.default_ip_address]
 }
+

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -1,12 +1,23 @@
-variable "template_name" {}
-variable "stack_name" {}
-variable "vsphere_datastore" {}
-variable "vsphere_datacenter" {}
-variable "vsphere_network" {}
-variable "vsphere_resource_pool" {}
+variable "template_name" {
+}
+
+variable "stack_name" {
+}
+
+variable "vsphere_datastore" {
+}
+
+variable "vsphere_datacenter" {
+}
+
+variable "vsphere_network" {
+}
+
+variable "vsphere_resource_pool" {
+}
 
 variable "authorized_keys" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "SSH keys to inject into all the nodes"
 }
@@ -27,19 +38,19 @@ variable "guest_id" {
 }
 
 variable "ntp_servers" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of ntp servers to configure"
 }
 
 variable "packages" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of additional packages to install"
 }
 
 variable "repositories" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "URLs of the repositories to mount via cloud-init"
 }
@@ -96,28 +107,30 @@ variable "master_disk_size" {
 
 #### To be moved to separate vsphere.tf? ####
 
-provider "vsphere" {}
+provider "vsphere" {
+}
 
 data "vsphere_resource_pool" "pool" {
-  name          = "${var.vsphere_resource_pool}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_resource_pool
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_datastore" "datastore" {
-  name          = "${var.vsphere_datastore}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_datacenter" "dc" {
-  name = "${var.vsphere_datacenter}"
+  name = var.vsphere_datacenter
 }
 
 data "vsphere_network" "network" {
-  name          = "${var.vsphere_network}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.vsphere_network
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_virtual_machine" "template" {
-  name          = "${var.template_name}"
-  datacenter_id = "${data.vsphere_datacenter.dc.id}"
+  name          = var.template_name
+  datacenter_id = data.vsphere_datacenter.dc.id
 }
+

--- a/ci/infra/vmware/versions.tf
+++ b/ci/infra/vmware/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -1,101 +1,103 @@
 data "template_file" "worker_repositories" {
-  template = "${file("cloud-init/repository.tpl")}"
-  count    = "${length(var.repositories)}"
+  template = file("cloud-init/repository.tpl")
+  count    = length(var.repositories)
 
-  vars {
-    repository_url  = "${element(values(var.repositories), count.index)}"
-    repository_name = "${element(keys(var.repositories), count.index)}"
+  vars = {
+    repository_url  = element(values(var.repositories), count.index)
+    repository_name = element(keys(var.repositories), count.index)
   }
 }
 
 data "template_file" "worker_register_scc" {
-  template = "${file("cloud-init/register-scc.tpl")}"
-  count    = "${var.caasp_registry_code == "" ? 0 : 1}"
+  template = file("cloud-init/register-scc.tpl")
+  count    = var.caasp_registry_code == "" ? 0 : 1
 
-  vars {
-    caasp_registry_code = "${var.caasp_registry_code}"
+  vars = {
+    caasp_registry_code = var.caasp_registry_code
   }
 }
 
 data "template_file" "worker_register_rmt" {
-  template = "${file("cloud-init/register-rmt.tpl")}"
-  count    = "${var.rmt_server_name == "" ? 0 : 1}"
+  template = file("cloud-init/register-rmt.tpl")
+  count    = var.rmt_server_name == "" ? 0 : 1
 
-  vars {
-    rmt_server_name = "${var.rmt_server_name}"
+  vars = {
+    rmt_server_name = var.rmt_server_name
   }
 }
 
 data "template_file" "worker_commands" {
-  template = "${file("cloud-init/commands.tpl")}"
-  count    = "${join("", var.packages) == "" ? 0 : 1}"
+  template = file("cloud-init/commands.tpl")
+  count    = join("", var.packages) == "" ? 0 : 1
 
-  vars {
-    packages = "${join(", ", var.packages)}"
+  vars = {
+    packages = join(", ", var.packages)
   }
 }
 
 data "template_file" "worker_cloud_init_metadata" {
-  template = "${file("cloud-init/metadata.tpl")}"
+  template = file("cloud-init/metadata.tpl")
 
-  vars {
-    network_config = "${base64gzip(data.local_file.network_cloud_init.content)}"
+  vars = {
+    network_config = base64gzip(data.local_file.network_cloud_init.content)
     instance_id    = "${var.stack_name}-worker"
   }
 }
 
 data "template_file" "worker_cloud_init_userdata" {
-  template = "${file("cloud-init/common.tpl")}"
+  template = file("cloud-init/common.tpl")
 
-  vars {
-    authorized_keys = "${join("\n", formatlist("  - %s", var.authorized_keys))}"
-    repositories    = "${join("\n", data.template_file.worker_repositories.*.rendered)}"
-    register_scc    = "${join("\n", data.template_file.worker_register_scc.*.rendered)}"
-    register_rmt    = "${join("\n", data.template_file.worker_register_rmt.*.rendered)}"
-    commands        = "${join("\n", data.template_file.worker_commands.*.rendered)}"
-    ntp_servers     = "${join("\n", formatlist ("    - %s", var.ntp_servers))}"
+  vars = {
+    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories    = join("\n", data.template_file.worker_repositories.*.rendered)
+    register_scc    = join("\n", data.template_file.worker_register_scc.*.rendered)
+    register_rmt    = join("\n", data.template_file.worker_register_rmt.*.rendered)
+    commands        = join("\n", data.template_file.worker_commands.*.rendered)
+    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
   }
 }
 
 resource "vsphere_virtual_machine" "worker" {
-  count            = "${var.workers}"
+  count            = var.workers
   name             = "${var.stack_name}-worker-${count.index}"
-  num_cpus         = "${var.worker_cpus}"
-  memory           = "${var.worker_memory}"
-  guest_id         = "${var.guest_id}"
-  firmware         = "${var.firmware}"
-  scsi_type        = "${data.vsphere_virtual_machine.template.scsi_type}"
-  resource_pool_id = "${data.vsphere_resource_pool.pool.id}"
-  datastore_id     = "${data.vsphere_datastore.datastore.id}"
+  num_cpus         = var.worker_cpus
+  memory           = var.worker_memory
+  guest_id         = var.guest_id
+  firmware         = var.firmware
+  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
+  resource_pool_id = data.vsphere_resource_pool.pool.id
+  datastore_id     = data.vsphere_datastore.datastore.id
 
   clone {
-    template_uuid = "${data.vsphere_virtual_machine.template.id}"
+    template_uuid = data.vsphere_virtual_machine.template.id
   }
 
   disk {
     label = "disk0"
-    size  = "${var.worker_disk_size}"
+    size  = var.worker_disk_size
   }
 
-  extra_config {
-    "guestinfo.metadata"          = "${base64gzip(data.template_file.worker_cloud_init_metadata.rendered)}"
+  extra_config = {
+    "guestinfo.metadata"          = base64gzip(data.template_file.worker_cloud_init_metadata.rendered)
     "guestinfo.metadata.encoding" = "gzip+base64"
-
-    "guestinfo.userdata"          = "${base64gzip(data.template_file.worker_cloud_init_userdata.rendered)}"
+    "guestinfo.userdata"          = base64gzip(data.template_file.worker_cloud_init_userdata.rendered)
     "guestinfo.userdata.encoding" = "gzip+base64"
   }
 
   network_interface {
-    network_id = "${data.vsphere_network.network.id}"
+    network_id = data.vsphere_network.network.id
   }
 }
 
 resource "null_resource" "worker_wait_cloudinit" {
-  count = "${var.workers}"
+  count = var.workers
 
   connection {
-    host  = "${element(vsphere_virtual_machine.worker.*.guest_ip_addresses.0, count.index)}"
-    user  = "${var.username}"
+    host = element(
+      vsphere_virtual_machine.worker.*.guest_ip_addresses.0,
+      count.index,
+    )
+    user  = var.username
     type  = "ssh"
     agent = true
   }
@@ -106,3 +108,4 @@ resource "null_resource" "worker_wait_cloudinit" {
     ]
   }
 }
+


### PR DESCRIPTION

These are the automatic and manual operations to perform for a terraform 0.12
upgrade.

I have tested terraform OpenStack end-to-end, including a skuba run, and a
terraform destroy.

I have done the upgrade and eventual validation fixes for libvirt and vmware.
I didn't run the deploy on those.

AWS is failing on my local machine, as I don't have the provider necessary
for the upgrade.

