### PR TITLE
Improve log level conventions

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/ssh.go
+++ b/internal/pkg/skuba/deployments/ssh/ssh.go
@@ -165,7 +165,7 @@ func (t *Target) internalSshWithStdin(silent bool, stdin string, command string,
 		finalCommand = fmt.Sprintf("sudo sh -c '%s'", finalCommand)
 	}
 	if !silent {
-		klog.V(1).Infof("running command: %q", finalCommand)
+		klog.V(2).Infof("running command: %q", finalCommand)
 	}
 	if err := session.Start(finalCommand); err != nil {
 		return "", "", err
@@ -188,7 +188,7 @@ func readerStreamer(reader io.Reader, outputChan chan<- string, description stri
 	for scanner.Scan() {
 		result.Write([]byte(scanner.Text()))
 		if description == "stdout" && !silent {
-			klog.V(1).Infof("%s", scanner.Text())
+			klog.V(2).Infof("%s", scanner.Text())
 		} else if description == "stderr" {
 			klog.Errorf("%s", scanner.Text())
 		}

--- a/internal/pkg/skuba/deployments/ssh/states.go
+++ b/internal/pkg/skuba/deployments/ssh/states.go
@@ -32,12 +32,12 @@ type Runner func(t *Target, data interface{}) error
 
 func (t *Target) Apply(data interface{}, states ...string) error {
 	for _, stateName := range states {
-		klog.V(1).Infof("=== applying state %s ===", stateName)
+		klog.V(2).Infof("=== applying state %s ===", stateName)
 		if state, stateExists := stateMap[stateName]; stateExists {
 			if err := state(t, data); err != nil {
 				return errors.Wrapf(err, "failed to apply state %s", stateName)
 			}
-			klog.V(1).Infof("=== state %s applied successfully ===", stateName)
+			klog.V(2).Infof("=== state %s applied successfully ===", stateName)
 		} else {
 			return errors.New(fmt.Sprintf("state does not exist: %s", stateName))
 		}

--- a/internal/pkg/skuba/deployments/ssh/systemd.go
+++ b/internal/pkg/skuba/deployments/ssh/systemd.go
@@ -24,7 +24,7 @@ import (
 
 // IsServiceEnabled returns if a service is enabled
 func (t *Target) IsServiceEnabled(serviceName string) (bool, error) {
-	klog.V(1).Infof("checking if %s is enabled", serviceName)
+	klog.V(2).Infof("checking if %s is enabled", serviceName)
 	isEnabled := true
 	_, _, err := t.silentSsh("systemctl", "is-enabled", serviceName)
 	if err != nil {

--- a/internal/pkg/skuba/kubernetes/jobs.go
+++ b/internal/pkg/skuba/kubernetes/jobs.go
@@ -68,7 +68,7 @@ func CreateAndWaitForJob(client clientset.Interface, name string, spec batchv1.J
 			klog.V(1).Infof("failed to get status for job %s, continuing...", name)
 		} else {
 			if job.Status.Active > 0 {
-				klog.V(1).Infof("job %s is active, waiting...", name)
+				klog.V(3).Infof("job %s is active, waiting...", name)
 			} else {
 				if job.Status.Succeeded > 0 {
 					klog.V(1).Infof("job %s executed successfully", name)

--- a/internal/pkg/skuba/kured/kured.go
+++ b/internal/pkg/skuba/kured/kured.go
@@ -44,7 +44,7 @@ func Lock(client clientset.Interface) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to patch daemonset with kured locking annotation")
 	}
-	klog.V(1).Info("successfully annotated daemonset with kured locking annotation")
+	klog.V(2).Info("successfully annotated daemonset with kured locking annotation")
 	return nil
 }
 
@@ -56,6 +56,6 @@ func Unlock(client clientset.Interface) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to patch daemonset with kured unlocking annotation")
 	}
-	klog.V(1).Info("successfully removed kured locking annotation")
+	klog.V(2).Info("successfully removed kured locking annotation")
 	return nil
 }


### PR DESCRIPTION
Referencing the upstream Kubernetes Instrumentation
Logging Conventions, move some of the log messages
in Skuba to align with described levels.

[0] https://github.com/kubernetes/community/blob/master/contributors
/devel/sig-instrumentation/logging.md

## Why is this PR needed?

https://github.com/SUSE/avant-garde/issues/1132

## What does this PR do?

The upstream Kubernetes Instrumentation SIG has published a convention for setting logging levels.  This PR attempts to get skuba code in line with those conventions (with values in the 0-5 range) by reviewing the existing klog.V() calls (which currently are all klog.V(1)) and setting levels for the messages that align with the convention.

## Anything else a reviewer needs to know?

There should be no significant change to user experience, though some messages that are currently logged with a 1 will now require a higher log level to trigger.

## Info for QA

Running skuba with -v [2-5] may not produce more log output than just -v 1, depending on the command and code path invoked.

### Status **BEFORE** applying the patch

Effectlively, all Info messages from skuba internal code were logged with a 1 level.

### Status **AFTER** applying the patch

Running skuba with -v [2-5] may not produce more log output than just -v 1, depending on the command and code path invoked.

## Docs

No documentation impact due to this change - current documentation about log levels is still correct.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
