### PR TITLE
Deprecate extensions apiGroup for PSP

### DIFF
--- a/internal/pkg/skuba/addons/psp.go
+++ b/internal/pkg/skuba/addons/psp.go
@@ -101,7 +101,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: suse:caasp:psp:privileged
 rules:
-  - apiGroups: ['extensions']
+  - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     resourceNames: ['suse.caasp.psp.privileged']
     verbs: ['use']
@@ -203,7 +203,7 @@ kind: ClusterRole
 metadata:
   name: suse:caasp:psp:unprivileged
 rules:
-  - apiGroups: ['extensions']
+  - apiGroups: ['policy']
     resources: ['podsecuritypolicies']
     verbs: ['use']
     resourceNames: ['suse.caasp.psp.unprivileged']

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -95,7 +95,7 @@ var (
 				Kured:   &AddonVersion{"1.2.0-rev4", 1},
 				Dex:     &AddonVersion{"2.16.0", 3},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"", 0},
+				PSP:     &AddonVersion{"", 1},
 			},
 		},
 		"1.15.2": KubernetesVersion{
@@ -115,7 +115,7 @@ var (
 				Kured:   &AddonVersion{"1.2.0-rev4", 1},
 				Dex:     &AddonVersion{"2.16.0", 3},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
-				PSP:     &AddonVersion{"", 0},
+				PSP:     &AddonVersion{"", 1},
 			},
 		},
 	}

--- a/internal/pkg/skuba/upgrade/addon/versions_test.go
+++ b/internal/pkg/skuba/upgrade/addon/versions_test.go
@@ -83,7 +83,7 @@ AddonsVersion:
 					kubernetes.PSP:     nil,
 				},
 				Updated: kubernetes.AddonsVersion{
-					kubernetes.PSP: &kubernetes.AddonVersion{Version: "", ManifestVersion: 0},
+					kubernetes.PSP: &kubernetes.AddonVersion{Version: "", ManifestVersion: 1},
 				},
 			},
 			expectedErr: false,
@@ -124,7 +124,7 @@ func TestHasAddonUpdate(t *testing.T) {
 					kubernetes.Kured:   &kubernetes.AddonVersion{Version: "1.2.0", ManifestVersion: 0},
 					kubernetes.Dex:     &kubernetes.AddonVersion{Version: "2.16.0", ManifestVersion: 0},
 					kubernetes.Gangway: &kubernetes.AddonVersion{Version: "3.1.0", ManifestVersion: 0},
-					kubernetes.PSP:     &kubernetes.AddonVersion{Version: "1.0.0", ManifestVersion: 0},
+					kubernetes.PSP:     &kubernetes.AddonVersion{Version: "1.0.0", ManifestVersion: 1},
 				},
 				Updated: kubernetes.AddonsVersion{
 					kubernetes.Cilium: &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 1},
@@ -140,7 +140,7 @@ func TestHasAddonUpdate(t *testing.T) {
 					kubernetes.Kured:   &kubernetes.AddonVersion{Version: "1.2.0", ManifestVersion: 0},
 					kubernetes.Dex:     &kubernetes.AddonVersion{Version: "2.16.0", ManifestVersion: 0},
 					kubernetes.Gangway: &kubernetes.AddonVersion{Version: "3.1.0", ManifestVersion: 0},
-					kubernetes.PSP:     &kubernetes.AddonVersion{Version: "1.0.0", ManifestVersion: 0},
+					kubernetes.PSP:     &kubernetes.AddonVersion{Version: "1.0.0", ManifestVersion: 1},
 				},
 			},
 			expected: false,


### PR DESCRIPTION
Replace the apiGroup 'extensions' with 'policy' as the
last part to make SUSE provided PSPs with Kubernetes 1.16.

## Why is this PR needed?

Fixes https://github.com/SUSE/avant-garde/issues/1122

## What does this PR do?

The PodSecurityPolicy in Kubernetes 1.15 used to work
in the `extentions/v1beta1` API group. In the new
version, this API group does not exist any more.
It has been deprecated and removed. The replacement is `policy/v1beta1`.

This PR replaces the apiGroup 'extensions' with 'policy' as the
last part to make SUSE provided PSPs with Kubernetes 1.16.

## Anything else a reviewer needs to know?

This PR makes sure that new kubernetes clusters bootstraped with skuba and 1.16 are working fine with PSP.

But, this PR does not check if this change will be affected during the maintenance update. The new configuration has to be applied during the maintenance update.

## Info for QA

All the info you need 

### Related info

Read my comment at: https://github.com/SUSE/avant-garde/issues/1122#issuecomment-561757161


### Status **BEFORE** applying the patch

```
$ kubectl auth can-i use psp/suse.caasp.psp.unprivileged --as=any-user
Warning: resource 'podsecuritypolicies' is not namespace scoped in group 'policy'
no
```

### Status **AFTER** applying the patch

```
$ kubectl auth can-i use psp/suse.caasp.psp.unprivileged --as=any-user
Warning: resource 'podsecuritypolicies' is not namespace scoped in group 'policy'
yes
```

## Docs

If there is description talking about PSP and there is a copy-paste of the the definition of it, make sure it reflects the changes to the new API. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
