### PR TITLE
Fix test failure for ./internal/pkg/skuba/kubeadm/configmap.go

### DIFF
--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -209,6 +209,7 @@ func TestGetAPIEndpointsFromConfigMap(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			gotAPIEndpoints, err := GetAPIEndpointsFromConfigMap(tt.client)
+			sort.Strings(gotAPIEndpoints)
 			if tt.expectedError {
 				if err == nil {
 					t.Errorf("error expected on %s, but no error reported", tt.name)


### PR DESCRIPTION
## Why is this PR needed?

Fix test failure in './internal/pkg/skuba/kubeadm/configmap_test.go'

## What does this PR do?

Fix test failure due to actual '[]string' data is unsorted when comparing to expected data.

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

### Related info

N/A

### Status **BEFORE** applying the patch

```
--- FAIL: TestGetAPIEndpointsFromConfigMap (0.00s)
    --- FAIL: TestGetAPIEndpointsFromConfigMap/kubeadm_get_api_endpoints_from_configmap (0.00s)
        configmap_test.go:224: got version [192.168.0.2 192.168.0.3 192.168.0.1], expect version [192.168.0.1 192.168.0.2 192.168.0.3]
FAIL
```

### Status **AFTER** applying the patch

```
ok  	github.com/SUSE/skuba/internal/pkg/skuba/kubeadm	0.016s	coverage: 96.7% of statements
```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready!
    If you can, please apply all applicable labels to help reviews out! -->
