### PR TITLE
Fix unable to bootstrap by using FQDN

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -85,8 +85,13 @@ func kubeletCreateAndUploadServerCert(t *Target, data interface{}) error {
 		}
 	}
 
-	alternateIPs := []net.IP{net.ParseIP(t.target.Target), net.IPv4(127, 0, 0, 1), net.IPv6loopback}
+	alternateIPs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
 	alternateDNS := []string{"localhost"}
+	if ip := net.ParseIP(t.target.Target); ip != nil {
+		alternateIPs = append(alternateIPs, ip)
+	} else {
+		alternateDNS = append(alternateDNS, t.target.Target)
+	}
 
 	altNames.IPs = append(altNames.IPs, alternateIPs...)
 	altNames.DNSNames = append(altNames.DNSNames, alternateDNS...)


### PR DESCRIPTION
##  Why is this PR needed?

Fix Unable to bootstrap first master node by using its FQDN hostname

Fixes https://github.com/SUSE/avant-garde/issues/1133

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Previously, the user input target node IP or FQDN inserted into altNames.IPs. When the target is FQDN, this causes generates kubelet server certificate failed.

Add all host IP or FQDN into hosts slice, then check each entity in hosts slice is IP or FQDN, adding to corresponding altNames.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

Bootstrap/Join the target node by using FQDN, deployed failed.

### Status **AFTER** applying the patch

1. Bootstrap/Join the target node by using FQDN, deployed success.
2. Install metrics server success. Reference to https://github.com/SUSE/skuba/pull/832#issue-342218019
2. `kubectl top [pod|node]` success

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
