### PR TITLE
Added ablilty to set env var for pip verbosity

### DIFF
--- a/ci/infra/testrunner/testrunner
+++ b/ci/infra/testrunner/testrunner
@@ -7,6 +7,7 @@ echo "Starting $0 script"
 SDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 VENVDIR=${WORKSPACE:-~}/py3venv
 export VENVDIR=${VENVDIR}
+PIP_VERBOSE=${PIP_VERBOSE:-"false"}
 
 setup_python_env() {
   type python3 >/dev/null 2>&1 || sudo zypper install --no-confirm python3
@@ -18,7 +19,12 @@ setup_python_env() {
   source ${VENVDIR}/bin/activate
   # Not calling to `pip3` directly because its shebang can exceed 128 characters
   # and this operation will fail. Check: https://github.com/pypa/pip/issues/1773
-  python -m pip install -r "${SDIR}/requirements.txt" &>/dev/null
+  if [[ $PIP_VERBOSE == "true" ]]; then
+    python -m pip install -r "${SDIR}/requirements.txt"
+  else
+    python -m pip install -r "${SDIR}/requirements.txt" &>/dev/null
+  fi
+  
 }
 
 setup_python_env

--- a/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
         FILTER_SUBDIRECTORY = 'ci/infra/vmware'
+        PIP_VERBOSE = 'true'
     }
 
     stages {

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
         PR_CONTEXT = 'jenkins/skuba-test'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
+        PIP_VERBOSE = 'true'
     }
 
 


### PR DESCRIPTION
## Why is this PR needed?

Fixes https://github.com/SUSE/avant-garde/issues/901

## What does this PR do?

Adds the ability to set an env var to control the verbosity of the pip install the testrunner shell script does.

## Anything else a reviewer needs to know?


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
