### PR TITLE
Add 1.17 deploy feature to skuba

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -3,8 +3,8 @@ import signal
 import time
 import yaml
 
-PREVIOUS_VERSION = "1.15.2"
-CURRENT_VERSION = "1.16.2"
+PREVIOUS_VERSION = "1.16.2"
+CURRENT_VERSION = "1.17.4"
 
 
 def check_nodes_ready(kubectl):

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -79,6 +79,27 @@ type KubernetesVersions map[string]KubernetesVersion
 
 var (
 	supportedVersions = KubernetesVersions{
+		"1.17.4": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.17.4",
+				ContainerRuntimeVersion: "1.17.0",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
+				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.5.3", 2},
+				Kured:         &AddonVersion{"1.3.0", 4},
+				Dex:           &AddonVersion{"2.16.0", 5},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
+				MetricsServer: &AddonVersion{"0.3.6", 0},
+				PSP:           &AddonVersion{"", 2},
+			},
+		},
 		"1.16.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.16.2",


### PR DESCRIPTION
This adds:
- 1.17 in the available versions for skuba, pointing to the right containers
- Test the 1.16->1.17 in CI
