### PR TITLE
cluster upgrade plan: remove misleading message

### DIFF
--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -81,8 +81,6 @@ func Plan(client clientset.Interface) error {
 	}
 	fmt.Println()
 	if addon.HasAddonUpdate(updatedAddons) {
-		fmt.Println("After you have completed the platform upgrade, there are new addon versions available:")
-		fmt.Println()
 		fmt.Printf("Addon upgrades from %s to %s:\n", currentVersion, nextClusterVersion.String())
 		addon.PrintAddonUpdates(updatedAddons)
 	} else {


### PR DESCRIPTION
## Why is this PR needed?

Remove this misleading message from `cluster upgrade plan`. We can
improve this situation by properly composing a list of addons based
on:

- Current addons version (for the current cluster version)
  - This is essentially our `skuba-config` ConfigMap contents

- Desired addons version (for the current cluster version)
  - This is essentially mapping the current versions and projecting
    them to their desired versions in the versions.go file, for the
    current cluster version.

- Desired addons version (for the next cluster version)
  - As the previous step, but projecting to the next cluster version.

By performing this logic, our `cluster upgrade plan` would be more
complete, so that we can report:

- Whether a `skuba addon upgrade apply` is required before trying to
  upgrade the platform (current addons version does not match desired
  addons version for the current cluster version)

- Versions that will be bumped when upgrading the platform

- Whether a `skuba addon upgrade apply` is required after upgrading
  the platform (desired addons version for the current cluster version
  does not match desired addons version for the next cluster version)

/cc @SUSE/caasp-qa 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
