### PR TITLE
Pass verbose level to kubeadm

### DIFF
--- a/cmd/skuba/flags/verbose.go
+++ b/cmd/skuba/flags/verbose.go
@@ -21,6 +21,7 @@ import (
 	"flag"
 
 	"github.com/spf13/pflag"
+	"k8s.io/klog"
 )
 
 const (
@@ -46,5 +47,7 @@ func RegisterVerboseFlag(local *pflag.FlagSet) {
 		pflagFlag.Name = verboseLevelFlagLong
 		pflagFlag.Usage = verboseLevelFlagUsage
 		local.AddFlag(pflagFlag)
+	} else {
+		klog.Fatalf("failed to find flag in global flagset (flag): %s", verboseLevelFlagShort)
 	}
 }

--- a/cmd/skuba/flags/verbose.go
+++ b/cmd/skuba/flags/verbose.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package flags
+
+import (
+	"flag"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	verboseLevelFlagShort = "v"
+	verboseLevelFlagLong  = "verbosity"
+	verboseLevelFlagUsage = "log level [0-5]. 0 (Only Error and Warning) to 5 (Maximum detail)."
+)
+
+// GetVerboseFlagLevel returns verbose flag level.
+func GetVerboseFlagLevel() string {
+	if f := flag.CommandLine.Lookup(verboseLevelFlagShort); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		return pflagFlag.Value.String()
+	}
+
+	return "0"
+}
+
+// RegisterVerboseFlag register verbose flag.
+func RegisterVerboseFlag(local *pflag.FlagSet) {
+	if f := flag.CommandLine.Lookup(verboseLevelFlagShort); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		pflagFlag.Name = verboseLevelFlagLong
+		pflagFlag.Usage = verboseLevelFlagUsage
+		local.AddFlag(pflagFlag)
+	}
+}

--- a/cmd/skuba/main.go
+++ b/cmd/skuba/main.go
@@ -18,16 +18,15 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/cmd/skuba/flags"
 	skubapkg "github.com/SUSE/skuba/pkg/skuba"
 )
 
@@ -46,7 +45,7 @@ func newRootCmd() *cobra.Command {
 		NewAddonCmd(),
 	)
 
-	register(cmd.PersistentFlags(), "v")
+	flags.RegisterVerboseFlag(cmd.PersistentFlags())
 
 	return cmd
 }
@@ -72,17 +71,5 @@ func printVersionStatement() {
 		fmt.Println("** This is a RC release and NOT intended for production usage. **")
 	case skubapkg.BuildType != "release":
 		fmt.Printf("** This is a tagged version (%s), but is not built in release mode (mode: %q.) **\n", skubapkg.Tag, skubapkg.BuildType)
-	}
-}
-
-// register adds a flag to local that targets the Value associated with the Flag named globalName in flag.CommandLine.
-func register(local *pflag.FlagSet, globalName string) {
-	if f := flag.CommandLine.Lookup(globalName); f != nil {
-		pflagFlag := pflag.PFlagFromGoFlag(f)
-		pflagFlag.Name = "verbosity"
-		pflagFlag.Usage = "log level [0-5]. 0 (Only Error and Warning) to 5 (Maximum detail)."
-		local.AddFlag(pflagFlag)
-	} else {
-		klog.Fatalf("failed to find flag in global flagset (flag): %s", globalName)
 	}
 }

--- a/cmd/skuba/node/bootstrap.go
+++ b/cmd/skuba/node/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/cmd/skuba/flags"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
 	"github.com/SUSE/skuba/pkg/skuba/actions"
@@ -50,7 +51,7 @@ func NewBootstrapCmd() *cobra.Command {
 			}
 
 			role := deployments.MasterRole
-			d := target.GetDeployment(nodenames[0], &role)
+			d := target.GetDeployment(nodenames[0], &role, flags.GetVerboseFlagLevel())
 			if err := node.Bootstrap(bootstrapConfiguration, d); err != nil {
 				klog.Fatalf("error bootstrapping node: %s", err)
 			}

--- a/cmd/skuba/node/join.go
+++ b/cmd/skuba/node/join.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/cmd/skuba/flags"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
@@ -58,7 +59,7 @@ func NewJoinCmd() *cobra.Command {
 				klog.Errorf("unable to get admin client set: %s", err)
 				os.Exit(1)
 			}
-			if err := node.Join(clientSet, joinConfiguration, target.GetDeployment(nodenames[0], &joinConfiguration.Role)); err != nil {
+			if err := node.Join(clientSet, joinConfiguration, target.GetDeployment(nodenames[0], &joinConfiguration.Role, flags.GetVerboseFlagLevel())); err != nil {
 				klog.Fatalf("error joining node %s: %s", nodenames[0], err)
 			}
 		},

