### PR TITLE
Remove unused aws_az from terraform.tfvars.example

### DIFF
--- a/ci/infra/aws/terraform.tfvars.example
+++ b/ci/infra/aws/terraform.tfvars.example
@@ -15,13 +15,6 @@ authorized_keys = [
 # A list of region names can be found here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
 aws_region = "eu-central-1"
 
-# AWS availability zone
-# You can get AZ name with the following command:
-#    aws ec2 describe-availability-zones --region region-name
-#
-# More information here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#using-regions-availability-zones-describe
-aws_az = "eu-central-1a"
-
 # access key for AWS services
 aws_access_key = "AKIXU..."
 
@@ -53,4 +46,4 @@ aws_secret_key = "ORd..."
 # This is required to have AWS CPI support working properly.
 #
 # Note well: you must  have the right set of permissions.
-#iam_profile_worker = "caasp-k8s-worker-vm-profile"
+# iam_profile_worker = "caasp-k8s-worker-vm-profile"


### PR DESCRIPTION
Fixes https://github.com/SUSE/avant-garde/issues/1359