### PR TITLE
Changed libvirt output in terraform

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -68,7 +68,7 @@ resource "libvirt_volume" "lb" {
 }
 
 resource "libvirt_cloudinit_disk" "lb" {
-  name = "${var.stack_name}-lib-cloudinit-disk"
+  name = "${var.stack_name}-lb-cloudinit-disk"
   pool = "${var.pool}"
 
   user_data = "${data.template_file.lb_cloud_init_userdata.rendered}"

--- a/ci/infra/libvirt/output.tf
+++ b/ci/infra/libvirt/output.tf
@@ -1,19 +1,11 @@
-output "hostnames_masters" {
-  value = ["${libvirt_domain.master.*.network_interface.0.hostname}"]
-}
-
-output "hostnames_workers" {
-  value = ["${libvirt_domain.worker.*.network_interface.0.hostname}"]
-}
-
 output "ip_load_balancer" {
-  value = "${libvirt_domain.lb.network_interface.0.addresses.0}"
+  value = "${zipmap(libvirt_domain.lb.*.network_interface.0.hostname, libvirt_domain.lb.*.network_interface.0.addresses.0)}"
 }
 
 output "ip_masters" {
-  value = ["${libvirt_domain.master.*.network_interface.0.addresses.0}"]
+  value = "${zipmap(libvirt_domain.master.*.network_interface.0.hostname, libvirt_domain.master.*.network_interface.0.addresses.0)}"
 }
 
 output "ip_workers" {
-  value = ["${libvirt_domain.worker.*.network_interface.0.addresses.0}"]
+  value = "${zipmap(libvirt_domain.worker.*.network_interface.0.hostname, libvirt_domain.worker.*.network_interface.0.addresses.0)}"
 }


### PR DESCRIPTION
1. changed output to map hostnames with ip addresses
2. fix misspelled 'lib' to 'lb' on lb-instances.tf

## Why is this PR needed?
Mapping hostnames with ip addresses
From:
```
Outputs:

hostnames_masters = [
    clee-master-0,
    clee-master-1,
    clee-master-2
]
hostnames_workers = [
    clee-worker-0,
    clee-worker-1,
    clee-worker-2
]
ip_load_balancer = 10.17.1.0
ip_masters = [
    10.17.2.0,
    10.17.2.1,
    10.17.2.2
]
ip_workers = [
    10.17.3.0,
    10.17.3.1,
    10.17.3.2
]
```
To:
```
Outputs:

ip_load_balancer = {
  clee-lb = 10.17.1.0
}
ip_masters = {
  clee-master-0 = 10.17.2.0
  clee-master-1 = 10.17.2.1
  clee-master-2 = 10.17.2.2
}
ip_workers = {
  clee-worker-0 = 10.17.3.0
  clee-worker-1 = 10.17.3.1
  clee-worker-2 = 10.17.3.2
}

```
# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
