### PR TITLE
Allow using image_id for terraform openstack

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -53,6 +53,7 @@ resource "openstack_compute_instance_v2" "master" {
   count      = var.masters
   name       = "caasp-master-${var.stack_name}-${count.index}"
   image_name = var.image_name
+  image_id   = var.image_id
   key_pair   = var.key_pair
 
   depends_on = [

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -1,7 +1,14 @@
 # Name of the image to use
+# Only used if image_id is empty
 # EXAMPLE:
 # image_name = "SLE-15-SP1-JeOS-GMC"
 image_name = ""
+
+# ID of the image to use
+# Will overwrite image_name unless its empty
+# EXAMPLE:
+# image_id = "da398424-9dfc-4dcf-96fc-55e2d7ebf561"
+image_id   = ""
 
 # Name of the internal network to be created
 # EXAMPLE:

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -1,6 +1,11 @@
 variable "image_name" {
   default     = ""
-  description = "Name of the image to use"
+  description = "Name of the image to use. Only used if image_id is empty."
+}
+
+variable "image_id" {
+  default     = ""
+  description = "ID of the image to use. overwrites image_name unless its empty."
 }
 
 variable "repositories" {

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -68,6 +68,7 @@ resource "openstack_compute_instance_v2" "worker" {
   count      = var.workers
   name       = "caasp-worker-${var.stack_name}-${count.index}"
   image_name = var.image_name
+  image_id   = var.image_id
   key_pair   = var.key_pair
 
   depends_on = [


### PR DESCRIPTION
Unfortunately image_name is not an unique field on openstack
images, so if there is more than 1 image with the same name,
provision will fail.

This patchs adds an extra field image_id that allows the image_id
to be set, instead of the image_name so provision can be done on
environments with duplicated images names.

image_id seems to overwrite image_name so they can be used together
but only image_id will be used unless image_name is empty

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
