### PR TITLE
Do not check that node exists when upgrading it

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
 	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/pkg/errors"
@@ -159,10 +158,6 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		return err
 	}
 
-	if err := target.Apply(nil, "kubernetes.wait-for-kubelet"); err != nil {
-		klog.Errorf("Kubelet could not register node %s. Please check the kubelet system logs and be aware that services kured or skuba-update will stay disabled", target.Nodename)
-		return err
-	}
 	if skubaUpdateWasEnabled {
 		err = target.Apply(nil,
 			"skuba-update.start.no-block",


### PR DESCRIPTION
## Why is this PR needed?

This operation is basically a no-op, because the node already exists
on the node list when an upgrade happens, and is not waiting in any
meaningful way for the node.

Thus, remove this check from the upgrade. Also, remove this logic that
is not referenced from anywhere else. It could make sense during
bootstrap and join operations, but this check is already done by
kubeadm.

xrefs bsc#1161069

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
