### PR TITLE
WIP CI: Add platform label to pipeline node selector

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_manager.py
@@ -96,6 +96,17 @@ def update_pr_status(args):
     status = PrStatus(build_url, repo)
     status.update_pr_status(args.commit_sha, args.context, args.state)
 
+def get_ci_labels(args):
+    if CHANGE_ID:
+        g = Github(GITHUB_TOKEN, per_page=1000)
+        repo = g.get_repo(GITHUB_REPO)
+        pull = repo.get_pull(CHANGE_ID)
+        # ci labels must start with 'ci:', take only the label value
+        labels = [l.name.split(":")[1] for l in pull.labels if l.name.startswith("ci:")]
+        for label in labels:
+            print(label)
+    else:
+        print('No CHANGE_ID was set. Assuming this is not a PR.', file=sys.stderr)
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -126,6 +137,10 @@ def parse_args():
     filter_parser.set_defaults(func=filter_pr)
 
     parsed_args = parser.parse_args()
+
+    # Parse get-ci-labels command
+    ci_labels_parser = subparsers.add_parser('get-ci-labels', help='retrieve the ci labels from PE')
+    ci_labels_parser.set_defaults(func=get_ci_labels)
 
     return parsed_args
 


### PR DESCRIPTION
## Why is this PR needed?

Presently, all the integration workers are identical in their capability to execute tests for any platform. However, as we move to a more diverse set-up,  some workers would be capable of executing only tests for certain platforms - due for instance to connectivity restrictions. It is necessary then to properly label workers with the platforms it support and add the platform to node selector in the pipeline.

## What does this PR do?
Add the platform label to the node selector for test pipelines.

## Anything else a reviewer needs to know?
This PR must be merged only after the workers have been properly labeled with the platforms they support. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
