### PR TITLE
Do not panic when version Unknown (bsc#1159452)

### DIFF
--- a/internal/pkg/skuba/kubernetes/node_version.go
+++ b/internal/pkg/skuba/kubernetes/node_version.go
@@ -168,11 +168,14 @@ func nodeVersioningInfo(client clientset.Interface, nodeName string) (NodeVersio
 	unschedulable := nodeObject.Spec.Unschedulable
 
 	// Extract the container runtime version from the raw version
-	containerRuntimeVersion := runtimeVersionRegexp.FindStringSubmatch(containerRuntimeVersionRaw)[1]
+	containerRuntimeVersion, err := version.ParseSemantic(runtimeVersionRegexp.FindStringSubmatch(containerRuntimeVersionRaw)[1])
+	if err != nil {
+		return NodeVersionInfo{}, errors.Wrapf(err, "could not retrieve node %q container runtime version", nodeName)
+	}
 
 	nodeVersions := NodeVersionInfo{
 		Nodename:                nodeName,
-		ContainerRuntimeVersion: version.MustParseSemantic(containerRuntimeVersion),
+		ContainerRuntimeVersion: containerRuntimeVersion,
 		KubeletVersion:          kubeletVersion,
 		Unschedulable:           unschedulable,
 	}


### PR DESCRIPTION
## Why is this PR needed?

If the container runtime version is Unknown, run `skuba node upgrade plan` or `skuba addon upgrade plan` would panic.

During node upgrade finished, there might exist a short time that kubelet fetched crio version is "Unknown". This is a timing issue bug.

Fixes https://github.com/SUSE/avant-garde/issues/1169

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Change parse crio version from `MustParseSemantic` to `ParseSemantic`, report error is the version cannot be parsed.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This issue not easily reproduced manually, please help double verify this, especially on VMWare environment.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

skuba crash when crio version is Unknown.

### Status **AFTER** applying the patch

skuba not crash but report error when crio version is Unknown.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
