### PR TITLE
Stop using password to ssh into VMs (libvirt provider)

### DIFF
--- a/ci/infra/libvirt/cloud-init/common.tpl
+++ b/ci/infra/libvirt/cloud-init/common.tpl
@@ -6,13 +6,6 @@ locale: en_US.UTF-8
 # set timezone
 timezone: Etc/UTC
 
-# set root password
-chpasswd:
-  list: |
-    root:linux
-    ${username}:${password}
-  expire: False
-
 ssh_authorized_keys:
 ${authorized_keys}
 

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -95,7 +95,6 @@ data "template_file" "lb_cloud_init_userdata" {
     register_rmt       = join("\n", data.template_file.lb_register_rmt.*.rendered)
     commands           = join("\n", data.template_file.lb_commands.*.rendered)
     username           = var.username
-    password           = var.password
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-lb"
     hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
@@ -158,7 +157,6 @@ resource "null_resource" "lb_wait_cloudinit" {
       count.index
     )
     user     = var.username
-    password = var.password
     type     = "ssh"
   }
 

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -49,7 +49,6 @@ data "template_file" "master-cloud-init" {
     register_rmt       = join("\n", data.template_file.master_register_rmt.*.rendered)
     commands           = join("\n", data.template_file.master_commands.*.rendered)
     username           = var.username
-    password           = var.password
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-master-${count.index}"
     hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
@@ -111,7 +110,6 @@ resource "null_resource" "master_wait_cloudinit" {
       count.index
     )
     user     = var.username
-    password = var.password
     type     = "ssh"
   }
 

--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -36,10 +36,6 @@ dns_domain = "caasp.local"
 # EXAMPLE:
 username = "sles"
 
-# Password for the cluster nodes
-# EXAMPLE:
-password = "linux"
-
 # define the repositories to use
 # EXAMPLE:
 # repositories = {

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -57,11 +57,6 @@ variable "username" {
   description = "Username for the cluster nodes"
 }
 
-variable "password" {
-  default     = "linux"
-  description = "Password for the cluster nodes"
-}
-
 variable "caasp_registry_code" {
   default     = ""
   description = "SUSE CaaSP Product Registration Code"

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -49,7 +49,6 @@ data "template_file" "worker-cloud-init" {
     register_rmt       = join("\n", data.template_file.worker_register_rmt.*.rendered)
     commands           = join("\n", data.template_file.worker_commands.*.rendered)
     username           = var.username
-    password           = var.password
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-worker-${count.index}"
     hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
@@ -111,7 +110,6 @@ resource "null_resource" "worker_wait_cloudinit" {
       count.index
     )
     user     = var.username
-    password = var.password
     type     = "ssh"
   }
 


### PR DESCRIPTION
Unlike other Terraform providers, we are using the user/password
authentication in libvirt. This is not needed as the cloud-init step
will eventually configure the keys correctly and Terraform will be able
to ssh into the VM. Besides, it avoids a problem we are seeing between
ssh-agent and terraform:

https://github.com/hashicorp/terraform/issues/23662

Signed-off-by: Manuel Buil <mbuil@suse.com>

## Why is this PR needed?
Yes, please read commit message

## What does this PR do?

Yes, please read commit message

## Anything else a reviewer needs to know?

This PR replaces the old one https://github.com/SUSE/skuba/pull/892

## Info for QA

This PR fixes a bug which appears from time to time when deploying terraform + libvirt and aligns the way to do ssh with other providers (e.g. openstack)

### Related info

This patch is related to https://github.com/hashicorp/terraform/issues/23662

### Status **BEFORE** applying the patch

Deploying skuba with terraform + libvirt as provider. It sometimes fail in the cloud_init step with a ssh problem

### Status **AFTER** applying the patch

The deployment never fails in the cloud_init step

## Docs

No docs needed

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
