### PR TITLE
Better node count for tests

### DIFF
--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -20,3 +20,19 @@ class Kubectl:
             return self.utils.runshellcommand(shell_cmd, stdin=stdin)
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(shell_cmd)) from ex
+
+    def get_node_names_by_role(self, role):
+        """Returns a list of node names for a given role
+        Uses selectors to get the nodes. Master nodes have the node-role.kubernetes.io/master="" label, while other
+        nodes (workers) dont even have the label.
+        """
+
+        if role not in ("master", "worker"):
+            raise ValueError("Invalid role {}".format(role))
+
+        roles = {
+            "master": "==",
+            "worker": "!="
+        }
+        command = f"get nodes --selector=node-role.kubernetes.io/master{roles.get(role)}"" -o jsonpath='{.items[*].metadata.name}'"
+        return self.run_kubectl(command).split()

--- a/ci/infra/testrunner/tests/test_masters.py
+++ b/ci/infra/testrunner/tests/test_masters.py
@@ -4,10 +4,11 @@ from tests.utils import wait
 
 @pytest.mark.disruptive
 def test_remove_master(deployment, conf, platform, skuba, kubectl):
-    initial_masters = skuba.num_of_nodes("master")
+    masters = kubectl.get_node_names_by_role("master")
+    masters_count = len(masters)
 
     # Remove the master
-    skuba.node_remove(role="master", nr=initial_masters - 1)
-    assert skuba.num_of_nodes("master") == initial_masters - 1
+    skuba.node_remove(role="master", nr=masters_count - 1)
+    assert len(kubectl.get_node_names_by_role("master")) == masters_count - 1
 
     wait(kubectl.run_kubectl, 'wait --timeout=5m --for=condition=Ready pods --all --namespace=kube-system  --field-selector=status.phase!=Succeeded', wait_delay=60, wait_timeout=300, wait_backoff=30, wait_retries=5, wait_allow=(RuntimeError))


### PR DESCRIPTION
Currently we rely on the output of skuba to know the number of
masters and workers. This is a very flimsy way of getting those
numbers as the output can change and its not really ready for
batch processing.

Instead, lets use kubectl to get those, which gives us a more
stable way of doing so thanks to selectors and the possibility
of getting the exact output we want.

This patch moves from using skuba output to guess the number of
masters to using kubectl to get the exact number of masters. The
new function can be used to get the workers as well.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes https://github.com/SUSE/avant-garde/issues/1349

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
