### PR TITLE
[CI Update packages in worker before deploying

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -48,9 +48,13 @@ test_jenkins_jobs:
 update_jenkins_jobs:
 	jenkins-jobs  --ignore-cache --conf ${JENKINS_JOB_CONFIG} update ${JENKINS_JOBS_DIR}/:${JENKINS_JOBS_DIR}/templates/
 
+.PHONY: update_pkgs
+update_pkgs:
+	sudo zypper update --allow-vendor-change -y kubernetes-client terraform terraform-provider-*
+
 # Stages
 .PHONY: pre_deployment
-pre_deployment: info
+pre_deployment: info update_pkgs
 
 .PHONY: pr_checks
 pr_checks: git_rebase_check


### PR DESCRIPTION
## Why is this PR needed?

Packages used by skuba admin node (terraform, kubectl) are regularly updated outside the CI pipeline. The CI jobs should use the latest available version, but the packages are installed in the workers.

## What does this PR do?

Automatically update packages before deploying the cluster to ensure the latest available version is used.

## Note to reviewers

skuba itself IS NOT installed in the workers from packages as it is built from source.


This PR requires the workers to be updated to SLES 15 https://github.com/SUSE/avant-garde/issues/1272

## Merge restrictions


(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
