### PR TITLE
libvirt: Add hostnames to the output

### DIFF
--- a/ci/infra/libvirt/output.tf
+++ b/ci/infra/libvirt/output.tf
@@ -1,3 +1,11 @@
+output "hostnames_masters" {
+  value = ["${libvirt_domain.master.*.network_interface.0.hostname}"]
+}
+
+output "hostnames_workers" {
+  value = ["${libvirt_domain.worker.*.network_interface.0.hostname}"]
+}
+
 output "ip_load_balancer" {
   value = "${libvirt_domain.lb.network_interface.0.addresses.0}"
 }


### PR DESCRIPTION
## Why is this PR needed?

The last argument of `skuba node` subcommands should be the same as
hostname of the provisioned node, otherwise kubeadm is going to show the
warning and the cluster might be not fully functional.

Before this change, looking up for hostnames after executing terraform
required manual lookup in libvirt domain data. This change adds
hostnames to the output of `terraform apply` command.

## What does this PR do?

It adds `hostnames_masters` and `hostnames_workers` to the output of terraform/libvirt.

## Info for QA

Just run terraform and check whether you see hostnames. ;)

### Status **BEFORE** applying the patch

Before applying the patch, terraform shows just IP addresses of VMs, but not hostnames. Users need to look for hostnames manually.

### Status **AFTER** applying the patch

After applying the patch, users can see hostnames of VMs, which they can use as arguments to `skuba node` commands.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
