### PR TITLE
kured: remove extra quotes from annotation

### DIFF
--- a/internal/pkg/skuba/kured/kured.go
+++ b/internal/pkg/skuba/kured/kured.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	kuredDSName             = "kured"
-	kuredLockAnnotationJson = `{"metadata":{"annotations":{"weave.works/kured-node-lock":"'{\"nodeID\":\"manual\"}'"}}}`
+	kuredLockAnnotationJson = `{"metadata":{"annotations":{"weave.works/kured-node-lock":"{\"nodeID\":\"manual\"}"}}}`
 )
 
 func LockExists(client clientset.Interface) (bool, error) {


### PR DESCRIPTION
## Why is this PR needed?

Remove extra quotes from annotation kured lock annotation. Before this
patch, the annotation created would look like:

```
weave.works/kured-node-lock: '''{"nodeID":"manual"}'''
```

With this patch, the annotation looks like:

```
weave.works/kured-node-lock: '{"nodeID":"manual"}'
```

/cc @SUSE/caasp-qa 
/cc @troytop 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
