### PR TITLE
skuba update management(bsc#1152334)

### DIFF
--- a/skuba-update/skuba_update/skuba_update.py
+++ b/skuba-update/skuba_update/skuba_update.py
@@ -195,12 +195,10 @@ def get_update_list(patch_xml):
 
 def has_updates(update_list):
     """
-    Returns true if there are updates available.
+    Returns true if there are updates available except optional packages.
     """
-    if update_list is None or len(update_list) == 0:
-        return False
-    else:
-        return True
+
+    return filter_updates(update_list, 'category', lambda x: x != 'optional')
 
 
 def has_security_updates(update_list):
@@ -225,12 +223,13 @@ def filter_updates(update_list, attrib, attrib_check):
     attribute (attrib) that is also passing the checker
     function (attrib_check)
     """
+    if update_list is None or len(update_list) == 0:
+        return False
 
-    if has_updates(update_list):
-        for update in update_list:
-            attr = update.attrib.get(attrib, '')
-            if attrib_check(attr):
-                return True
+    for update in update_list:
+        attr = update.attrib.get(attrib, '')
+        if attrib_check(attr):
+            return True
 
     return False
 
@@ -323,6 +322,10 @@ def run_zypper_command(command, needsOutput=False):
 
 
 def run_zypper_patch():
+    """
+    Run patch updates without --with-optional. --with-optional can cause
+    conflicts with K8s upgrade scenario.
+    """
     return run_zypper_command([
         '--non-interactive', '--non-interactive-include-reboot-patches',
         'patch'


### PR DESCRIPTION
## Why is this PR needed?
In fresh bootstrap/join/upgrade, the command `skuba cluster status` shows HAS-UPDATES yes.
At first, I changed to add `--with-optional` in zypper patch. But it can cause conflicts with skuba upgrade and node updates ( by refering David). As Jordi mentioned in the below comment that Skuba does not install optional pending updates, skuba cluster does not need to check optional packages for HAS-UPDATES.

## What does this PR do?

This PR will skip for checking optional patch for node annotations.

## Anything else a reviewer needs to know?
Bootstrapping/join/upgrad will run this skub-update on nodes. This should show HAS-UPDATES no because all necessary packages installed already. The optional packages are not considered critical patches for K8s and Skuba. 

## Info for QA

After cluster bootstrap/join/upgrade and then when you run`skuba cluster status`, HAS-UPDATES and  HAS-DISRUPTIVE-UPDATES should be "no".
skuba-update will be installed with patterns-caasp-Node-1.XX. To test this PR, you need to have available skuba-update package in the test node.
 
### Status **BEFORE** applying the patch

After /bootstrap/join/remove,
```
skuba cluster status
** This is an UNTAGGED version and NOT intended for production usage. **
NAME       STATUS   ROLE     OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
master-0   Ready    master   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.1      yes           no                       4.1.1
worker-0   Ready    <none>   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.1      yes            no                       4.1.1
```
### Status **AFTER** applying the patch

After /bootstrap/join/remove,
```
skuba cluster status
** This is an UNTAGGED version and NOT intended for production usage. **
NAME       STATUS   ROLE     OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
master-0   Ready    master   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.1      no           no                       4.1.1
worker-0   Ready    <none>   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.29-default   v1.16.2           cri-o://1.16.1      no            no                       4.1.1
```

## Docs

Manual instructions for patching update will be handled by https://github.com/SUSE/avant-garde/issues/1356

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
