### PR TITLE
Be explicit about not using ssh-agent

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -110,6 +110,7 @@ resource "null_resource" "lb_wait_cloudinit" {
     user     = "${var.username}"
     password = "${var.password}"
     type     = "ssh"
+    agent    = false
   }
 
   provisioner "remote-exec" {

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -104,6 +104,7 @@ resource "null_resource" "master_wait_cloudinit" {
     user     = "${var.username}"
     password = "${var.password}"
     type     = "ssh"
+    agent    = false
   }
 
   provisioner "remote-exec" {

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -104,6 +104,7 @@ resource "null_resource" "worker_wait_cloudinit" {
     user     = "${var.username}"
     password = "${var.password}"
     type     = "ssh"
+    agent    = false
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
Cloud-init is taking care of setting the correct keys and ssh config
and thus it should not use key authentication. Our config is 
correct because it provides the password; however, if nothing is set,
then the default is agent = true, which does not make sense.

For example:

```
null_resource.master_wait_cloudinit[0]: Provisioning with
'remote-exec'...
null_resource.master_wait_cloudinit[0] (remote-exec): Connecting to
remote host via SSH...
null_resource.master_wait_cloudinit[0] (remote-exec):   Host: 10.17.2.0
null_resource.master_wait_cloudinit[0] (remote-exec):   User: sles
null_resource.master_wait_cloudinit[0] (remote-exec):   Password: true
null_resource.master_wait_cloudinit[0] (remote-exec):   Private key:
false
null_resource.master_wait_cloudinit[0] (remote-exec):   Certificate:
false
null_resource.master_wait_cloudinit[0] (remote-exec):   SSH Agent: true
null_resource.master_wait_cloudinit[0] (remote-exec):   Checking Host Key:
false
```

As a result, sometimes the terraform deploy fails at cloud-init step
when changing from password to key authentication in the same terraform
task (cloud-init)

Signed-off-by: Manuel Buil <mbuil@suse.com>

## Why is this PR needed?
Yes, please read commit message

## What does this PR do?
Please read commit message

## Anything else a reviewer needs to know?
No

## Info for QA
This PR fixes a bug which appears from time to time when deploying terraform + libvirt

### Related info

### Status **BEFORE** applying the patch
Deploying skuba with terraform + libvirt as provider. It sometimes fail in the cloud_init step with a ssh problem

### Status **AFTER** applying the patch
The deployment never fails in the cloud_init step

## Docs
No docs needed

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
