### PR TITLE
Update global client secret

### DIFF
--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -22,13 +22,10 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/dex"
-	"github.com/SUSE/skuba/internal/pkg/skuba/gangway"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
 	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
 )
-
-var gangwayClientSecret string
 
 func init() {
 	registerAddon(kubernetes.Dex, renderDexTemplate, dexCallbacks{}, normalPriority, []getImageCallback{GetDexImage})
@@ -40,13 +37,6 @@ func GetDexImage(imageTag string) string {
 
 func (renderContext renderContext) DexImage() string {
 	return GetDexImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Dex, renderContext.config.ClusterVersion).Version)
-}
-
-func (renderContext renderContext) GangwayClientSecret() string {
-	if len(gangwayClientSecret) == 0 {
-		gangwayClientSecret = dex.GenerateClientSecret()
-	}
-	return gangwayClientSecret
 }
 
 func renderDexTemplate(addonConfiguration AddonConfiguration) string {
@@ -61,13 +51,6 @@ func (dexCallbacks) beforeApply(addonConfiguration AddonConfiguration, skubaConf
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return errors.Wrap(err, "could not get admin client set")
-	}
-
-	// Read gangway client secret from secret resource if present
-	// in order to update global variable gangwayClientSecret.
-	gangwayClientSecret, err = gangway.GetClientSecret(client)
-	if err != nil {
-		return errors.Wrap(err, "unable to determine if gangway client secret exists")
 	}
 
 	dexCertExists, err := dex.DexCertExists(client)

--- a/internal/pkg/skuba/addons/dex_test.go
+++ b/internal/pkg/skuba/addons/dex_test.go
@@ -86,33 +86,6 @@ func Test_renderContext_DexImage(t *testing.T) {
 	}
 }
 
-func Test_renderContext_GangwayClientSecret(t *testing.T) {
-	type test struct {
-		name          string
-		renderContext renderContext
-		want          string
-	}
-	for _, ver := range kubernetes.AvailableVersions() {
-		tt := test{
-			name:          "get gangway client secret when cluster version is " + ver.String(),
-			renderContext: renderContext{},
-			want:          "[[:alpha:][:digit:]]{20}",
-		}
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.renderContext.GangwayClientSecret()
-			matched, err := regexp.Match(tt.want, []byte(got))
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			if !matched {
-				t.Errorf("renderContext.GangwayClientSecret() = %v, want %v", got, tt.want)
-				return
-			}
-		})
-	}
-}
-
 func Test_dexCallbacks_beforeApply(t *testing.T) {
 	type test struct {
 		name               string

--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -39,6 +39,15 @@ func (renderContext renderContext) GangwayImage() string {
 	return GetGangwayImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Gangway, renderContext.config.ClusterVersion).Version)
 }
 
+func (renderContext renderContext) GangwayClientSecret() string {
+	client, err := kubernetes.GetAdminClientSet()
+	if err != nil {
+		return ""
+	}
+
+	return gangway.GetClientSecret(client)
+}
+
 func renderGangwayTemplate(addonConfiguration AddonConfiguration) string {
 	return gangwayManifest
 }
@@ -49,13 +58,6 @@ func (gangwayCallbacks) beforeApply(addonConfiguration AddonConfiguration, skuba
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
 		return errors.Wrap(err, "could not get admin client set")
-	}
-
-	// Read gangway client secret from secret resource if present
-	// in order to update global variable gangwayClientSecret.
-	gangwayClientSecret, err = gangway.GetClientSecret(client)
-	if err != nil {
-		return errors.Wrap(err, "unable to determine if gangway client secret exists")
 	}
 
 	gangwaySecretExists, err := gangway.GangwaySecretExists(client)

--- a/internal/pkg/skuba/addons/gangway_test.go
+++ b/internal/pkg/skuba/addons/gangway_test.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"testing"
 
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
 	img "github.com/SUSE/skuba/pkg/skuba"
@@ -80,6 +82,20 @@ func Test_renderContext_GangwayImage(t *testing.T) {
 			}
 			if !matched {
 				t.Errorf("renderContext.GangwayImage() = %v, want %v", got, tt.want)
+				return
+			}
+		})
+	}
+}
+
+func Test_renderContext_GangwayClientSecret(t *testing.T) {
+	for _, ver := range kubernetes.AvailableVersions() {
+		t.Run("get gangway client secret when cluster version is "+ver.String(), func(t *testing.T) {
+			fake.NewSimpleClientset()
+
+			got := renderContext{}.GangwayClientSecret()
+			if got != "" {
+				t.Errorf("expect got client secret empty")
 				return
 			}
 		})


### PR DESCRIPTION
## Why is this PR needed?

With kustomize supported, the manifest would be force rendered on `skuba node bootstrap` and `skuba addon upgrade apply`.

This causes the dex/gangway client secret mismatch when bootstrapping the cluster.

Fixes #

## What does this PR do?

When rendering the client secret:
1. read from global client secret variable if present
2. read from gangway ConfigMap client secret if present
3. otherwise generates a new client secret and stores it in global client
secret variable

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

1. Bootstrap the cluster
2. The client secret mismatch
   ```
   kubectl get cm oidc-dex-config -o yaml
   kubectl get cm oidc-gangway-config -o yaml
   ```

### Status **AFTER** applying the patch

1. Bootstrap the cluster
2. The client secret matched
   ```
   kubectl get cm oidc-dex-config -o yaml
   kubectl get cm oidc-gangway-config -o yaml
   ```

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>