### PR TITLE
Include libvirt platform as part of the PRs tests

### DIFF
--- a/ci/infra/libvirt/README.md
+++ b/ci/infra/libvirt/README.md
@@ -35,6 +35,8 @@ Copy the `terraform.tfvars.example` to `terraform.tfvars` and provide reasonable
 
 ## Variables
 
+`libvirt_uri` - URL of the libvirt host
+`libvirt_keyfile` - The key file used for the connection to a remote libvirt server
 `image_uri` - URL of the image to use
 `stack_name` - Identifier to make all your resources unique and avoid clashes with other users of this terraform project
 `authorized_keys` - A list of ssh public keys that will be installed on all nodes

--- a/ci/infra/libvirt/main.tf
+++ b/ci/infra/libvirt/main.tf
@@ -1,5 +1,5 @@
 provider "libvirt" {
-  uri = var.libvirt_uri
+  uri = var.libvirt_keyfile == "" ? var.libvirt_uri : "${var.libvirt_uri}?keyfile=${var.libvirt_keyfile}"
 }
 
 resource "libvirt_volume" "img" {

--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -1,6 +1,17 @@
+# URL of the libvirt server
+# EXAMPLE:
+# libvirt_uri = "qemu:///system"
+libvirt_uri = ""
+
+# Path of the key file used to connect to the libvirt server
+# Note this value will be appended to the libvirt_uri as a 'keyfile' query: <libvirt_uri>?keyfile=<libvirt_keyfile>
+# EXAMPLE:
+# libvirt_keyfile = "~/.ssh/custom_id"
+libvirt_uri = ""
+
 # URL of the image to use
 # EXAMPLE:
-# image_uri = "SLE-15-SP1-JeOS-GMC"
+# image_uri = "http://download.suse.com/..."
 image_uri = ""
 
 # Identifier to make all your resources unique and avoid clashes with other users of this terraform project

--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -1,14 +1,14 @@
 {
     "libvirt_uri": "qemu:///system",
+    "libvirt_keyfile": "",
     "pool": "default",
-    "image_uri": "SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU1.qcow2",
+    "image_uri": "",
     "stack_name": "testing",
     "network_cidr": "10.17.0.0/22",
     "dns_domain": "caasp.local",
     "masters": 1,
     "workers": 2,
     "username": "sles",
-    "password": "linux",
     "repositories": {
         "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/",
         "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/",

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -3,6 +3,11 @@ variable "libvirt_uri" {
   description = "URL of libvirt connection - default to localhost"
 }
 
+variable "libvirt_keyfile" {
+  default     = ""
+  description = "The private key file used for libvirt connection - default to none"
+}
+
 variable "pool" {
   default     = "default"
   description = "Pool to be used to store all the volumes"
@@ -96,7 +101,7 @@ variable "lbs" {
 }
 
 variable "lb_memory" {
-  default     = 2048
+  default     = 4096
   description = "Amount of RAM for a load balancer node"
 }
 
@@ -129,7 +134,7 @@ variable "masters" {
 }
 
 variable "master_memory" {
-  default     = 2048
+  default     = 4096
   description = "Amount of RAM for a master"
 }
 
@@ -149,7 +154,7 @@ variable "workers" {
 }
 
 variable "worker_memory" {
-  default     = 2048
+  default     = 4096
   description = "Amount of RAM for a worker"
 }
 

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -299,15 +299,20 @@ or as an environment variable: `export VMWARE_ENV_FILE=/path/to/vmware-env.sh`
 
 #### Libvirt
 
-`testrunner` can provision a cluster of virtual machines using terraform libvirt provider. The only noticeable difference with other platforms is the dependency on the terraform libvirt provider plugin which is not available from the official terraform plugin site, neither is delivered as part of the CaaSP packages. Moreover, the version of this plugin must be compatible with the version of terraform used by skuba (and by extension, the testrunner) which as of today is `0.11`. [This version](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) has been tested to work. Notice it requires an updated version of libvirt (4.1.0 or above). 
+`testrunner` can provision a cluster of virtual machines using terraform libvirt provider. The only noticeable difference with other platforms is the dependency on the terraform libvirt provider plugin which is not available from the official terraform plugin site, neither is delivered as part of the CaaSP packages. However this is available from the development [CaaSP repositories](http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/) for SLE15-SP1 or from the public [openSUSE repositories](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) for non SLE15-SP1 hosts. Notice it requires an updated version of libvirt (4.1.0 or above).
 
-Once the plugin is installed locally, it must be made available to terraform by copying the plugin binary to `ci/infra/libvirt/terraform.d/plugins/linux_<arch>/`, where `<arch>` is the architecture of the computer where terraform is running (e.g. `amd64`).
+There three configuration variables required for libvirt operations, all configurable from the configuration yaml file or by environment variables like any other variable in the yaml file:
 
-**Note**: setting the `tf_plugin_dir` parameter in the `testrunner` configuration as shown bellow **will not work**. The reason is that terraform will disable the [default discovery process](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery) and therefore the other required plugings will not be available.
+```yaml
+libvirt:
+  uri: "qemu:///system" #os.getenv("LIBVIRT_URI")
+  keyfile: "" #os.getenv("LIBVIRT_KEYFILE")
+  image_uri: "" #os.getenv("LIBVIRT_IMAGE_URI")
 ```
-terraform:
-  plugin_dir: "/path/to/libvirt/provider"
-```
+
+`uri` is the URI used by the libvirt client to connect the libvirt host `qemu:///system` for local libvirt services.
+`keyfile` is the path of the keyfile used to connect to the libbirt `uri`. This path is included as part of the `uri` as a query. Consider a remote ssh uri as `qemu+ssh://<user>@<libvirt_host>/system`, defining a `keyfile` turns it into `qemu+ssh://<user>@<libvirt_host>/system?keyfile=<keyfile_path>`
+`image_uri` is the URI that will be used to pull the image for the VMs deployment, usually this points to some JeOS image.Note the image is expected to include cloud-init.
 
 ### Jenkins Setup
 

--- a/ci/infra/testrunner/platforms/libvirt.py
+++ b/ci/infra/testrunner/platforms/libvirt.py
@@ -9,6 +9,11 @@ from utils import Format
 class Libvirt(Terraform):
     def __init__(self, conf):
         super().__init__(conf, 'libvirt')
+        self.platform_new_vars = {
+            "libvirt_uri": self.conf.libvirt.uri,
+            "libvirt_keyfile": self.conf.libvirt.keyfile,
+            "image_uri": self.conf.libvirt.image_uri
+        }
 
     def _env_setup_cmd(self):
         return ":"

--- a/ci/infra/testrunner/platforms/openstack.py
+++ b/ci/infra/testrunner/platforms/openstack.py
@@ -12,6 +12,8 @@ class Openstack(Terraform):
         if not os.path.isfile(conf.openstack.openrc):
             raise ValueError(Format.alert(f"Your openrc file path \"{conf.openstack.openrc}\" does not exist.\n\t    "
                                           "Check your openrc file path in a configured yaml file"))
+        self.platform_new_vars = {}
+
 
     def _env_setup_cmd(self):
         return f"source {self.conf.openstack.openrc}"

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -151,6 +151,8 @@ class Terraform(Platform):
             "authorized_keys": [self.utils.authorized_keys()]
         }
 
+        new_vars.update(self.platform_new_vars)
+
         for k, v in new_vars.items():
             if tfvars.get(k) is not None:
                 if isinstance(v, list):

--- a/ci/infra/testrunner/platforms/vmware.py
+++ b/ci/infra/testrunner/platforms/vmware.py
@@ -13,6 +13,7 @@ class VMware(Terraform):
             msg = (f'Your VMware env file path "{conf.vmware.env_file}" does not exist.\n\t    '
                    'Check the VMware env file path in your configured yaml file.')
             raise ValueError(Format.alert(msg))
+        self.platform_new_vars = {}
 
     def _env_setup_cmd(self):
         return f"source {self.conf.vmware.env_file}"

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -24,6 +24,7 @@ class BaseConfig:
         obj.terraform = BaseConfig.Terraform()
         obj.openstack = BaseConfig.Openstack()
         obj.vmware = BaseConfig.VMware()
+        obj.libvirt = BaseConfig.Libvirt()
         obj.skuba = BaseConfig.Skuba()
         obj.test = BaseConfig.Test()
         obj.log = BaseConfig.Log()
@@ -37,7 +38,8 @@ class BaseConfig:
             BaseConfig.Openstack,
             BaseConfig.Terraform,
             BaseConfig.Skuba,
-            BaseConfig.VMware
+            BaseConfig.VMware,
+            BaseConfig.Libvirt
         )
 
         # vars get the values from yaml file
@@ -103,6 +105,12 @@ class BaseConfig:
             self.env_file = None
             self.template_name = None
 
+    class Libvirt:
+        def __init__(self):
+            super().__init__()
+            self.uri = "qemu:///system"
+            self.keyfile = None
+            self.image_uri = None
 
     class Packages:
         def __init__(self):

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -42,5 +42,10 @@ vmware:
   env_file: "" #os.getenv("VMWARE_ENV_FILE")
   template_name: "SLES15-SP1-GM-guestinfo" #os.getenv("VMWARE_TEMPLATE_NAME")
 
+libvirt:
+  uri: "qemu:///system" #os.getenv("LIBVIRT_URI")
+  keyfile: "" #os.getenv("LIBVIRT_KEYFILE")
+  image_uri: "" #os.getenv("LIBVIRT_IMAGE_URI") 
+
 log:
   level: DEBUG

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -3,10 +3,9 @@
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
-    platform: openstack
     jobs:
         - '{name}/test'
-        - '{name}/test-vmware'
+        - '{name}/test-libvirt'
         - '{name}/update-unit'
         - '{name}/update-acceptance'
         - '{name}/code-lint'

--- a/ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
@@ -1,0 +1,146 @@
+/**
+ * This pipeline verifies on a Github PR:
+ *   - skuba unit and e2e tests
+ *   - Basic skuba deployment, bootstrapping, and adding nodes to a cluster
+ */
+
+pipeline {
+    agent { node { label 'caasp-team-private-integration-nue && kvm' } }
+
+    environment {
+        SKUBA_BINPATH = '/home/jenkins/go/bin/skuba'
+        GITHUB_TOKEN = credentials('github-token')
+        PLATFORM = 'libvirt'
+        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}".take(70)
+        PR_CONTEXT = 'jenkins/skuba-test-libvirt'
+        PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
+        REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
+        PIP_VERBOSE = 'true'
+        LIBVIRT_URI = 'qemu+ssh://jenkins@node52.cloud.suse.de/system'
+        LIBVIRT_KEYFILE = credentials('libvirt-keyfile')
+        LIBVIRT_IMAGE_URI = 'http://download.suse.de/install/SLE-15-SP1-JeOS-QU2/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU2.qcow2'
+    }
+
+    stages {
+        stage('Collaborator Check') { steps { script {
+            if (env.BRANCH_NAME.startsWith('PR')) {
+                def membersResponse = httpRequest(
+                    url: "https://api.github.com/repos/SUSE/skuba/collaborators/${CHANGE_AUTHOR}",
+                    authentication: 'github-token',
+                    validResponseCodes: "204:404")
+
+                if (membersResponse.status == 204) {
+                    echo "Test execution for collaborator ${CHANGE_AUTHOR} allowed"
+
+                } else {
+                    def allowExecution = false
+
+                    try {
+                        timeout(time: 5, unit: 'MINUTES') {
+                            allowExecution = input(id: 'userInput', message: "Change author is not a SUSE member: ${CHANGE_AUTHOR}", parameters: [
+                                booleanParam(name: 'allowExecution', defaultValue: false, description: 'Run tests anyway?')
+                            ])
+                        }
+                    } catch(err) {
+                        def user = err.getCauses()[0].getUser()
+                        if('SYSTEM' == user.toString()) {
+                            echo "Timeout while waiting for input"
+                        } else {
+                            allowExecution = false
+                            echo "Unhandled error:\n${err}"
+                        }
+                    }
+
+                    if (!allowExecution) {
+                        echo "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed"
+                        error(message: "Test execution for unknown user (${CHANGE_AUTHOR}) disallowed")
+                        return;
+                    }
+                }
+            }
+        } } }
+
+        stage('Setting GitHub in-progress status') { steps {
+            sh(script: "${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'pending'", label: "Sending pending status")
+        } }
+
+        stage('Git Clone') { steps {
+            deleteDir()
+            checkout([$class: 'GitSCM',
+                      branches: [[name: "*/${BRANCH_NAME}"], [name: '*/master']],
+                      doGenerateSubmoduleConfigurations: false,
+                      extensions: [[$class: 'LocalBranch'],
+                                   [$class: 'WipeWorkspace'],
+                                   [$class: 'RelativeTargetDirectory', relativeTargetDir: 'skuba']],
+                      submoduleCfg: [],
+                      userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/PR-*',
+                                           credentialsId: 'github-token',
+                                           url: 'https://github.com/SUSE/skuba']]])
+
+            dir("${WORKSPACE}/skuba") {
+                sh(script: "git checkout ${BRANCH_NAME}", label: "Checkout PR Branch")
+            }
+        }}
+
+        stage('Run skuba unit tests') { steps {
+            dir("skuba") {
+              sh(script: 'make test-unit', label: 'make test-unit')
+            }
+        } }
+
+        stage('Getting Ready For Cluster Deployment') { steps {
+            sh(script: 'make -f skuba/ci/Makefile pre_deployment', label: 'Pre Deployment')
+            sh(script: 'make -f skuba/ci/Makefile pr_checks', label: 'PR Checks')
+            sh(script: "pushd skuba; make -f Makefile install; popd", label: 'Build Skuba')
+        } }
+
+        stage('Deploy cluster') {
+            steps {
+                sh(script: 'make -f skuba/ci/Makefile create_environment', label: 'Provision')
+                sh(script: 'make -f skuba/ci/Makefile bootstrap', label: 'Bootstrap')
+                sh(script: 'make -f skuba/ci/Makefile join_nodes', label: 'Join Nodes')
+            }
+        }
+
+        stage('Run e2e tests') { steps {
+            sh(script: "make -f skuba/ci/Makefile test_pr", label: "test_pr")
+        } }
+
+    }
+    post {
+        always {
+            archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
+            sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
+            archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
+            junit('skuba/ci/infra/testrunner/*.xml')
+        }
+        cleanup {
+            sh(script: "make --keep-going -f skuba/ci/Makefile cleanup", label: 'Cleanup')
+            dir("${WORKSPACE}@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}") {
+                deleteDir()
+            }
+            sh(script: "rm -f ${SKUBA_BINPATH}; ", label: 'Remove built skuba')
+        }
+        unstable {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
+        failure {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'failure'", label: "Sending failure status")
+        }
+        success {
+            sh(script: "skuba/${PR_MANAGER} update-pr-status ${GIT_COMMIT} ${PR_CONTEXT} 'success'", label: "Sending success status")
+        }
+    }
+}

--- a/ci/jenkins/templates/test-libvirt-template.yaml
+++ b/ci/jenkins/templates/test-libvirt-template.yaml
@@ -1,10 +1,10 @@
 - job-template:
-    name: '{name}/test-vmware'
+    name: '{name}/test-libvirt'
     project-type: multibranch
     periodic-folder-trigger: 5m
     number-to-keep: 30
     days-to-keep: 30
-    script-path: ci/jenkins/pipelines/prs/skuba-test-vmware.Jenkinsfile
+    script-path: ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
     wrappers:
       - timeout:
           timeout: 120


### PR DESCRIPTION
## Why is this PR needed?

This PR is needed to start using libvirt platform to tests skuba PRs in addition to the current VMWare tests.

Part of SUSE/avant-garde#1227

## What does this PR do?

This commit sets to test skuba PRs using testrunner for libvirt and
vmware platforms. Moreover it cleans up some of the previous old and
unused VMWare job settings.

## Anything else a reviewer needs to know?


## Info for QA

None, it is CI PR.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
