### PR TITLE
Condense privileged RoleBinding

### DIFF
--- a/internal/pkg/skuba/addons/psp.go
+++ b/internal/pkg/skuba/addons/psp.go
@@ -118,10 +118,6 @@ roleRef:
   kind: ClusterRole
   name: suse:caasp:psp:privileged
 subjects:
-# Only authenticated users
-- kind: Group
-  apiGroup: rbac.authorization.k8s.io
-  name: system:authenticated
 # All ServiceAccounts in the 'kube-system' namespace
 - kind: Group
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Skuba only needs some service accounts to have the
suse:caasp:psp:privileged ClusterRole in order to function. It is
redundant to also apply this RoleBinding to any authenticated user in
the kube-system namespace, since any service account (including
"default") already has this RoleBinding. This change cleans up the
redundancy.

This is not a security issue in itself because even with the redundancy
removed any service account in the kube-system namespace can still use
the privileged PSP, but it prepares the RoleBinding for further pruning
in the future.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
