### PR TITLE
Update cri-o version in versions.go

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -81,7 +81,7 @@ var (
 		"1.16.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.16.2",
-				ContainerRuntimeVersion: "1.16.0",
+				ContainerRuntimeVersion: "1.16.1",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
 				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},


### PR DESCRIPTION
# Why is this PR needed?

It fixes an issue reported by QA during 4.1.1 testing.

Fixes SUSE/avant-garde#1263

# What does this PR do?

This PR aligns the value in ContainerRuntimeVersion to the current
cri-o version being released (1.16.1).

## Anything else a reviewer needs to know?

The version of `ContainerRuntimeVersion` should match the cri-o version of the same CaaSP release.

## Info for QA

Ugrading from CaaSP 4.1.0 to 4.1.1 the nodes should get a new cri-o version (1.16.0 -> 1.16.1) after running `skuba-update` or manually running `zypper patch`

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

`skuba node upgrade plan` was not showing the correct cri-o version.

### Status **AFTER** applying the patch

`skuba node upgrade plan` shows that correct cri-o version.
