### PR TITLE
Add hard reboot test to e2e

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -125,6 +125,10 @@ test_e2e:
 test_cpi_openstack:
 	${TEST_RUNNER} -v vars.yaml -p openstack test --verbose --suite test_cpi_openstack.py
 
+.PHONY: test_hard_reboot
+test_hard_reboot:
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_node_reboot.py --test test_hard_reboot
+
 .PHONY: test_remove_master
 test_remove_master:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --suite test_masters.py --test test_remove_master

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -45,6 +45,7 @@
         - openstack
         - vmware
     test:
+        - 'test_hard_reboot'
         - 'test_upgrade_plan_all_fine'
         - 'test_upgrade_plan_from_previous'
         - 'test_upgrade_plan_from_previous_with_upgraded_control_plane'


### PR DESCRIPTION
## Why is this PR needed?
The test_hard_reboot test is executed in the nightly job. This job will be removed as it is redundant with respect to the e2e jobs (https://github.com/SUSE/avant-garde/issues/1282). This PR adds a job to preserve the execution of this test.
 
Fixes https://github.com/SUSE/avant-garde/issues/1281

## What does this PR do?

Adds a new target to the CI Makefile for executing the test_hard_reboot test, and adds a job to the e2e project that invokes this target.

## Anything else a reviewer needs to know?

The new target will eventually be removed when the Makefile is reorganized (https://github.com/SUSE/avant-garde/issues/1281) It is added in this PR for consistency with the existing e2e tests. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
