### PR TITLE
versions: updated the kured version

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -92,7 +92,7 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 1},
-				Kured:   &AddonVersion{"1.2.0-rev4", 1},
+				Kured:   &AddonVersion{"1.3.0", 2},
 				Dex:     &AddonVersion{"2.16.0", 4},
 				Gangway: &AddonVersion{"3.1.0-rev4", 3},
 				PSP:     &AddonVersion{"", 1},


### PR DESCRIPTION
There is a new version for kured available (1.3.0) which fixes some problems
we've been having in regards to v1.16 support. We've already done the packaging
heavy lifting, so the only thing left was to update the version here.

See SUSE/avant-garde#1346

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
