### PR TITLE
Fix skuba-update --version always 0.0.0 (bsc#1160463)

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -93,6 +93,7 @@ make %{?_smp_mflags} docs
 # skuba-update install
 #
 
+echo %{version} > VERSION
 pushd skuba-update
 python3 setup.py install --root %{buildroot} \
     --install-script %{_sbindir}


### PR DESCRIPTION
## Why is this PR needed?

Fix `skuba-update --version` always print `0.0.0`

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Create the VERSION file for skuba-update, and then, the `skuba-update/setup.py` would read the VERSION file.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A
### Status **BEFORE** applying the patch

- SSH into one of the node
- Execute `skuba-update --version`

### Status **AFTER** applying the patch

- SSH into one of the node
- Execute `skuba-update --version`

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>