### PR TITLE
skuba-update: include --userdata in calls to zypper

### DIFF
--- a/skuba-update/skuba_update/skuba_update.py
+++ b/skuba-update/skuba_update/skuba_update.py
@@ -75,7 +75,7 @@ def main():
     if os.geteuid() != 0:
         raise Exception('root privileges are required to run this tool')
 
-    run_zypper_command(['zypper', 'ref', '-s'])
+    run_zypper_command(['ref', '-s'])
     if not args.annotate_only:
         code = update()
         restart_services()
@@ -142,7 +142,7 @@ def annotate_updates_available(node_name):
     """
 
     patch_xml = run_zypper_command(
-        ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+        ['--non-interactive', '--xmlout', 'list-patches'],
         needsOutput=True
     ).output
     updates = get_update_list(patch_xml)
@@ -241,7 +241,7 @@ def restart_services():
     restart.
     """
 
-    result = run_zypper_command(['zypper', 'ps', '-sss'], needsOutput=True)
+    result = run_zypper_command(['ps', '-sss'], needsOutput=True)
     for service in result.output.splitlines():
         cmd = run_command(['systemctl', 'restart', service], needsOutput=False)
         if cmd.returncode != 0:
@@ -272,7 +272,7 @@ def is_reboot_needed():
     """
 
     return run_zypper_command(
-        ['zypper', 'needs-rebooting']
+        ['needs-rebooting']
     ) == ZYPPER_EXIT_INF_REBOOT_NEEDED
 
 
@@ -312,10 +312,11 @@ def run_zypper_command(command, needsOutput=False):
     Run the given zypper command. The command is expected to be a tuple which
     also contains the 'zypper' string. It returns the exit code from zypper.
     """
+    zypperCommand = ['zypper', '--userdata', 'skuba-update', ] + command
 
-    process = run_command(command, needsOutput)
+    process = run_command(zypperCommand, needsOutput)
     if is_zypper_error(process.returncode):
-        raise Exception('"{0}" failed'.format(' '.join(command)))
+        raise Exception('"{0}" failed'.format(' '.join(zypperCommand)))
     if needsOutput:
         return process
     return process.returncode
@@ -323,8 +324,8 @@ def run_zypper_command(command, needsOutput=False):
 
 def run_zypper_patch():
     return run_zypper_command([
-        'zypper', '--non-interactive',
-        '--non-interactive-include-reboot-patches', 'patch'
+        '--non-interactive', '--non-interactive-include-reboot-patches',
+        'patch'
     ])
 
 

--- a/skuba-update/test/unit/skuba_update_test.py
+++ b/skuba-update/test/unit/skuba_update_test.py
@@ -146,13 +146,16 @@ def test_main(
     main()
     assert mock_subprocess.call_args_list == [
         call(['zypper', '--version'], stdout=-1, stderr=-1, env=ANY),
-        call(['zypper', 'ref', '-s'], stdout=None, stderr=None, env=ANY),
+        call(
+            ['zypper', '--userdata', 'skuba-update', 'ref', '-s'],
+            stdout=None, stderr=None, env=ANY
+        ),
         call([
-            'zypper', '--non-interactive',
+            'zypper', '--userdata', 'skuba-update', '--non-interactive',
             '--non-interactive-include-reboot-patches', 'patch'
         ], stdout=None, stderr=None, env=ANY),
         call(
-            ['zypper', 'ps', '-sss'],
+            ['zypper', '--userdata', 'skuba-update', 'ps', '-sss'],
             stdout=-1, stderr=-1, env=ANY
         ),
         call(
@@ -163,7 +166,10 @@ def test_main(
             ['systemctl', 'restart', 'some_service2'],
             stdout=None, stderr=None, env=ANY
         ),
-        call(['zypper', 'needs-rebooting'], stdout=None, stderr=None, env=ANY),
+        call(
+            ['zypper', '--userdata', 'skuba-update', 'needs-rebooting'],
+            stdout=None, stderr=None, env=ANY
+        ),
     ]
 
 
@@ -210,7 +216,10 @@ def test_main_annotate_only(
     main()
     assert mock_subprocess.call_args_list == [
         call(['zypper', '--version'], stdout=-1, stderr=-1, env=ANY),
-        call(['zypper', 'ref', '-s'], stdout=None, stderr=None, env=ANY),
+        call(
+            ['zypper', '--userdata', 'skuba-update', 'ref', '-s'],
+            stdout=None, stderr=None, env=ANY
+        ),
         call([
             'rpm', '-q', 'caasp-release', '--queryformat', '%{VERSION}'
         ], stdout=-1, stderr=-1, env=ANY),
@@ -245,24 +254,26 @@ def test_main_zypper_returns_100(
     main()
     assert mock_subprocess.call_args_list == [
         call(['zypper', '--version'], stdout=-1, stderr=-1, env=ANY),
-        call(['zypper', 'ref', '-s'], stdout=None, stderr=None, env=ANY),
         call([
-            'zypper', '--non-interactive',
+            'zypper', '--userdata', 'skuba-update', 'ref', '-s'
+        ], stdout=None, stderr=None, env=ANY),
+        call([
+            'zypper', '--userdata', 'skuba-update', '--non-interactive',
             '--non-interactive-include-reboot-patches', 'patch'
         ], stdout=None, stderr=None, env=ANY),
         call([
-            'zypper', '--non-interactive',
+            'zypper', '--userdata', 'skuba-update', '--non-interactive',
             '--non-interactive-include-reboot-patches', 'patch'
         ], stdout=None, stderr=None, env=ANY),
         call(
-            ['zypper', 'ps', '-sss'],
+            ['zypper', '--userdata', 'skuba-update', 'ps', '-sss'],
             stdout=-1, stderr=-1, env=ANY
         ),
         call([
             'rpm', '-q', 'caasp-release', '--queryformat', '%{VERSION}'
         ], stdout=-1, stderr=-1, env=ANY),
         call([
-            'zypper', 'needs-rebooting'
+            'zypper', '--userdata', 'skuba-update', 'needs-rebooting'
         ], stdout=None, stderr=None, env=ANY),
     ]
 
@@ -295,11 +306,11 @@ def test_run_zypper_command(mock_subprocess):
     mock_process.communicate.return_value = (b'stdout', b'stderr')
     mock_process.returncode = 0
     mock_subprocess.return_value = mock_process
-    assert run_zypper_command(['zypper', 'patch']) == 0
+    assert run_zypper_command(['patch']) == 0
     mock_process.returncode = ZYPPER_EXIT_INF_RESTART_NEEDED
     mock_subprocess.return_value = mock_process
     assert run_zypper_command(
-        ['zypper', 'patch']) == ZYPPER_EXIT_INF_RESTART_NEEDED
+        ['patch']) == ZYPPER_EXIT_INF_RESTART_NEEDED
 
 
 @patch('subprocess.Popen')
@@ -310,10 +321,10 @@ def test_run_zypper_command_failure(mock_subprocess):
     mock_subprocess.return_value = mock_process
     exception = False
     try:
-        run_zypper_command(['zypper', 'patch']) == 'stdout'
+        run_zypper_command(['patch']) == 'stdout'
     except Exception as e:
         exception = True
-        assert '"zypper patch" failed' in str(e)
+        assert '"zypper --userdata skuba-update patch" failed' in str(e)
     assert exception
 
 
@@ -421,7 +432,8 @@ def test_annotate_updates_empty(mock_subprocess, mock_annotate, mock_name):
     annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
-            ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+            ['zypper', '--userdata', 'skuba-update',
+             '--non-interactive', '--xmlout', 'list-patches'],
             stdout=-1, stderr=-1, env=ANY
         )
     ]
@@ -447,7 +459,8 @@ def test_annotate_updates(mock_subprocess, mock_annotate, mock_name):
     annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
-            ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+            ['zypper', '--userdata', 'skuba-update',
+             '--non-interactive', '--xmlout', 'list-patches'],
             stdout=-1, stderr=-1, env=ANY
         )
     ]
