### PR TITLE
Annotate CaaSP version on node

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,12 +209,12 @@ upgrades. The tool is currently returning fake data.
 
 ```
 $ kubectl caasp cluster status
-NAME      OS-IMAGE             KERNEL-VERSION                CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES
-master0   openSUSE Leap 15.0   4.12.14-lp150.12.28-default   docker://18.6.1     <none>        <none>
-master1   openSUSE Leap 15.0   4.12.14-lp150.12.28-default   docker://18.6.1     <none>        <none>
-master2   openSUSE Leap 15.0   4.12.14-lp150.12.28-default   docker://18.6.1     <none>        <none>
-worker0   openSUSE Leap 15.0   4.12.14-lp150.12.28-default   docker://18.6.1     <none>        <none>
-worker1   openSUSE Leap 15.0   4.12.14-lp150.12.28-default   cri-o://1.13.0      <none>        <none>
+NAME      OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
+master0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
+master1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
+master2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
+worker0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
+worker1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -210,11 +210,12 @@ upgrades. The tool is currently returning fake data.
 ```
 $ kubectl caasp cluster status
 NAME      OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
-master0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
-master1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
-master2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
-worker0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
-worker1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
+master0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+master1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+master2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+worker0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+worker1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+worker2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
 ```
 
 ## Demo

--- a/internal/pkg/skuba/deployments/ssh/skuba-update.go
+++ b/internal/pkg/skuba/deployments/ssh/skuba-update.go
@@ -18,7 +18,7 @@
 package ssh
 
 func init() {
-	stateMap["skuba-update.start.no-wait"] = skubaUpdateStartNoWait
+	stateMap["skuba-update.start.no-block"] = skubaUpdateStartNoWait
 	stateMap["skuba-update-timer.enable"] = skubaUpdateTimerEnable
 	stateMap["skuba-update-timer.disable"] = skubaUpdateTimerDisable
 }

--- a/internal/pkg/skuba/deployments/ssh/skuba-update.go
+++ b/internal/pkg/skuba/deployments/ssh/skuba-update.go
@@ -18,12 +18,12 @@
 package ssh
 
 func init() {
-	stateMap["skuba-update.start.no-block"] = skubaUpdateStartNoWait
+	stateMap["skuba-update.start.no-block"] = skubaUpdateStartNoBlock
 	stateMap["skuba-update-timer.enable"] = skubaUpdateTimerEnable
 	stateMap["skuba-update-timer.disable"] = skubaUpdateTimerDisable
 }
 
-func skubaUpdateStartNoWait(t *Target, data interface{}) error {
+func skubaUpdateStartNoBlock(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "start", "--no-block", "skuba-update")
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/skuba-update.go
+++ b/internal/pkg/skuba/deployments/ssh/skuba-update.go
@@ -18,16 +18,22 @@
 package ssh
 
 func init() {
-	stateMap["skuba-update.start"] = skubaUpdateStart
-	stateMap["skuba-update.stop"] = skubaUpdateStop
+	stateMap["skuba-update.start.no-wait"] = skubaUpdateStartNoWait
+	stateMap["skuba-update-timer.enable"] = skubaUpdateTimerEnable
+	stateMap["skuba-update-timer.disable"] = skubaUpdateTimerDisable
 }
 
-func skubaUpdateStart(t *Target, data interface{}) error {
+func skubaUpdateStartNoWait(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "start", "--no-block", "skuba-update")
+	return err
+}
+
+func skubaUpdateTimerEnable(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "enable", "--now", "skuba-update.timer")
 	return err
 }
 
-func skubaUpdateStop(t *Target, data interface{}) error {
+func skubaUpdateTimerDisable(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "disable", "--now", "skuba-update.timer")
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/systemd.go
+++ b/internal/pkg/skuba/deployments/ssh/systemd.go
@@ -24,7 +24,7 @@ import (
 
 // IsServiceEnabled returns if a service is enabled
 func (t *Target) IsServiceEnabled(serviceName string) (bool, error) {
-	klog.V(1).Info("checking if skuba-update.timer is enabled")
+	klog.V(1).Infof("checking if %s is enabled", serviceName)
 	isEnabled := true
 	_, _, err := t.silentSsh("systemctl", "is-enabled", serviceName)
 	if err != nil {

--- a/pkg/skuba/actions/cluster/status/status.go
+++ b/pkg/skuba/actions/cluster/status/status.go
@@ -34,7 +34,7 @@ func Status(client clientset.Interface) error {
 		return errors.Wrap(err, "could not retrieve node list")
 	}
 
-	outputFormat := "custom-columns=NAME:.metadata.name,OS-IMAGE:.status.nodeInfo.osImage,KERNEL-VERSION:.status.nodeInfo.kernelVersion,KUBELET-VERSION:.status.nodeInfo.kubeletVersion,CONTAINER-RUNTIME:.status.nodeInfo.containerRuntimeVersion,HAS-UPDATES:.metadata.annotations.caasp\\.suse\\.com/has-updates,HAS-DISRUPTIVE-UPDATES:.metadata.annotations.caasp\\.suse\\.com/has-disruptive-updates"
+	outputFormat := "custom-columns=NAME:.metadata.name,OS-IMAGE:.status.nodeInfo.osImage,KERNEL-VERSION:.status.nodeInfo.kernelVersion,KUBELET-VERSION:.status.nodeInfo.kubeletVersion,CONTAINER-RUNTIME:.status.nodeInfo.containerRuntimeVersion,HAS-UPDATES:.metadata.annotations.caasp\\.suse\\.com/has-updates,HAS-DISRUPTIVE-UPDATES:.metadata.annotations.caasp\\.suse\\.com/has-disruptive-updates,CAASP-RELEASE-VERSION:.metadata.annotations.caasp\\.suse\\.com/caasp-release-version"
 
 	printFlags := kubectlget.NewGetPrintFlags()
 	printFlags.OutputFormat = &outputFormat

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -143,7 +143,7 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.init",
-		"skuba-update.start.no-wait",
+		"skuba-update.start.no-block",
 		"skuba-update-timer.enable",
 	)
 	if err != nil {

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -143,7 +143,8 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.init",
-		"skuba-update.start",
+		"skuba-update.start.no-wait",
+		"skuba-update-timer.enable",
 	)
 	if err != nil {
 		return err

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -86,7 +86,9 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.join",
-		"skuba-update.start")
+		"skuba-update.start.no-wait",
+		"skuba-update-timer.enable",
+	)
 
 	fmt.Println("[join] applying states to new node")
 

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -86,7 +86,7 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.join",
-		"skuba-update.start.no-wait",
+		"skuba-update.start.no-block",
 		"skuba-update-timer.enable",
 	)
 

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -26,13 +26,14 @@ import (
 	"k8s.io/klog"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
+	"github.com/pkg/errors"
+
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kured"
 	"github.com/SUSE/skuba/internal/pkg/skuba/node"
 	upgradenode "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/node"
-	"github.com/pkg/errors"
 )
 
 func Apply(client clientset.Interface, target *deployments.Target) error {
@@ -109,7 +110,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 	fmt.Printf("Performing node %s (%s) upgrade, please wait...\n", target.Nodename, target.Target)
 
 	if skubaUpdateWasEnabled {
-		err = target.Apply(nil, "skuba-update.stop")
+		err = target.Apply(nil, "skuba-update-timer.disable")
 		if err != nil {
 			return err
 		}
@@ -163,7 +164,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		return err
 	}
 	if skubaUpdateWasEnabled {
-		err = target.Apply(nil, "skuba-update.start")
+		err = target.Apply(nil, "skuba-update-timer.enable")
 		if err != nil {
 			return err
 		}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -164,7 +164,10 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		return err
 	}
 	if skubaUpdateWasEnabled {
-		err = target.Apply(nil, "skuba-update-timer.enable")
+		err = target.Apply(nil,
+			"skuba-update.start.no-block",
+			"skuba-update-timer.enable",
+		)
 		if err != nil {
 			return err
 		}

--- a/skuba-update/dev-requirements.txt
+++ b/skuba-update/dev-requirements.txt
@@ -5,4 +5,3 @@ pytest
 pytest-cov
 tox
 mock
-tox

--- a/skuba-update/skuba_update/skuba-update.timer
+++ b/skuba-update/skuba_update/skuba-update.timer
@@ -3,9 +3,9 @@ Description=Daily update of the system
 After=network-online.target local-fs.target
 
 [Timer]
+OnActiveSec=0
 OnCalendar=daily
 AccuracySec=1m
-RandomizedDelaySec=2h
 Persistent=true
 
 [Install]

--- a/skuba-update/skuba_update/skuba-update.timer
+++ b/skuba-update/skuba_update/skuba-update.timer
@@ -3,9 +3,9 @@ Description=Daily update of the system
 After=network-online.target local-fs.target
 
 [Timer]
-OnActiveSec=0
 OnCalendar=daily
 AccuracySec=1m
+RandomizedDelaySec=2h
 Persistent=true
 
 [Install]

--- a/skuba-update/skuba_update/skuba_update.py
+++ b/skuba-update/skuba_update/skuba_update.py
@@ -162,7 +162,7 @@ def annotate_updates_available(node_name):
 
 def annotate_caasp_release_version(node_name):
     """
-    Get rpm package caasp-release version.
+    Performs fetch caasp-release version and annotates to the node.
     """
 
     cmd = run_command(['rpm', '-q', 'caasp-release',

--- a/skuba-update/skuba_update/skuba_update.py
+++ b/skuba-update/skuba_update/skuba_update.py
@@ -56,6 +56,7 @@ KUBECONFIG_PATH = '/etc/kubernetes/kubelet.conf'
 KUBE_UPDATES_KEY = 'caasp.suse.com/has-updates'
 KUBE_SECURITY_UPDATES_KEY = 'caasp.suse.com/has-security-updates'
 KUBE_DISRUPTIVE_UPDATES_KEY = 'caasp.suse.com/has-disruptive-updates'
+KUBE_CAASP_RELEASE_VERSION_KEY = 'caasp.suse.com/caasp-release-version'
 
 
 def main():
@@ -78,10 +79,10 @@ def main():
     if not args.annotate_only:
         code = update()
         restart_services()
-        annotate_updates_available()
+        annotate_node()
         reboot_sentinel_file(code)
     else:
-        annotate_updates_available()
+        annotate_node()
 
 
 def parse_args():
@@ -123,7 +124,13 @@ def update():
     return code
 
 
-def annotate_updates_available():
+def annotate_node():
+    node_name = node_name_from_machine_id()
+    annotate_updates_available(node_name)
+    annotate_caasp_release_version(node_name)
+
+
+def annotate_updates_available(node_name):
     """
     Performs a zypper list-patches and annotates the node like so:
 
@@ -134,7 +141,6 @@ def annotate_updates_available():
          flag is set.
     """
 
-    node_name = node_name_from_machine_id()
     patch_xml = run_zypper_command(
         ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
         needsOutput=True
@@ -151,6 +157,23 @@ def annotate_updates_available():
     annotate(
         'node', node_name, KUBE_DISRUPTIVE_UPDATES_KEY,
         'yes' if has_disruptive_updates(updates) else 'no'
+    )
+
+
+def annotate_caasp_release_version(node_name):
+    """
+    Get rpm package caasp-release version.
+    """
+
+    cmd = run_command(['rpm', '-q', 'caasp-release',
+                       '--queryformat', '%{VERSION}'])
+    if cmd.returncode != 0 or not cmd.output:
+        log('Failed get caasp-release rpm package version')
+        return
+
+    annotate(
+        'node', node_name, KUBE_CAASP_RELEASE_VERSION_KEY,
+        cmd.output,
     )
 
 

--- a/skuba-update/test/os/suse/Dockerfile.builder
+++ b/skuba-update/test/os/suse/Dockerfile.builder
@@ -1,4 +1,4 @@
 FROM registry.opensuse.org/opensuse/tumbleweed
 
-RUN zypper ref && zypper -n in rpm-build rpmdevtools createrepo
+RUN zypper ref && zypper -n in rpm-build rpmdevtools createrepo libcreaterepo_c-devel
 RUN rm /var/run/reboot-needed

--- a/skuba-update/test/unit/skuba_update_test.py
+++ b/skuba-update/test/unit/skuba_update_test.py
@@ -29,6 +29,7 @@ from skuba_update.skuba_update import (
     is_reboot_needed,
     reboot_sentinel_file,
     annotate_updates_available,
+    annotate_caasp_release_version,
     get_update_list,
     restart_services,
     REBOOT_REQUIRED_PATH,
@@ -37,7 +38,8 @@ from skuba_update.skuba_update import (
     ZYPPER_EXIT_INF_REBOOT_NEEDED,
     KUBE_UPDATES_KEY,
     KUBE_SECURITY_UPDATES_KEY,
-    KUBE_DISRUPTIVE_UPDATES_KEY
+    KUBE_DISRUPTIVE_UPDATES_KEY,
+    KUBE_CAASP_RELEASE_VERSION_KEY
 )
 
 
@@ -111,12 +113,16 @@ def test_main_no_root(mock_subprocess, mock_args):
     assert exception
 
 
+@patch('skuba_update.skuba_update.node_name_from_machine_id')
+@patch('skuba_update.skuba_update.annotate_caasp_release_version')
 @patch('skuba_update.skuba_update.annotate_updates_available')
 @patch('argparse.ArgumentParser.parse_args')
 @patch('os.environ.get', new={}.get, spec_set=True)
 @patch('os.geteuid')
 @patch('subprocess.Popen')
-def test_main(mock_subprocess, mock_geteuid, mock_args, mock_annotate):
+def test_main(
+    mock_subprocess, mock_geteuid, mock_args, mock_annotate, mock_annotate_version, mock_name
+):
     return_values = [
         (b'some_service1\nsome_service2', b''),
         (b'zypper 1.14.15', b'')
@@ -183,13 +189,14 @@ def test_restart_services_error(mock_zypp_cmd, mock_subprocess, capsys):
     assert 'returned non zero exit code' in out
 
 
+@patch('skuba_update.skuba_update.node_name_from_machine_id')
 @patch('skuba_update.skuba_update.annotate_updates_available')
 @patch('argparse.ArgumentParser.parse_args')
 @patch('os.environ.get', new={}.get, spec_set=True)
 @patch('os.geteuid')
 @patch('subprocess.Popen')
 def test_main_annotate_only(
-        mock_subprocess, mock_geteuid, mock_args, mock_annotate
+        mock_subprocess, mock_geteuid, mock_args, mock_annotate, mock_name
 ):
     args = Mock()
     args.annotate_only = True
@@ -203,16 +210,20 @@ def test_main_annotate_only(
     assert mock_subprocess.call_args_list == [
         call(['zypper', '--version'], stdout=-1, stderr=-1, env=ANY),
         call(['zypper', 'ref', '-s'], stdout=None, stderr=None, env=ANY),
+        call([
+            'rpm', '-q', 'caasp-release', '--queryformat', '%{VERSION}'
+        ], stdout=-1, stderr=-1, env=ANY),
     ]
 
 
+@patch('skuba_update.skuba_update.node_name_from_machine_id')
 @patch('skuba_update.skuba_update.annotate_updates_available')
 @patch('argparse.ArgumentParser.parse_args')
 @patch('os.environ.get', new={}.get, spec_set=True)
 @patch('os.geteuid')
 @patch('subprocess.Popen')
 def test_main_zypper_returns_100(
-        mock_subprocess, mock_geteuid, mock_args, mock_annotate
+        mock_subprocess, mock_geteuid, mock_args, mock_annotate, mock_name
 ):
     return_values = [(b'', b''), (b'zypper 1.14.15', b'')]
 
@@ -246,6 +257,9 @@ def test_main_zypper_returns_100(
             ['zypper', 'ps', '-sss'],
             stdout=-1, stderr=-1, env=ANY
         ),
+        call([
+            'rpm', '-q', 'caasp-release', '--queryformat', '%{VERSION}'
+        ], stdout=-1, stderr=-1, env=ANY),
         call([
             'zypper', 'needs-rebooting'
         ], stdout=None, stderr=None, env=ANY),
@@ -403,7 +417,7 @@ def test_annotate_updates_empty(mock_subprocess, mock_annotate, mock_name):
     )
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
-    annotate_updates_available()
+    annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
             ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
@@ -429,7 +443,7 @@ def test_annotate_updates(mock_subprocess, mock_annotate, mock_name):
     )
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
-    annotate_updates_available()
+    annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
             ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
@@ -457,7 +471,7 @@ def test_annotate_updates_available(mock_subprocess, mock_open, mock_name):
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
 
-    annotate_updates_available()
+    annotate_updates_available(mock_name.return_value)
 
     assert mock_subprocess.call_args_list == [
         call(
@@ -495,7 +509,7 @@ def test_annotate_updates_bad_xml(mock_subprocess, mock_annotate, mock_name):
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
 
-    annotate_updates_available()
+    annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
             ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
@@ -525,7 +539,7 @@ def test_annotate_updates_security(
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
 
-    annotate_updates_available()
+    annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
             ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
@@ -555,7 +569,7 @@ def test_annotate_updates_available_is_reboot(
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
 
-    annotate_updates_available()
+    annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
             ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
@@ -565,7 +579,34 @@ def test_annotate_updates_available_is_reboot(
     assert mock_annotate.call_args_list == [
         call('node', 'mynode', KUBE_UPDATES_KEY, 'yes'),
         call('node', 'mynode', KUBE_SECURITY_UPDATES_KEY, 'no'),
-        call('node', 'mynode', KUBE_DISRUPTIVE_UPDATES_KEY, 'yes')
+        call('node', 'mynode', KUBE_DISRUPTIVE_UPDATES_KEY, 'yes'),
+    ]
+
+
+@patch('skuba_update.skuba_update.node_name_from_machine_id')
+@patch('skuba_update.skuba_update.annotate')
+@patch('subprocess.Popen')
+def test_annotate_caasp_release_version(
+    mock_subprocess, mock_annotate, mock_name
+):
+    mock_name.return_value = 'mynode'
+
+    mock_process = Mock()
+    mock_process.communicate.return_value = (
+        b'1.2.3', b''
+    )
+    mock_process.returncode = 0
+    mock_subprocess.return_value = mock_process
+
+    annotate_caasp_release_version(mock_name.return_value)
+    assert mock_subprocess.call_args_list == [
+        call(
+            ['rpm', '-q', 'caasp-release', '--queryformat', '%{VERSION}'],
+            stdout=-1, stderr=-1, env=ANY
+        )
+    ]
+    assert mock_annotate.call_args_list == [
+        call('node', 'mynode', KUBE_CAASP_RELEASE_VERSION_KEY, '1.2.3'),
     ]
 
 

--- a/skuba-update/test/unit/skuba_update_test.py
+++ b/skuba-update/test/unit/skuba_update_test.py
@@ -121,7 +121,8 @@ def test_main_no_root(mock_subprocess, mock_args):
 @patch('os.geteuid')
 @patch('subprocess.Popen')
 def test_main(
-    mock_subprocess, mock_geteuid, mock_args, mock_annotate, mock_annotate_version, mock_name
+    mock_subprocess, mock_geteuid, mock_args,
+    mock_annotate, mock_annotate_version, mock_name
 ):
     return_values = [
         (b'some_service1\nsome_service2', b''),

--- a/skuba-update/test/unit/skuba_update_test.py
+++ b/skuba-update/test/unit/skuba_update_test.py
@@ -579,7 +579,7 @@ def test_annotate_updates_available_is_reboot(
     assert mock_annotate.call_args_list == [
         call('node', 'mynode', KUBE_UPDATES_KEY, 'yes'),
         call('node', 'mynode', KUBE_SECURITY_UPDATES_KEY, 'no'),
-        call('node', 'mynode', KUBE_DISRUPTIVE_UPDATES_KEY, 'yes'),
+        call('node', 'mynode', KUBE_DISRUPTIVE_UPDATES_KEY, 'yes')
     ]
 
 


### PR DESCRIPTION
## Why is this PR needed?

Fixes https://github.com/SUSE/avant-garde/issues/1095

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Fetch caasp-release-version per node in skuba-update, and annotated the caasp-release-version to node
```
caasp.suse.com/caasp-release-version: X.Y.Z
```

When node bootstrap/join/upgrade, skuba call `skuba-update` via systemctl, the `skuba-update` run immediately with setting `OnActiveSec=0` in `skuba-update.timer`. After `skuba-update` finished, the `skuba-update.timer` would schedule the next time (`OnCalendar=daily`) to trigger `skuba-update`.

The user could see the caasp-release-version via `skuba cluster status`
For example:
```
NAME      OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
master0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
master1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
master2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
worker0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
worker1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.26-default   v1.16.2           cri-o://1.16.0      <none>        <none>                   4.1.0
```

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

The user could only read caasp-release rpm package on each node step-by-step.

### Status **AFTER** applying the patch

The user could read caasp-release-version via `skuba cluster status`.

## Docs

https://github.com/SUSE/doc-caasp/pull/635

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
