### PR TITLE
Clarifications in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ When this command has finished, some secrets will have been copied to your
 * Generated secrets will be copied inside the `pki` folder
 * The administrative `admin.conf` file of the cluster has been copied in
   root of the `company-cluster` folder
+  * The `company-cluster/admin.conf` file is the `kubeconfig` configuration
+    required by `kubectl` and other command line tools
 
 ## Growing a cluster
 
@@ -205,17 +207,17 @@ call to the same commands presented in `skuba` as `kubectl caasp` when installin
 `kubectl-caasp` binary in your path.
 
 The purpose of the tool is to provide a quick way to see if nodes have pending
-upgrades. The tool is currently returning fake data.
+upgrades.
 
 ```
 $ kubectl caasp cluster status
-NAME      OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
-master0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
-master1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
-master2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
-worker0   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
-worker1   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
-worker2   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+NAME      STATUS   ROLE     OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
+master0   Ready    master   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+master1   Ready    master   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+master2   Ready    master   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+worker0   Ready    <none>   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+worker1   Ready    <none>   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
+worker2   Ready    <none>   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.0      no            no                       4.1.0
 ```
 
 ## Demo


### PR DESCRIPTION
Add note that kubeconfig is admin.conf
Remove claim that 'cluster status' is returning fake data

## Why is this PR needed?
https://github.com/SUSE/skuba/issues/164

The README needed some clarification, and in process I noticed that the README indicated that 'cluster status' was returning fake data.  After verifying that 'cluster status' does indeed work, I removed that sentence.

## What does this PR do?

This PR changes the README.md.  No code changes are included.

## Info for QA

No QA needed, as only a documentation change in the README.md


## Docs

No further Doc changes: this is a self-contained change.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
