### PR TITLE
Opt out of vmware testing rather than opt in

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr-manager
+++ b/ci/jenkins/pipelines/prs/helpers/pr-manager
@@ -18,9 +18,10 @@ setup_python_env() {
     source ${VENVDIR}/bin/activate
     # Not calling to `pip3` directly because its shebang can exceed 128 characters
     # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
-    python -m pip install -r "${SDIR}/pr_manager/requirements.txt"
+    python -m pip -q --disable-pip-version-check install -U -r "${SDIR}/pr_manager/requirements.txt"
 }
 
 setup_python_env
-python -u ${SDIR}/pr_manager/pr_manager.py "$@"
+cd ${SDIR}
+python -u pr_manager/pr_manager.py "$@"
 deactivate

--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env Python3
+#!/usr/bin/env python3
 
 import argparse
 import configparser
@@ -59,12 +59,7 @@ def filter_pr(args):
         repo = g.get_repo(GITHUB_REPO)
 
         pull = repo.get_pull(CHANGE_ID)
-        changed_files = pull.get_files()
-        files_list = []
-
-        # change paginated list to normal list
-        for f in changed_files:
-            files_list.append(f.filename)
+        files_list = [f.filename for f in pull.get_files()]
 
         if any([s for s in files_list if args.filename in s]):
             msg = "contains"


### PR DESCRIPTION
## Why is this PR needed?

Without this PR, VMware testing will be always skipped. 

Fixes https://github.com/SUSE/avant-garde/issues/1137

## What does this PR do?

We're saving the result of the filter-pr evaluation on whether it touches vmware
specific CI code paths inside the pipeline env, so that later pipeline steps can
reference the result. 

Also the logic is changed to be more aligned with "better be safe than sorry",
so it explicitely skips when it is determined to *not* match. 

## Info for QA

This is CI automation specific.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)
