### PR TITLE
Fix timeout handling in wait function

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -62,14 +62,15 @@ def wait(func, *args, **kwargs):
         try:
             return func(*args, **kwargs)
         except TimeoutError:
-            if elapsed > 0 and int(time.time())-start >= elapsed:
-               reason = "maximum wait time exceeded: {}s".format(elapsed)
-               break
             reason = "timeout of {}s exceded".format(timeout)
         except allow as ex:
             reason = "{}: '{}'".format(ex.__class__.__name__, ex)
         finally:
             signal.alarm(0)
+
+        if elapsed > 0 and int(time.time())-start >= elapsed:
+            reason = "maximum wait time exceeded: {}s".format(elapsed)
+            break
 
         if retries > 0 and attempts == retries:
             break


### PR DESCRIPTION
## Why is this PR needed?

Tests enter loop checking for conditions regardless of a timeout been set. 

Fixes https://github.com/SUSE/avant-garde/issues/1242

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Fix logic that handles timeout handling in wait function.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
