### PR TITLE
Restrict kube-system control plane pods, bsc#1121353

### DIFF
--- a/internal/pkg/skuba/addons/kured.go
+++ b/internal/pkg/skuba/addons/kured.go
@@ -104,6 +104,19 @@ roleRef:
   kind: Role
   name: kured
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:kured
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kured
+  namespace: kube-system
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -93,11 +93,11 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.5.3", 1},
-				Kured:         &AddonVersion{"1.3.0", 2},
+				Kured:         &AddonVersion{"1.3.0", 3},
 				Dex:           &AddonVersion{"2.16.0", 5},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
 				MetricsServer: &AddonVersion{"0.3.6", 0},
-				PSP:           &AddonVersion{"", 1},
+				PSP:           &AddonVersion{"", 2},
 			},
 		},
 		"1.15.2": KubernetesVersion{


### PR DESCRIPTION
Control plane pods in kube-system namespace should run with
'suse.caasp.psp.kube-system' PodSecurityPolicy. Only cilium
and kube-proxy pods require 'suse.caasp.psp.priviliged' mode.

## Why is this PR needed?

We would like to limit control plane pods in kube-system namespace and disable privileged mode for them. Exception for it is `cilium`, `kured` and `kube-proxy` these DaemonSets will be running with  'suse.caasp.psp.priviliged' mode.

Fixes # bsc#1121353

## What does this PR do?

It will create new PodSecurityPolicy schema with name `kube-system` which will be applied to control plane pods.

## Anything else a reviewer needs to know?


## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch
```
kubectl get pod --namespace kube-system | grep -v NAME | awk {'print $1'} | xargs -d '\n' -i bash -c 'echo {} && kubectl describe pod -n kube-system {} | grep kubernetes.io/psp'
cilium-gn8sm
              kubernetes.io/psp: suse.caasp.psp.privileged
cilium-operator-654b5785c9-j4rc2
                      kubernetes.io/psp: suse.caasp.psp.privileged
cilium-qmck5
              kubernetes.io/psp: suse.caasp.psp.privileged
cilium-vrmzj
              kubernetes.io/psp: suse.caasp.psp.privileged
coredns-7ffbb88dbb-qrjd6
                      kubernetes.io/psp: suse.caasp.psp.privileged
coredns-7ffbb88dbb-w8kbf
                      kubernetes.io/psp: suse.caasp.psp.privileged
etcd-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-apiserver-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-controller-manager-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-proxy-4mwjr
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-proxy-h9l7q
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-proxy-rgbsb
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-scheduler-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.privileged
kured-cf7vt
              kubernetes.io/psp: suse.caasp.psp.privileged
kured-m5j97
              kubernetes.io/psp: suse.caasp.psp.privileged
kured-vz6z7
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-dex-5566f77f89-9fgrf
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-dex-5566f77f89-t9vrv
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-dex-5566f77f89-xl6nj
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-gangway-79447879fb-hpwjg
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-gangway-79447879fb-q7597
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-gangway-79447879fb-v7tg9
              kubernetes.io/psp: suse.caasp.psp.privileged
```

### Status **AFTER** applying the patch

```
kubectl get pod --namespace kube-system | grep -v NAME | awk {'print $1'} | xargs -d '\n' -i bash -c 'echo {} && kubectl describe pod -n kube-system {} | grep kubernetes.io/psp'
cilium-mgvsr
              kubernetes.io/psp: suse.caasp.psp.privileged
cilium-operator-654b5785c9-jkxph
                      kubernetes.io/psp: suse.caasp.psp.kube-system
coredns-7ffbb88dbb-jp4rv
                      kubernetes.io/psp: suse.caasp.psp.kube-system
coredns-7ffbb88dbb-k9kw6
                      kubernetes.io/psp: suse.caasp.psp.kube-system
etcd-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.kube-system
kube-apiserver-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.kube-system
kube-controller-manager-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.kube-system
kube-proxy-cqbk7
                      kubernetes.io/psp: suse.caasp.psp.privileged
kube-scheduler-caasp-master-mjura-0
                      kubernetes.io/psp: suse.caasp.psp.kube-system
kured-c5hg6
              kubernetes.io/psp: suse.caasp.psp.privileged
oidc-dex-5c6c475b54-25lbx
              kubernetes.io/psp: suse.caasp.psp.kube-system
oidc-dex-5c6c475b54-dw5tb
              kubernetes.io/psp: suse.caasp.psp.kube-system
oidc-dex-5c6c475b54-xkkxg
              kubernetes.io/psp: suse.caasp.psp.kube-system
oidc-gangway-79447879fb-fswxx
              kubernetes.io/psp: suse.caasp.psp.kube-system
oidc-gangway-79447879fb-mxjcq
              kubernetes.io/psp: suse.caasp.psp.kube-system
oidc-gangway-79447879fb-qwmw8
              kubernetes.io/psp: suse.caasp.psp.kube-system
```


## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
