### PR TITLE
Enhance dex/gangway addon upgrade

### DIFF
--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -67,22 +67,20 @@ func (dexCallbacks) beforeApply(addonConfiguration AddonConfiguration, skubaConf
 	// in order to update global variable gangwayClientSecret.
 	gangwayClientSecret, err = gangway.GetClientSecret(client)
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if gangway client secret exists")
+		return errors.Wrap(err, "unable to determine gangway client secret exists")
 	}
 
-	dexCertExists, err := dex.DexCertExists(client)
+	certExist, err := dex.IsCertExist(client)
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if dex certificate exists")
+		return errors.Wrap(err, "unable to determine dex certificate exists")
 	}
-	err = dex.CreateCert(client, skubaconstants.PkiDir(), skubaconstants.KubeadmInitConfFile())
-	if err != nil {
-		return errors.Wrap(err, "unable to create dex certificate")
-	}
-	if dexCertExists {
-		if err := dex.RestartPods(client); err != nil {
-			return err
+
+	if !certExist {
+		if err := dex.CreateCert(client, skubaconstants.PkiDir(), skubaconstants.KubeadmInitConfFile()); err != nil {
+			return errors.Wrap(err, "unable to create dex certificate")
 		}
 	}
+
 	return nil
 }
 

--- a/internal/pkg/skuba/dex/dex.go
+++ b/internal/pkg/skuba/dex/dex.go
@@ -83,12 +83,8 @@ func GenerateClientSecret() string {
 	return fmt.Sprintf("%x", b)
 }
 
-func DexCertExists(client clientset.Interface) (bool, error) {
+// IsCertExist checks dex certificate exists in secret resource
+func IsCertExist(client clientset.Interface) (bool, error) {
 	_, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get(secretCertName, metav1.GetOptions{})
 	return kubernetes.DoesResourceExistWithError(err)
-}
-
-func RestartPods(client clientset.Interface) error {
-	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", certCommonName)}
-	return client.CoreV1().Pods(metav1.NamespaceSystem).DeleteCollection(&metav1.DeleteOptions{}, listOptions)
 }

--- a/internal/pkg/skuba/dex/dex_test.go
+++ b/internal/pkg/skuba/dex/dex_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func Test_GenerateClientSecret(t *testing.T) {
+func TestGenerateClientSecret(t *testing.T) {
 	tests := []struct {
 		name      string
 		inputLen  int
@@ -58,7 +58,7 @@ func Test_GenerateClientSecret(t *testing.T) {
 	}
 }
 
-func Test_CreateCert(t *testing.T) {
+func TestCreateCert(t *testing.T) {
 	tests := []struct {
 		name                string
 		pkiPath             string
@@ -99,7 +99,7 @@ func Test_CreateCert(t *testing.T) {
 	}
 }
 
-func Test_DexCertExists(t *testing.T) {
+func TestIsCertExist(t *testing.T) {
 	tests := []struct {
 		name          string
 		client        clientset.Interface
@@ -128,7 +128,7 @@ func Test_DexCertExists(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := DexCertExists(tt.client)
+			got, err := IsCertExist(tt.client)
 			if tt.expectedError {
 				if err == nil {
 					t.Errorf("error expected on %s, but no error reported", tt.name)
@@ -141,57 +141,6 @@ func Test_DexCertExists(t *testing.T) {
 
 			if got != tt.expectedExist {
 				t.Errorf("expect %t, got %t\n", tt.expectedExist, got)
-			}
-		})
-	}
-}
-
-func Test_RestartPods(t *testing.T) {
-	tests := []struct {
-		name          string
-		client        clientset.Interface
-		expectedError bool
-	}{
-		{
-			name: "restart pod successfully",
-			client: fake.NewSimpleClientset(&corev1.PodList{
-				Items: []corev1.Pod{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "dex-pod-1",
-							Labels: map[string]string{"app": "oidc-dex"},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "dex-pod-2",
-							Labels: map[string]string{"app": "oidc-dex"},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "dex-pod-3",
-							Labels: map[string]string{"app": "oidc-dex"},
-						},
-					},
-				},
-			}),
-			expectedError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			err := RestartPods(tt.client)
-			if tt.expectedError {
-				if err == nil {
-					t.Errorf("error expected on %s, but no error reported", tt.name)
-				}
-				return
-			} else if err != nil {
-				t.Errorf("error not expected on %s, but an error was reported (%v)", tt.name, err)
-				return
 			}
 		})
 	}

--- a/internal/pkg/skuba/gangway/gangway.go
+++ b/internal/pkg/skuba/gangway/gangway.go
@@ -20,7 +20,6 @@ package gangway
 import (
 	"crypto/rand"
 	"encoding/base64"
-	"fmt"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -133,17 +132,14 @@ func CreateCert(client clientset.Interface, pkiPath, kubeadmInitConfPath string)
 	return nil
 }
 
-func GangwaySecretExists(client clientset.Interface) (bool, error) {
+// IsSessionKeyExist checks gangway session key exists in secret resource
+func IsSessionKeyExist(client clientset.Interface) (bool, error) {
 	_, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get(secretKeyName, metav1.GetOptions{})
 	return kubernetes.DoesResourceExistWithError(err)
 }
 
-func GangwayCertExists(client clientset.Interface) (bool, error) {
+// IsCertExist checks gangway certificate exists in secret resource
+func IsCertExist(client clientset.Interface) (bool, error) {
 	_, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Get(secretCertName, metav1.GetOptions{})
 	return kubernetes.DoesResourceExistWithError(err)
-}
-
-func RestartPods(client clientset.Interface) error {
-	listOptions := metav1.ListOptions{LabelSelector: fmt.Sprintf("app=%s", certCommonName)}
-	return client.CoreV1().Pods(metav1.NamespaceSystem).DeleteCollection(&metav1.DeleteOptions{}, listOptions)
 }

--- a/internal/pkg/skuba/gangway/gangway_test.go
+++ b/internal/pkg/skuba/gangway/gangway_test.go
@@ -212,7 +212,7 @@ func TestCreateCert(t *testing.T) {
 	}
 }
 
-func TestGangwaySecretExists(t *testing.T) {
+func TestIsSessionKeyExist(t *testing.T) {
 	tests := []struct {
 		name          string
 		client        clientset.Interface
@@ -241,7 +241,7 @@ func TestGangwaySecretExists(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GangwaySecretExists(tt.client)
+			got, err := IsSessionKeyExist(tt.client)
 			if tt.expectedError {
 				if err == nil {
 					t.Errorf("error expected on %s, but no error reported", tt.name)
@@ -259,7 +259,7 @@ func TestGangwaySecretExists(t *testing.T) {
 	}
 }
 
-func TestGangwayCertExists(t *testing.T) {
+func TestIsCertExist(t *testing.T) {
 	tests := []struct {
 		name          string
 		client        clientset.Interface
@@ -288,7 +288,7 @@ func TestGangwayCertExists(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GangwayCertExists(tt.client)
+			got, err := IsCertExist(tt.client)
 			if tt.expectedError {
 				if err == nil {
 					t.Errorf("error expected on %s, but no error reported", tt.name)
@@ -301,57 +301,6 @@ func TestGangwayCertExists(t *testing.T) {
 
 			if got != tt.expectedExist {
 				t.Errorf("expect %t, got %t\n", tt.expectedExist, got)
-			}
-		})
-	}
-}
-
-func TestRestartPods(t *testing.T) {
-	tests := []struct {
-		name          string
-		client        clientset.Interface
-		expectedError bool
-	}{
-		{
-			name: "restart pod successfully",
-			client: fake.NewSimpleClientset(&corev1.PodList{
-				Items: []corev1.Pod{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "gangway-pod-1",
-							Labels: map[string]string{"app": "oidc-gangway"},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "gangway-pod-2",
-							Labels: map[string]string{"app": "oidc-gangway"},
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "gangway-pod-3",
-							Labels: map[string]string{"app": "oidc-gangway"},
-						},
-					},
-				},
-			}),
-			expectedError: false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			err := RestartPods(tt.client)
-			if tt.expectedError {
-				if err == nil {
-					t.Errorf("error expected on %s, but no error reported", tt.name)
-				}
-				return
-			} else if err != nil {
-				t.Errorf("error not expected on %s, but an error was reported (%v)", tt.name, err)
-				return
 			}
 		})
 	}


### PR DESCRIPTION
## Why is this PR needed?

Even dex and gangway addon no need be upgraded, dex and gangway pod still got restart.
This makes the dex and gangway service might be available during addon upgrade and increase the time on addon upgrade.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Remove the pod restart code.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

1. Bump kured manifest version
2. Upgrade addon `skuba addon upgrade apply`
3. During addon upgrade, watch the dex and gangway pod, it's be restarted
   ```
   kubectl get pods -w
   ```

### Status **AFTER** applying the patch

1. Bump kured manifest version
2. Upgrade addon `skuba addon upgrade apply`
3. During addon upgrade, watch the dex and gangway pod, it's won't be restarted
   ```
   kubectl get pods -w
   ```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>