@@ -476,7 +489,8 @@ def test_annotate_updates_available(mock_subprocess, mock_open, mock_name):
 
     assert mock_subprocess.call_args_list == [
         call(
-            ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+            ['zypper', '--userdata', 'skuba-update',
+             '--non-interactive', '--xmlout', 'list-patches'],
             stdout=-1, stderr=-1, env=ANY
         ),
         call(
@@ -513,7 +527,8 @@ def test_annotate_updates_bad_xml(mock_subprocess, mock_annotate, mock_name):
     annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
-            ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+            ['zypper', '--userdata', 'skuba-update',
+             '--non-interactive', '--xmlout', 'list-patches'],
             stdout=-1, stderr=-1, env=ANY
         )
     ]
@@ -543,7 +558,8 @@ def test_annotate_updates_security(
     annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
-            ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+            ['zypper', '--userdata', 'skuba-update',
+             '--non-interactive', '--xmlout', 'list-patches'],
             stdout=-1, stderr=-1, env=ANY
         )
     ]
@@ -573,7 +589,8 @@ def test_annotate_updates_available_is_reboot(
     annotate_updates_available(mock_name.return_value)
     assert mock_subprocess.call_args_list == [
         call(
-            ['zypper', '--non-interactive', '--xmlout', 'list-patches'],
+            ['zypper', '--userdata', 'skuba-update',
+             '--non-interactive', '--xmlout', 'list-patches'],
             stdout=-1, stderr=-1, env=ANY
         )
     ]


### PR DESCRIPTION
To help differentiate calls to zypper from Skuba from calls made
by a user administrator, include a --userdata flag in the command.

## Why is this PR needed?

https://github.com/SUSE/skuba/issues/904

## What does this PR do?

This change does a minor refactor to the run_zypper_command in skuba-update.py
A further change will later be made to kubernetes.go to match.

## Anything else a reviewer needs to know?

A simple static userdata identifier is sufficient for now (log messages already contain
a timestamp to make them unique and come from a unique machine).

## Info for QA

This change has virtually no impact to a user, as it does not change any functional behavior.
The one marker for this change working is that when skuba-update is run, any commands
to zypper will now include the --userdata flag, so when zypper writes to its log at 
/var/log/zypper.log, lines similar to this will appear:

`2020-01-15 18:52:28 <1> test-worker-0(7476) [zypper] main.cc(main):98 ===== 'zypper' '--userdata' 'skuba-update' 'ref' =====`

`2020-01-15 18:52:28 <1> test-worker-0(7476) [zconfig] ZConfig.cc(setUserData):908 Set user data string to 'skuba-update'`

This userdata may also be visible in the system journal when the zypper command is logged.

## Docs

No known docs impact.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
