### PR TITLE
Add code ownership for ci to SUSE/caasp-platform/automation group

### DIFF
--- a/ci/CODEOWNERS
+++ b/ci/CODEOWNERS
@@ -1,0 +1,2 @@
+@SUSE/caasp-platform-automation
+


### PR DESCRIPTION
Following the decision of having this group own

github/SUSE/caasp-automation

I would like to have the same ownership in the ci directory and then we
make it a requirement to have an approval of this group.

This is to prevent merging code into the CI without the CI maintainers
knowledge.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

