### PR TITLE
Rename testrunner logs directory

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -110,7 +110,7 @@ username: "username"
 
 There are some arguments that are currently at the top level of the configuration, but are actually related to the platform:
 
-- log_dir: path to the directory where platform logs are collected. Defaults to `<workspace>/testrunner_logs` 
+- log_dir: path to the directory where platform logs are collected. Defaults to `<workspace>/platform_logs`
 - nodeuser: the user name used to login into the platform nodes. Optional. 
 - ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
 
@@ -530,7 +530,7 @@ kube-system   kube-scheduler-my-master-0            1/1       Running   0       
 
 ```./testrunner get_logs```
 
-All collected logs are stored at `path/to/workspace/testrunner_logs/`
+All collected logs are stored at `path/to/workspace/platform_logs/`
 
 Logs that are currently being collected are the cloud-init logs for each of the nodes:
 
@@ -538,7 +538,7 @@ Logs that are currently being collected are the cloud-init logs for each of the 
     /var/log/cloud-init-output.log
     /var/log/cloud-init.log
 
-These are stored each in their own folder named `path/to/workspace/testrunner_logs/{master|worker}_ip_address/`
+These are stored each in their own folder named `path/to/workspace/platform_logs/{master|worker}_ip_address/`
 
 ### Install using registration code
 

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -151,7 +151,7 @@ class BaseConfig:
         conf.workspace = os.path.expanduser(conf.workspace)
 
         if not conf.log_dir:
-            conf.log_dir = os.path.join(conf.workspace, 'testrunner_logs')
+            conf.log_dir = os.path.join(conf.workspace, 'platform_logs')
         elif not os.path.isabs(conf.log_dir):
             conf.log_dir = os.path.join(conf.workspace, conf.log_dir)
 

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
             script {
                 if (shouldRun) {
                     sh(script: 'make --keep-going -f skuba/ci/Makefile post_run', label: 'Post Run')
-                    zip(archive: true, dir: 'testrunner_logs', zipFile: 'testrunner_logs.zip')
+                    zip(archive: true, dir: 'platform_logs', zipFile: 'platform_logs.zip')
                 }
             }
         }

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -136,7 +136,7 @@ pipeline {
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
             sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
-            archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
             junit('skuba/ci/infra/testrunner/*.xml')
         }
         cleanup {

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     post {
         always {
             sh(script: 'make --keep-going -f skuba/ci/Makefile post_run', label: 'Post Run')
-            zip(archive: true, dir: 'testrunner_logs', zipFile: 'testrunner_logs.zip')
+            zip(archive: true, dir: 'platform_logs', zipFile: 'platform_logs.zip')
         }
         cleanup {
             dir("${WORKSPACE}") {

--- a/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-nightly.Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
             archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
-            archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
         }
         cleanup {
             sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')

--- a/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-nightly.Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
             sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
-            archiveArtifacts(artifacts: 'testrunner_logs/**/*', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
             junit('skuba/ci/infra/testrunner/*.xml')
         }
         cleanup {


### PR DESCRIPTION
## Why is this PR needed?

Without this change, the logs that testrunner collects from the platform
nodes are archived in the testrunner_logs directory, which is a
confusing place for these logs since the logs for testrunner itself are
not stored there. 

Fixes SUSE/avant-garde#714

## What does this PR do?

This change moves the default platform log directory
to platform_logs and updates the Jenkinsfiles and documentation for the
new log path.

## Anything else a reviewer needs to know?

n/a

## Info for QA

n/a

### Related info

n/a

### Status **BEFORE** applying the patch

Logs from CI are stored in testrunner_logs directory in the workspace.

### Status **AFTER** applying the patch

Logs from CI are stored in the platform_logs directory in the workspace.

## Docs

n/a 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
