### PR TITLE
Fix errors for skuba-update tests

### DIFF
--- a/skuba-update/Dockerfile
+++ b/skuba-update/Dockerfile
@@ -20,7 +20,7 @@ COPY test/unit-tests-init.sh /init
 
 RUN zypper -n ref && \
     zypper -n in python3-setuptools python3-pip ShellCheck lsof && \
-    pip install -r /dev-requirements.txt && \
+    pip install -r /dev-requirements.txt --ignore-installed && \
     chmod +x /init && \
     useradd -m -d /home/suse -s /bin/bash suse && \
     zypper clean -a

--- a/skuba-update/tox.ini
+++ b/skuba-update/tox.ini
@@ -69,4 +69,4 @@ setenv =
 commands =
     flake8 --statistics -j auto --count {toxinidir}/skuba_update
     flake8 --statistics -j auto --count {toxinidir}/test
-    bash -c 'find . -name "*.sh" -exec shellcheck -e SC1090,SC1117 \{\} \+'
+    find {toxinidir}/test -name "*.sh" -exec shellcheck -e SC1090 \{\} +


### PR DESCRIPTION
skuba-update test runs when skuba-update folder has any code change.
My PR still has failures because skuba-update tests had errors. 

1. Error when six is installed in a container.
CI skuba-update test has an error because skuba-update-unit-build:latest
has six 1.11.0 installed.

2. shell checks all the unnecessary sh files from root in a container env.
tox.init generates errors  on `bash -c 'find . -name "*.sh" -exec shellcheck  -e SC1090,SC1117 \{\} \+'` because of all sh scripts from /.  

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
