### PR TITLE
Add option to configure datastore_cluster 

### DIFF
--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -54,6 +54,7 @@ Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable
 
 `vsphere_datastore` - Provide the datastore to use in vSphere\
 `vsphere_datacenter` - Provide the datacenter to use in vSphere\
+`vsphere_datastore_cluster` - Provide the datastore cluster to use on the vSphere server\
 `vsphere_network` - Provide the network to use in vSphere - this network must be able to access the ntp servers and the nodes must be able to reach each other\
 `vsphere_resource_pool` - Provide the resource pool the machines will be running in\
 `template_name` - The template name the machines will be copied from\

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -134,7 +134,8 @@ resource "vsphere_virtual_machine" "lb" {
   firmware         = var.firmware
   scsi_type        = data.vsphere_virtual_machine.template.scsi_type
   resource_pool_id = data.vsphere_resource_pool.pool.id
-  datastore_id     = data.vsphere_datastore.datastore.id
+  datastore_id     = (var.vsphere_datastore == null ? null: data.vsphere_datastore.datastore[0].id)
+  datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
 
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -66,7 +66,8 @@ resource "vsphere_virtual_machine" "master" {
   firmware         = var.firmware
   scsi_type        = data.vsphere_virtual_machine.template.scsi_type
   resource_pool_id = data.vsphere_resource_pool.pool.id
-  datastore_id     = data.vsphere_datastore.datastore.id
+  datastore_id     = (var.vsphere_datastore == null ? null: data.vsphere_datastore.datastore[0].id)
+  datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
 
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -1,6 +1,7 @@
 {
     "vsphere_datastore": "node51-2",
     "vsphere_datacenter": "NUREMBERG",
+    "vsphere_datastore_cluster": null,
     "vsphere_network": "VM Network",
     "vsphere_resource_pool": "CaaSP_CI",
     "template_name": "SLES15-SP1-GM-up191203-guestinfo_node51",

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -5,6 +5,11 @@ variable "stack_name" {
 }
 
 variable "vsphere_datastore" {
+  default = null
+}
+
+variable "vsphere_datastore_cluster" {
+  default = null
 }
 
 variable "vsphere_datacenter" {
@@ -116,7 +121,14 @@ data "vsphere_resource_pool" "pool" {
 }
 
 data "vsphere_datastore" "datastore" {
+  count         = var.vsphere_datastore == null ? 0 : 1
   name          = var.vsphere_datastore
+  datacenter_id = data.vsphere_datacenter.dc.id
+}
+
+data "vsphere_datastore_cluster" "datastore" {
+  count         = var.vsphere_datastore_cluster == null ? 0 : 1
+  name          = var.vsphere_datastore_cluster
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -66,7 +66,8 @@ resource "vsphere_virtual_machine" "worker" {
   firmware         = var.firmware
   scsi_type        = data.vsphere_virtual_machine.template.scsi_type
   resource_pool_id = data.vsphere_resource_pool.pool.id
-  datastore_id     = data.vsphere_datastore.datastore.id
+  datastore_id     = (var.vsphere_datastore == null ? null: data.vsphere_datastore.datastore[0].id)
+  datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
 
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id


### PR DESCRIPTION
Using 3PAR over network ISCSI is not a great idea regarding IOPS
performance which matters for etcd.  Add ability to set a datastore_cluster
as well (optionally)

## Why is this PR needed?

It fixes the e2e CI failures on vmware because they are currently using
ISCSI (which is very slow) on 3PAR (which is extremely slow). 

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

## Docs

Documentation update is in https://github.com/SUSE/doc-caasp/pull/629


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
