### PR TITLE
add missing quotes

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-code-lint.Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
             sh(script: 'make lint', label: 'make lint')
         } }
         stage('Checking status of git tree') { steps {
-            sh(script: 'test -z $(git status --porcelain go.mod go.sum vendor/) || { echo "there are uncommitted changes. This should never happen"; exit 1; }', label: 'git tree status')
+            sh(script: 'test -z "$(git status --porcelain go.mod go.sum vendor/)" || { echo "there are uncommitted changes. This should never happen"; exit 1; }', label: 'git tree status')
         } }
 
         // TODO: Add here golint later on


### PR DESCRIPTION
## Why is this PR needed?

Fix an undesirable error message which is confusing, but which does not affect script functionality

## What does this PR do?

Add a set of quotes which were previously missing.

## Anything else a reviewer needs to know?

If there are no changes, the command emits nothing but whitespace, which `$()` eats.  If there are changes, the command emits the list of filesystem entries which are changed.  Without the quotes, this causes the `test` command to fail and emit a usage error.  With the quotes, the string is not empty ("**z**ero size"), and test still returns false - but no confusing error message is emitted.  We want the "with quotes" behavior.

## Info for QA

N/A

### Related info

test results:
```bash
sauer@macdanny:~/dev/skuba> test -z $(git status --porcelain go.mod go.sum vendor/); echo $?
0
sauer@macdanny:~/dev/skuba> test -z "$(git status --porcelain go.mod go.sum vendor/)"; echo $?
0
sauer@macdanny:~/dev/skuba> touch vendor/file
sauer@macdanny:~/dev/skuba> test -z $(git status --porcelain go.mod go.sum vendor/); echo $?
bash: test: ci: binary operator expected
2
sauer@macdanny:~/dev/skuba> test -z "$(git status --porcelain go.mod go.sum vendor/)"; echo $?
1
```

### Status **BEFORE** applying the patch

Start with an unchanged git repo.  Run `test -z $(git status --porcelain go.mod go.sum vendor/); echo $?".  Observe zero exit code.  Make a change to a file.  Run the same command.  Observe error message and non-zero exit code.

### Status **AFTER** applying the patch

Start with an unchanged git repo.  Run modified code: `test -z "$(git status --porcelain go.mod go.sum vendor/)"; echo $?".  Observe zero exit code.  Make a change to a file.  Run the same command.  Observe non-zero exit code without stderr output.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
