### PR TITLE
Add protection against transient states from ssh

### DIFF
--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -126,6 +126,7 @@ resource "null_resource" "master_reboot" {
     command = <<EOT
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
 # wait for ssh ready after reboot
+until nc -zv $host 22; do sleep 5; done
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
   }

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -126,6 +126,7 @@ resource "null_resource" "worker_reboot" {
     command = <<EOT
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
 # wait for ssh ready after reboot
+until nc -zv $host 22; do sleep 5; done
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
 EOT
   }


### PR DESCRIPTION
Sometimes the deployment of terraform fails because of a "connection
refused". For example:

```
* Error running command 'ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $user@$host sudo reboot || :
ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -oConnectionAttempts=60 $user@$host /usr/bin/true
': exit status 255. Output: Warning: Permanently added '10.17.2.0' (ECDSA) to the list of known hosts.
Connection to 10.17.2.0 closed by remote host.
ssh: connect to host 10.17.2.0 port 22: Connection refused
```

After investigating, it seems that after the reboot, there is a very 
small transient period in which the ssh server asks for password
instead of using the key. If Terraform tries to do the ssh command 
during that period, the deployment fails, even though everything is
fine. When trying manually with a while loop:

```
ssh: connect to host 10.17.3.0 port 22: No route to host
255
ssh: connect to host 10.17.3.0 port 22: No route to host
255
ssh: connect to host 10.17.3.0 port 22: Connection refused
255
ssh: connect to host 10.17.3.0 port 22: Connection refused
255
Warning: Permanently added '10.17.3.0' (ECDSA) to the list of known hosts.
0
Warning: Permanently added '10.17.3.0' (ECDSA) to the list of known hosts.
sign_and_send_pubkey: signing failed: communication with agent failed
Password:
```

After that, the ssh connection works always.

This patch protects ourselves against that because it checks the ssh
port first and then it tries the ssh connection. This way, the 
transient period happens while we are testing the ssh port.

Signed-off-by: Manuel Buil <mbuil@suse.com>

## Why is this PR needed?

This PR fixes an issue we are seeing when using libvirt as the
provider of terraform. Explained in the message of the patch. This
issue was not reported in Jira or Github.

## What does this PR do?

Please refer to the message of the patch

## Anything else a reviewer needs to know?

No

## Info for QA

Run the deployment of terraform using libvirt as provider and around
30% of the time, you will see the problem I am describing.

### Related info
Nothing

### Status **BEFORE** applying the patch

Please check the message of the patch

### Status **AFTER** applying the patch

Please check the message of the patch

## Docs
No docs are needed

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
