### PR TITLE
Add more unit-test for kubelet

### DIFF
--- a/internal/pkg/skuba/kubernetes/jobs_test.go
+++ b/internal/pkg/skuba/kubernetes/jobs_test.go
@@ -28,7 +28,7 @@ import (
 	ktest "k8s.io/client-go/testing"
 )
 
-func Test_CreateJob(t *testing.T) {
+func TestCreateJob(t *testing.T) {
 	tests := []struct {
 		name          string
 		errExpected   bool
@@ -131,7 +131,7 @@ func Test_CreateJob(t *testing.T) {
 	}
 }
 
-func Test_Delete(t *testing.T) {
+func TestDelete(t *testing.T) {
 	tests := []struct {
 		name         string
 		jobName      string
@@ -189,7 +189,7 @@ func Test_Delete(t *testing.T) {
 	}
 }
 
-func Test_CreateAndWaitForJob(t *testing.T) {
+func TestCreateAndWaitForJob(t *testing.T) {
 	tests := []struct {
 		name           string
 		timeout        int

--- a/internal/pkg/skuba/kubernetes/nodes_test.go
+++ b/internal/pkg/skuba/kubernetes/nodes_test.go
@@ -82,7 +82,7 @@ func createNode(name string, isControlPlane bool, machineID string) corev1.Node 
 	}
 }
 
-func Test_GetAllNodes(t *testing.T) {
+func TestGetAllNodes(t *testing.T) {
 	tests := []struct {
 		name          string
 		fakeClientset *fake.Clientset
@@ -138,7 +138,7 @@ func Test_GetAllNodes(t *testing.T) {
 	}
 }
 
-func Test_GetControlPlaneNodes(t *testing.T) {
+func TestGetControlPlaneNodes(t *testing.T) {
 	tests := []struct {
 		name          string
 		fakeClientset *fake.Clientset
@@ -204,7 +204,7 @@ func Test_GetControlPlaneNodes(t *testing.T) {
 	}
 }
 
-func Test_GetNodeWithMachineID(t *testing.T) {
+func TestGetNodeWithMachineID(t *testing.T) {
 	fakeClientset := fake.NewSimpleClientset(
 		&corev1.NodeList{
 			Items: []corev1.Node{
@@ -257,7 +257,7 @@ func Test_GetNodeWithMachineID(t *testing.T) {
 	}
 }
 
-func Test_DrainNode(t *testing.T) {
+func TestDrainNode(t *testing.T) {
 	tests := []struct {
 		name         string
 		node         string

--- a/internal/pkg/skuba/kubernetes/resources_test.go
+++ b/internal/pkg/skuba/kubernetes/resources_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_DoesResourceExistWithError(t *testing.T) {
+func TestDoesResourceExistWithError(t *testing.T) {
 	fakeWorker := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "worker",

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -126,7 +126,7 @@ func getVersionTestData() versionTestData {
 
 var vtd = getVersionTestData()
 
-func Test_ComponentVersionForClusterVersion(t *testing.T) {
+func TestComponentVersionForClusterVersion(t *testing.T) {
 	var tests = vtd.hostComponent
 	tests = append(
 		tests,
@@ -150,7 +150,7 @@ func Test_ComponentVersionForClusterVersion(t *testing.T) {
 	}
 }
 
-func Test_AllComponentContainerImagesForClusterVersion(t *testing.T) {
+func TestAllComponentContainerImagesForClusterVersion(t *testing.T) {
 	var clusterVersion *version.Version
 	for ver := range supportedVersions {
 		clusterVersion = version.MustParseSemantic(ver)
@@ -172,7 +172,7 @@ func Test_AllComponentContainerImagesForClusterVersion(t *testing.T) {
 	}
 }
 
-func Test_ComponentContainerImageForClusterVersion(t *testing.T) {
+func TestComponentContainerImageForClusterVersion(t *testing.T) {
 	var tests = vtd.containerComponent
 	tests = append(
 		tests,
@@ -204,7 +204,7 @@ func Test_ComponentContainerImageForClusterVersion(t *testing.T) {
 	}
 }
 
-func Test_AddonVersionForClusterVersion(t *testing.T) {
+func TestAddonVersionForClusterVersion(t *testing.T) {
 	var tests = vtd.addon
 	tests = append(
 		tests,
@@ -239,7 +239,7 @@ func Test_AddonVersionForClusterVersion(t *testing.T) {
 	}
 }
 
-func Test_AllAddonVersionsForClusterVersion(t *testing.T) {
+func TestAllAddonVersionsForClusterVersion(t *testing.T) {
 	type test struct {
 		name           string
 		clusterVersion *version.Version
@@ -286,7 +286,7 @@ func Test_AllAddonVersionsForClusterVersion(t *testing.T) {
 	}
 }
 
-func Test_AvailableVersionsForMap(t *testing.T) {
+func TestAvailableVersionsForMap(t *testing.T) {
 	var versions = []struct {
 		name                      string
 		kubernetesVersions        KubernetesVersions
@@ -328,19 +328,19 @@ func Test_AvailableVersionsForMap(t *testing.T) {
 	}
 }
 
-func Test_LatestVersion(t *testing.T) {
+func TestLatestVersion(t *testing.T) {
 	if _, ok := supportedVersions[LatestVersion().String()]; !ok {
 		t.Errorf("Versions map --authoritative version mapping-- does not include version %q", LatestVersion().String())
 	}
 }
 
-func Test_IsVersionAvailable(t *testing.T) {
+func TestIsVersionAvailable(t *testing.T) {
 	if !IsVersionAvailable(LatestVersion()) {
 		t.Errorf("Versions map does not include version %q", LatestVersion().String())
 	}
 }
 
-func Test_MajorMinorVersion(t *testing.T) {
+func TestMajorMinorVersion(t *testing.T) {
 	tests := []struct {
 		name                      string
 		version                   *version.Version

--- a/internal/pkg/skuba/kubernetes/volumes_test.go
+++ b/internal/pkg/skuba/kubernetes/volumes_test.go
@@ -25,7 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Test_VolumeMount(t *testing.T) {
+func TestVolumeMount(t *testing.T) {
 	tests := []struct {
 		name                string
 		volumeName          string
@@ -82,7 +82,7 @@ func Test_VolumeMount(t *testing.T) {
 	}
 }
 
-func Test_HostMount(t *testing.T) {
+func TestHostMount(t *testing.T) {
 	tests := []struct {
 		name          string
 		volumeName    string


### PR DESCRIPTION
## Why is this PR needed?

Increase unit test code coverage.
Ref: SUSE/avant-garde#744

## What does this PR do?

Tests include:
* generate kubelet root cert
* generate kubelet root cert when already exist
* disarm kubelet

Other changes:
* Refactor TestDisarmKubeletJobName to consolidate duplicated codes.
* Unify test function names in kubernetes.

## Anything else a reviewer needs to know?

## Info for QA

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes/kubelet.go (6.2%)
```

### Status **AFTER** applying the patch

```
github.com/SUSE/skuba/internal/pkg/skuba/kubernetes/kubelet.go (87.5%)
```

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
