### PR TITLE
Report latest component versions for control plane components

### DIFF
--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -224,10 +224,11 @@ func controlPlaneUpdateStatusWithAvailableVersions(currentClusterVersion *versio
 	if !nodeVersioningInfo.EqualsClusterVersion(currentClusterVersion) {
 		return NodeVersionInfoUpdate{}, errors.Errorf("cannot infer how to upgrade this node from version %s to version %s", nodeVersioningInfo.String(), currentClusterVersion.String())
 	}
-	// This node is up to date and there are not newer versions available of the platform
+	// This node is up to date and there are not newer versions available of the platform. In any case, return the latest
+	// version components known to our static map in case a patch or metadata version changed.
 	return NodeVersionInfoUpdate{
 		Current: nodeVersioningInfo,
-		Update:  nodeVersioningInfo,
+		Update:  versionInquirer.NodeVersionInfoForClusterVersion(node, currentClusterVersion),
 	}, nil
 }
 


### PR DESCRIPTION
## Why is this PR needed?

When checking whether a control plane node is up to date, make sure
that we report our latest known versions present in the current static
map.

This ensures that if only one component changes in its patch (or
metadata) version, while the platform version is kept the same, we
will detect that a control plane node requires upgrading. E.g., by:

- `skuba node upgrade plan` or,
- `skuba node upgrade apply`

xref https://github.com/SUSE/avant-garde/issues/1258

## Info for QA

With this PR, if we bump only, say `etcd` without bumping the Kubernetes platform version, `skuba node upgrade plan/apply` will report and upgrade the node to the latest version available, in this case to the latest `etcd` version.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