--- a/cmd/skuba/node/upgrade.go
+++ b/cmd/skuba/node/upgrade.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	"github.com/SUSE/skuba/cmd/skuba/flags"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/pkg/skuba/actions/node/upgrade"
@@ -74,7 +75,7 @@ func newUpgradeApplyCmd() *cobra.Command {
 				klog.Errorf("unable to get admin client set: %s", err)
 				os.Exit(1)
 			}
-			if err := upgrade.Apply(clientSet, target.GetDeployment("", nil)); err != nil {
+			if err := upgrade.Apply(clientSet, target.GetDeployment("", nil, flags.GetVerboseFlagLevel())); err != nil {
 				fmt.Printf("Unable to apply node upgrade: %s\n", err)
 				os.Exit(1)
 			}

--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -62,7 +62,7 @@ func kubeadmInit(t *Target, data interface{}) error {
 	if len(ignorePreflightErrorsVal) > 0 {
 		ignorePreflightErrors = "--ignore-preflight-errors=" + ignorePreflightErrorsVal
 	}
-	_, _, err := t.ssh("kubeadm", "init", "--config", remoteKubeadmInitConfFile, "--skip-token-print", ignorePreflightErrors)
+	_, _, err := t.ssh("kubeadm", "init", "--config", remoteKubeadmInitConfFile, "--skip-token-print", ignorePreflightErrors, "-v", t.verboseLevel)
 	return err
 }
 
@@ -98,12 +98,12 @@ func kubeadmJoin(t *Target, data interface{}) error {
 	if len(ignorePreflightErrorsVal) > 0 {
 		ignorePreflightErrors = "--ignore-preflight-errors=" + ignorePreflightErrorsVal
 	}
-	_, _, err = t.ssh("kubeadm", "join", "--config", remoteKubeadmInitConfFile, ignorePreflightErrors)
+	_, _, err = t.ssh("kubeadm", "join", "--config", remoteKubeadmInitConfFile, ignorePreflightErrors, "-v", t.verboseLevel)
 	return err
 }
 
 func kubeadmReset(t *Target, data interface{}) error {
-	_, _, err := t.ssh("kubeadm", "reset", "--cri-socket", "/var/run/crio/crio.sock", "--ignore-preflight-errors", "all", "--force")
+	_, _, err := t.ssh("kubeadm", "reset", "--cri-socket", "/var/run/crio/crio.sock", "--ignore-preflight-errors", "all", "--force", "-v", t.verboseLevel)
 	return err
 }
 
@@ -126,11 +126,11 @@ func kubeadmUpgradeApply(t *Target, data interface{}) error {
 		}
 	}()
 
-	_, _, err := t.ssh("kubeadm", "upgrade", "apply", "--config", remoteKubeadmUpgradeConfFile, "-y")
+	_, _, err := t.ssh("kubeadm", "upgrade", "apply", "--config", remoteKubeadmUpgradeConfFile, "-y", "-v", t.verboseLevel)
 	return err
 }
 
 func kubeadmUpgradeNode(t *Target, data interface{}) error {
-	_, _, err := t.ssh("kubeadm", "upgrade", "node")
+	_, _, err := t.ssh("kubeadm", "upgrade", "node", "-v", t.verboseLevel)
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/ssh.go
+++ b/internal/pkg/skuba/deployments/ssh/ssh.go
@@ -83,12 +83,13 @@ var (
 )
 
 type Target struct {
-	target     *deployments.Target
-	user       string
-	targetName string
-	sudo       bool
-	port       int
-	client     *ssh.Client
+	target       *deployments.Target
+	user         string
+	targetName   string
+	sudo         bool
+	port         int
+	verboseLevel string
+	client       *ssh.Client
 }
 
 // GetFlags adds init flags bound to the config to the specified flagset
@@ -108,17 +109,18 @@ func (t Target) String() string {
 	return fmt.Sprintf("%s@%s:%d", t.user, t.target.Target, t.port)
 }
 
-func (t *Target) GetDeployment(nodename string, role *deployments.Role) *deployments.Target {
+func (t *Target) GetDeployment(nodename string, role *deployments.Role, verboseLevel string) *deployments.Target {
 	res := deployments.Target{
 		Target:   t.targetName,
 		Nodename: nodename,
 		Role:     role,
 	}
 	res.Actionable = &Target{
-		target: &res,
-		user:   t.user,
-		sudo:   t.sudo,
-		port:   t.port,
+		target:       &res,
+		user:         t.user,
+		sudo:         t.sudo,
+		port:         t.port,
+		verboseLevel: verboseLevel,
 	}
 	return &res
 }


### PR DESCRIPTION
## Why is this PR needed?

The skuba verbosity does not distribute to kubeadm, sometimes make it hard to troubleshoot kubeadm issue without pass the verbosity.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Pass skuba verbosity to kubeadm.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

Setup verbosity to 1, the log output of kubeadm part DOES NOT display klog.V(1) related log.

### Status **AFTER** applying the patch

Setup verbosity to 1, the log output of kubeadm part DOES display klog.V(1) related log.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>