### PR TITLE
Define log verbosity as 0 to 5

### DIFF
--- a/cmd/skuba/main.go
+++ b/cmd/skuba/main.go
@@ -80,7 +80,7 @@ func register(local *pflag.FlagSet, globalName string) {
 	if f := flag.CommandLine.Lookup(globalName); f != nil {
 		pflagFlag := pflag.PFlagFromGoFlag(f)
 		pflagFlag.Name = "verbosity"
-		pflagFlag.Usage = "number for the log level verbosity [0-10]"
+		pflagFlag.Usage = "log level [0-5]. 0 (Only Error and Warning) to 5 (Maximum detail)."
 		local.AddFlag(pflagFlag)
 	} else {
 		klog.Fatalf("failed to find flag in global flagset (flag): %s", globalName)

--- a/docs/man/skuba.1.md
+++ b/docs/man/skuba.1.md
@@ -4,7 +4,7 @@ skuba - tool to manage the full lifecycle of a Kubernetes cluster
 
 # SYNOPSIS
 **skuba**
-[**--help**|**-h**] [**-v**]
+[**-h**|**--help**] [**-v**|**--verbosity**]
 *command* [*args*]
 
 # DESCRIPTION
@@ -13,11 +13,11 @@ reconfiguration in an easy way.
 
 # GLOBAL OPTIONS
 
-**--help, -h**
+**-h, --help**
   Print usage statement.
 
-**-v**
-  number for the log level verbosity [0-10].
+**-v, --verbosity**
+  Log level [0-5]. 0 (Only Error and Warning) to 5 (Maximum detail).
 
 # COMMANDS
 


### PR DESCRIPTION
In an effort to make skuba consistent with upstream Kubernetes
logging practices, simplify the log level range from 10 to 5.
This change modifies the command line help and man page for skuba,
but does not change any existing calls to klog.V() in the code.

## Why is this PR needed?
This simplifies the log levels used by skuba.
https://github.com/SUSE/doc-caasp/pull/637
See also https://github.com/SUSE/avant-garde/issues/493

## What does this PR do?

This change modifies the command line help and man page for skuba,
but does not change any existing calls to klog.V() in the code.

## Info for QA
This change is somewhat cosmetic, and only changes the messages
displayed from "skuba -h" and in the man page.

### Related info
See also the documentation change to match in 
https://github.com/SUSE/doc-caasp/pull/637

## Docs
https://github.com/SUSE/doc-caasp/pull/637

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
