### PR TITLE
Dex deployment label in manifest is missing

### DIFF
--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -161,6 +161,8 @@ kind: Deployment
 metadata:
   name: oidc-dex
   namespace: kube-system
+  labels:
+    app: oidc-dex
 spec:
   replicas: 3
   selector:

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -93,7 +93,7 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 1},
 				Kured:   &AddonVersion{"1.2.0-rev4", 1},
-				Dex:     &AddonVersion{"2.16.0", 3},
+				Dex:     &AddonVersion{"2.16.0", 4},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
 				PSP:     &AddonVersion{"", 1},
 			},
@@ -113,7 +113,7 @@ var (
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 1},
 				Kured:   &AddonVersion{"1.2.0-rev4", 1},
-				Dex:     &AddonVersion{"2.16.0", 3},
+				Dex:     &AddonVersion{"2.16.0", 4},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
 				PSP:     &AddonVersion{"", 1},
 			},


### PR DESCRIPTION
## Why is this PR needed?

Dex is missing app labels.

## What does this PR do?

This adds metadata:labels:app:oidc-dex to dex manifest.

## Anything else a reviewer needs to know?

## Info for QA

### Related info

### Status **BEFORE** applying the patch

### Status **AFTER** applying the patch

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
