### PR TITLE
Rename jjb job

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -85,7 +85,7 @@
         - '{name}-release-staging-on-demand'
 
 - job:
-    name: caasp-jobs/caasp-jjb
+    name: caasp-jobs/caasp-jjb-skuba
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

Jobs are moving over to the [new repo](https://github.com/SUSE/caasp-automation) and until this is done we need to run both jjb jobs in parallel.

## What does this PR do?

rename the caasp-jjb job which moved to https://github.com/SUSE/caasp-automation/blob/master/jenkins/jobs.yaml#L2 now.

## Anything else a reviewer needs to know?

There is a follow up job in SUSE/caasp-automation which will be the new default one.
https://github.com/SUSE/caasp-automation/blob/master/jenkins/jobs.yaml#L2
