### PR TITLE
add --userdata to call to zypper

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -78,7 +78,7 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 		updatedVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.UpdatedVersion))
 		patternName = fmt.Sprintf("patterns-caasp-Node-%s-%s", currentVersion, updatedVersion)
 	}
-	_, _, err = t.ssh("zypper", "--non-interactive", "install", patternName)
+	_, _, err = t.ssh("zypper", "--userdata", "skuba-update", "--non-interactive", "install", patternName)
 	return err
 }
 

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -78,7 +78,7 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 		updatedVersion := kubernetes.MajorMinorVersion(version.MustParseSemantic(kubernetesBaseOSConfiguration.UpdatedVersion))
 		patternName = fmt.Sprintf("patterns-caasp-Node-%s-%s", currentVersion, updatedVersion)
 	}
-	_, _, err = t.ssh("zypper", "--userdata", "skuba-update", "--non-interactive", "install", patternName)
+	_, _, err = t.ssh("zypper", "--userdata", "skuba", "--non-interactive", "install", patternName)
 	return err
 }
 


### PR DESCRIPTION
To help differentiate calls to zypper from Skuba from calls made
by a user administrator, include "--userdata skuba" with
the command arguments.

## Why is this PR needed?

https://github.com/SUSE/skuba/issues/904

## What does this PR do?

This change adds '--userdata skuba' to the call to zypper from kubernetes.go
This change matches up with the change made in https://github.com/SUSE/skuba/pull/913

## Anything else a reviewer needs to know?

A simple static userdata identifier is sufficient for now (log messages already contain
a timestamp to make them unique and come from a unique machine).

## Info for QA

This change has virtually no impact to a user, as it does not change any functional behavior.
The one marker for this change working is that when skuba is run, any commands
to zypper will now include the --userdata flag, so when zypper writes to its log at 
/var/log/zypper.log, lines similar to this will appear:

`2020-01-15 18:52:28 <1> test-worker-0(7476) [zypper] main.cc(main):98 ===== 'zypper' '--userdata' 'skuba' 'ref' =====`

`2020-01-15 18:52:28 <1> test-worker-0(7476) [zconfig] ZConfig.cc(setUserData):908 Set user data string to 'skuba'`

This userdata may also be visible in the system journal when the zypper command is logged.

## Docs

No known docs impact.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
