### PR TITLE
CI: Use configurable branch for sonobuoy job

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -10,21 +10,6 @@ pipeline {
     }
 
     stages {
-
-        stage('Git Clone') { steps {
-            deleteDir()
-            checkout([$class: 'GitSCM',
-                      branches: [[name: "*/${BRANCH}"]],
-                      doGenerateSubmoduleConfigurations: false,
-                      extensions: [[$class: 'LocalBranch'],
-                                   [$class: 'WipeWorkspace'],
-                                   [$class: 'RelativeTargetDirectory', relativeTargetDir: 'skuba'],
-                                   [$class: 'ChangelogToBranch', options: [compareRemote: "origin", compareTarget: "master"]]],
-                      submoduleCfg: [],
-                      userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/PR-*',
-                                           credentialsId: 'github-token',
-                                           url: 'https://github.com/SUSE/skuba']]])
-        }}
         stage('Getting Ready For Cluster Deployment') { steps {
             sh(script: 'make -f skuba/ci/Makefile pre_deployment', label: 'Pre Deployment')
             sh(script: 'cd skuba; make install; cd ../', label: 'Install skuba')
@@ -48,7 +33,6 @@ pipeline {
                 sh(script: "skuba/ci/tasks/sonobuoy_e2e.py cleanup --kubeconfig ${WORKSPACE}/test-cluster/admin.conf", label: 'Cleanup Cluster')
             }
         }
-
     }
     post {
         always {

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -3,7 +3,6 @@
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30
-    branch: master
     wrappers:
       - timeout:
           timeout: 180
@@ -13,7 +12,7 @@
     parameters:
         - string:
             name: BRANCH
-            default: '{branch}'
+            default: master
             description: The branch to checkout
         - string:
               name: PLATFORM
@@ -25,7 +24,7 @@
                 url: 'https://github.com/{repo-owner}/{repo-name}.git'
                 credentials-id: '{repo-credentials}'
                 branches:
-                    - '{branch}'
+                    - $branch
                 browser: auto
                 suppress-automatic-scm-triggering: true
                 basedir: skuba

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -24,8 +24,13 @@
                 url: 'https://github.com/{repo-owner}/{repo-name}.git'
                 credentials-id: '{repo-credentials}'
                 branches:
-                    - $branch
+                    - ${{BRANCH}}
                 browser: auto
                 suppress-automatic-scm-triggering: true
                 basedir: skuba
+                refspec: '+refs/pull/*/head:refs/remotes/origin/PR-*'
+                changelog-against:
+                    remote: origin
+                    branch: master
+                wipe-workspace: true
         script-path: skuba/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile


### PR DESCRIPTION
Looks like we were hardcoding the branch value on the job template
for sonobuoy, but what we really want is to have the default
branch parameter be master and allow setting the branch to pick
the jenkinsfile from set to that value dynamically so we
can test changes in the jenkinsfile from PRs.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
