### PR TITLE
Isolate libvirt deployment disk size by role

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -63,7 +63,7 @@ data "template_file" "lb_cloud_init_userdata" {
 resource "libvirt_volume" "lb" {
   name           = "${var.stack_name}-lb-volume"
   pool           = "${var.pool}"
-  size           = "${var.disk_size}"
+  size           = "${var.lb_disk_size}"
   base_volume_id = "${libvirt_volume.img.id}"
 }
 

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -53,7 +53,7 @@ data "template_file" "master-cloud-init" {
 resource "libvirt_volume" "master" {
   name           = "${var.stack_name}-master-volume-${count.index}"
   pool           = "${var.pool}"
-  size           = "${var.disk_size}"
+  size           = "${var.master_disk_size}"
   base_volume_id = "${libvirt_volume.img.id}"
   count          = "${var.masters}"
 }

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -72,11 +72,6 @@ variable "rmt_server_name" {
   description = "SUSE Repository Mirroring Server Name"
 }
 
-variable "disk_size" {
-  default     = "25769803776"
-  description = "Disk size (in bytes)"
-}
-
 variable "dns_domain" {
   type        = "string"
   default     = "caasp.local"
@@ -110,6 +105,11 @@ variable "lb_vcpu" {
   description = "Amount of virtual CPUs for a load balancer node"
 }
 
+variable "lb_disk_size" {
+  default     = "25769803776"
+  description = "Disk size (in bytes)"
+}
+
 variable "lb_repositories" {
   type = "map"
 
@@ -138,6 +138,11 @@ variable "master_vcpu" {
   description = "Amount of virtual CPUs for a master"
 }
 
+variable "master_disk_size" {
+  default     = "25769803776"
+  description = "Disk size (in bytes)"
+}
+
 variable "workers" {
   default     = 2
   description = "Number of worker nodes"
@@ -151,4 +156,9 @@ variable "worker_memory" {
 variable "worker_vcpu" {
   default     = 2
   description = "Amount of virtual CPUs for a worker"
+}
+
+variable "worker_disk_size" {
+  default     = "25769803776"
+  description = "Disk size (in bytes)"
 }

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -53,7 +53,7 @@ data "template_file" "worker-cloud-init" {
 resource "libvirt_volume" "worker" {
   name           = "${var.stack_name}-worker-volume-${count.index}"
   pool           = "${var.pool}"
-  size           = "${var.disk_size}"
+  size           = "${var.worker_disk_size}"
   base_volume_id = "${libvirt_volume.img.id}"
   count          = "${var.workers}"
 }


### PR DESCRIPTION
## Why is this PR needed?

Currently libvirt deployment restrict to same disk size for all instance role. This might cause over resource reservation on host, as different cluster role have different requirement for disk size.

## What does this PR do?

This isolates libvirt deployment disk size by role of lb, master, worker.

## Anything else a reviewer needs to know?

## Info for QA

### Related info

### Status **BEFORE** applying the patch

Unable to configure libvirt deployment disk size according to role.

### Status **AFTER** applying the patch

Able to configure libvirt deployment disk size according to role.

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>
