### PR TITLE
Fix CI jobs subfolder

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -5,14 +5,14 @@
     repo-credentials: github-token
     platform: openstack
     jobs:
-        - '{name}-test'
-        - '{name}-test-vmware'
-        - '{name}-update-unit'
-        - '{name}-update-acceptance'
-        - '{name}-code-lint'
-        - '{name}-code-author'
-        - '{name}-handle-pr'
-        - '{name}-jjb-validation'
+        - '{name}/test'
+        - '{name}/test-vmware'
+        - '{name}/update-unit'
+        - '{name}/update-acceptance'
+        - '{name}/code-lint'
+        - '{name}/code-author'
+        - '{name}/handle-pr'
+        - '{name}/jjb-validation'
 
 - project:
       name: caasp-jobs/v4/conformance
@@ -23,7 +23,7 @@
         - openstack
         - vmware
       jobs:
-          - '{name}-{platform}-conformance'
+          - '{name}/{platform}-conformance'
 
 - project:
     name: caasp-jobs/v4/e2e
@@ -49,8 +49,8 @@
         - 'test_remove_master'
         - 'test_remove_worker'
     jobs:
-        - '{name}-{platform}-{test}-nightly'
-        - '{name}-{platform}-update-nightly'
+        - '{name}/{platform}/{test}-nightly'
+        - '{name}/{platform}/update-nightly'
 
 - job:
     name: caasp-jobs/caasp-jjb-skuba

--- a/ci/jenkins/templates/code-author.yaml
+++ b/ci/jenkins/templates/code-author.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-code-author'
+    name: '{name}/code-author'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30

--- a/ci/jenkins/templates/code-lint.yaml
+++ b/ci/jenkins/templates/code-lint.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-code-lint'
+    name: '{name}/code-lint'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-{platform}-conformance'
+    name: '{name}/{platform}-conformance'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/e2e-nightly-template.yaml
+++ b/ci/jenkins/templates/e2e-nightly-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-{platform}-{test}-nightly'
+    name: '{name}/{platform}/{test}-nightly'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/e2e-update-nightly-template.yaml
+++ b/ci/jenkins/templates/e2e-update-nightly-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-{platform}-update-nightly'
+    name: '{name}/{platform}/update-nightly'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/handle-pr.yaml
+++ b/ci/jenkins/templates/handle-pr.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-handle-pr'
+    name: '{name}/handle-pr'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/jjb-validation.yaml
+++ b/ci/jenkins/templates/jjb-validation.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-jjb-validation'
+    name: '{name}/jjb-validation'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30

--- a/ci/jenkins/templates/test-template.yaml
+++ b/ci/jenkins/templates/test-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-test'
+    name: '{name}/test'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30

--- a/ci/jenkins/templates/test-vmware-template.yaml
+++ b/ci/jenkins/templates/test-vmware-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-test-vmware'
+    name: '{name}/test-vmware'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30

--- a/ci/jenkins/templates/update-acceptance-template.yaml
+++ b/ci/jenkins/templates/update-acceptance-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-update-acceptance'
+    name: '{name}/update-acceptance'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30

--- a/ci/jenkins/templates/update-unit-template.yaml
+++ b/ci/jenkins/templates/update-unit-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}-update-unit'
+    name: '{name}/update-unit'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

Fix commit 0ddd35ab. The job names were not placed in the desired
subfolder. `e2e`, `pr` and `conformance` are not part of the job name
but the subfolder they live in.

## What does this PR do?

Fixes the PR #952 

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
