### PR TITLE
libvirt: Fix ip in testrunner

### DIFF
--- a/ci/infra/testrunner/platforms/libvirt.py
+++ b/ci/infra/testrunner/platforms/libvirt.py
@@ -17,3 +17,15 @@ class Libvirt(Terraform):
     def _cleanup_platform(self):
         self.destroy()
 
+    def get_lb_ipaddr(self):
+        self._load_tfstate()
+        return self.state["modules"][0]["outputs"]["ip_load_balancer"]["value"]["{}-lb".format(self.conf.terraform.stack_name)]
+
+    def get_nodes_ipaddrs(self, role):
+        self._load_tfstate()
+
+        if role not in ("master", "worker"):
+            raise ValueError("Invalid role: {}".format(role))
+        role_key = "ip_" + role + "s"
+
+        return list(self.state["modules"][0]["outputs"][role_key]["value"].values())


### PR DESCRIPTION
commit 084b421e048c5a17f47c65534e66c090a4092295 introduced a change in
the output for the libvirt deployments which now included the node
names.

Unfortunately testrunner was not updated to use that new format which
results in the impossibility of bootstraping the master node as we
return a dictionary instead of the master0 IP/FQDN.

This patch fixes that by returning the IP as before

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
