### PR TITLE
CI: fix upgrade tests by importing function

### DIFF
--- a/ci/infra/testrunner/tests/test_skuba_upgrade.py
+++ b/ci/infra/testrunner/tests/test_skuba_upgrade.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 
-from tests.utils import (check_nodes_ready, wait)
+from tests.utils import (check_pods_ready, check_nodes_ready, wait)
 
 PREVIOUS_VERSION = "1.15.2"
 CURRENT_VERSION = "1.16.2"


### PR DESCRIPTION
## Why is this PR needed?

```
>       wait(check_pods_ready,
             kubectl,
             namespace="kube-system",
             wait_delay=60,
             wait_backoff=30,
             wait_elapsed=60*10,
             wait_allow=(AssertionError))
E       NameError: name 'check_pods_ready' is not defined
```

## What does this PR do?

correctly import function

## Anything else a reviewer needs to know?

Follow up of https://github.com/SUSE/skuba/pull/881

https://ci.suse.de/job/caasp-jobs/job/e2e/job/caasp-v4-openstack-test_upgrade_plan_from_previous_with_upgraded_control_plane-nightly/126/console
