### PR TITLE
CI: include timestamps into testrunner

### DIFF
--- a/ci/infra/testrunner/utils/logger.py
+++ b/ci/infra/testrunner/utils/logger.py
@@ -9,8 +9,12 @@ class Logger:
 
     @staticmethod
     def config_logger(conf, level=None):
+        logging.basicConfig(
+            format='%(asctime)s %(levelname)s] %(message)s',
+            level=logging.DEBUG,
+            datefmt='%Y-%m-%d %H:%M:%S')
+
         logger = logging.getLogger("testrunner")
-        logger.setLevel(logging.getLevelName("DEBUG"))
 
         if conf.log.file:
             mode = 'a'


### PR DESCRIPTION
## Why is this PR needed?

This makes it easier to corelate e.g. pod logs with testrunner
executions.

## What does this PR do?

Configures the logger to prepend a timestamp and log level

## Example output

```
2019-12-03 13:58:55 DEBUG] Entering gather_logs
```
