### PR TITLE
Check preconditions on worker nodes before upgrading

### DIFF
--- a/pkg/skuba/actions/node/upgrade/plan.go
+++ b/pkg/skuba/actions/node/upgrade/plan.go
@@ -38,7 +38,6 @@ func Plan(client clientset.Interface, nodeName string) error {
 
 	fmt.Printf("Current Kubernetes cluster version: %s\n", currentClusterVersion.String())
 	fmt.Printf("Latest Kubernetes version: %s\n", kubernetes.LatestVersion().String())
-	fmt.Println()
 	fmt.Printf("Current Node version: %s\n", nodeVersionInfoUpdate.Current.KubeletVersion.String())
 	fmt.Println()
 
@@ -54,6 +53,12 @@ func Plan(client clientset.Interface, nodeName string) error {
 		}
 		fmt.Printf("  - kubelet: %s -> %s\n", nodeVersionInfoUpdate.Current.KubeletVersion.String(), nodeVersionInfoUpdate.Update.KubeletVersion.String())
 		fmt.Printf("  - cri-o: %s -> %s\n", nodeVersionInfoUpdate.Current.ContainerRuntimeVersion.String(), nodeVersionInfoUpdate.Update.ContainerRuntimeVersion.String())
+
+		// Check if the node is upgradeable (matches preconditions)
+		if err := nodeVersionInfoUpdate.NodeUpgradeableCheck(client, currentClusterVersion); err != nil {
+			fmt.Println()
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Why is this PR needed?

Fixes https://github.com/SUSE/avant-garde/issues/1127
Fixes https://github.com/SUSE/avant-garde/issues/1128

## What does this PR do?

Worker nodes have preconditions: they cannot be upgraded if all
control planes are not in the same version (the cluster version).

This patch adds help in case any of the preconditions for any node is
not matching at `skuba node upgrade plan` and `skuba node upgrade
apply`.

Different cases have different preconditions, and this makes it clear
to the user what precondition is not met and how they can fix the
problem.

### Status **BEFORE** applying the patch

- When upgrading the platform in an HA environment, it's possible to `skuba node upgrade plan/apply` a worker node when not all control plane nodes have been updated yet.

### Status **AFTER** applying the patch

- When upgrading the platform in an HA environment, `skuba node upgrade plan/apply` will show a clear message if any of the preconditions for any node is not met, so the upgrade cannot be started.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
