### PR TITLE
Fix libvirt terraform JSON example

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -1,7 +1,7 @@
 {
     "libvirt_uri": "qemu:///system",
     "pool": "default",
-    "image_uri": "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU1.qcow2"
+    "image_uri": "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU1.qcow2",
     "stack_name": "testing",
     "network_cidr": "10.17.0.0/22",
     "dns_domain": "caasp.local",


### PR DESCRIPTION
 ## Why is this PR needed?
Without this patch, a libvirt deployment using the terraform example
file will fail with error:

  XML error: Cannot use host name '-lb' in network '-network'')

because the stack_name isn't defined because of the invalid JSON.

## What does this PR do?

This change fixes the issue by correcting the JSON example file.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
