### PR TITLE
CI: Use NUE VMware cluster in CI

### DIFF
--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -1,9 +1,9 @@
 {
-    "vsphere_datastore": "3PAR",
-    "vsphere_datacenter": "PROVO",
+    "vsphere_datastore": "node51-2",
+    "vsphere_datacenter": "NUREMBERG",
     "vsphere_network": "VM Network",
-    "vsphere_resource_pool": "CaaSP_RP",
-    "template_name": "SLES15-SP1-GM-up190905-guestinfo",
+    "vsphere_resource_pool": "CaaSP_CI",
+    "template_name": "SLES15-SP1-GM-up191203-guestinfo_node51",
     "firmware": "bios",
     "stack_name": "caasp-jenkins-v4",
     "masters": 1,


### PR DESCRIPTION
## Why is this PR needed?

VMware cluster in PRO doesn't offer the performance required for running the CI tests, causing frequent failures. The new VMware cluster in NUE should offer better performance and eliminate these failures (see for example https://github.com/SUSE/avant-garde/issues/1061). 

Fixes https://github.com/SUSE/avant-garde/issues/1304

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Modify tfvars used in ci jobs for using VMware cluster at NUE.

## Anything else a reviewer needs to know?

Due to https://github.com/SUSE/avant-garde/issues/1299 PR is not properly tested. VMware e2e jobs will be used for testing it.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
