### PR TITLE
Add replica HA on metric-server

### DIFF
--- a/internal/pkg/skuba/addons/metricsserver.go
+++ b/internal/pkg/skuba/addons/metricsserver.go
@@ -208,12 +208,18 @@ metadata:
   namespace: kube-system
   labels:
     app: metrics-server
+    caasp.suse.com/skuba-replica-ha: "true"
 spec:
   replicas: 2
   revisionHistoryLimit: 3
   selector:
     matchLabels:
       app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   template:
     metadata:
       name: metrics-server


### PR DESCRIPTION
## Why is this PR needed?

In #966 added metrcs-server with  `caasp.suse.com/skuba-replica-ha: "true"`. It was revered in #994 due to an issue reported that extra metrics pod stuck in `Pending`.

With default `RollingUpdateStrategy:  25% max unavailable, 25% max surge` plus affinity rule in-place caused replicaset unable to complete rolling update deployment, leaving 1 Pod runing in replicaset revision in small cluster.

Ref: https://github.com/SUSE/avant-garde/issues/1393

## What does this PR do?

This enables metrics-server for replica HA and set rolling update strategy to allow rolling update overhead.

## Anything else a reviewer needs to know?

## Info for QA

### Related info

### Status **BEFORE** applying the patch

```
NAME                              READY   STATUS    RESTARTS   AGE
metrics-server-554b946d44-7lwg7   1/1     Running   0          16m
metrics-server-848d94b477-8blgc   0/1     Pending   0          14m
metrics-server-848d94b477-jxnbq   1/1     Running   0          14m

NAME                         DESIRED   CURRENT   READY   AGE
cilium-operator-654b5785c9   1         1         1       43m
coredns-7ffbb88dbb           2         2         2       44m
metrics-server-554b946d44    1         1         1       43m
metrics-server-848d94b477    2         2         1       27m
oidc-dex-5c9b5d9cf4          3         3         3       27m
oidc-dex-67d55d8fd7          0         0         0       44m
oidc-gangway-79b78f74c5      3         3         3       27m
oidc-gangway-7f47b9c947      0         0         0       44m
```

### Status **AFTER** applying the patch

```
NAME                              READY   STATUS    RESTARTS   AGE
metrics-server-848d94b477-b5nws   1/1     Running   0          4m33s
metrics-server-848d94b477-xqq9p   1/1     Running   0          4m34s

NAME                         DESIRED   CURRENT   READY   AGE
cilium-operator-654b5785c9   1         1         1       26m
coredns-7ffbb88dbb           2         2         2       27m
metrics-server-554b946d44    0         0         0       26m
metrics-server-848d94b477    2         2         2       17m
oidc-dex-67d55d8fd7          0         0         0       25m
oidc-dex-767dc6847b          3         3         3       10m
oidc-gangway-7f47b9c947      0         0         0       27m
oidc-gangway-c4f5b57c9       3         3         3       10m
```

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>
