### PR TITLE
Remove MetricsServer from 4.2.0

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -93,12 +93,11 @@ var (
 				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.5.3", 2},
-				Kured:         &AddonVersion{"1.3.0", 4},
-				Dex:           &AddonVersion{"2.16.0", 5},
-				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
-				MetricsServer: &AddonVersion{"0.3.6", 0},
-				PSP:           &AddonVersion{"", 2},
+				Cilium:  &AddonVersion{"1.5.3", 2},
+				Kured:   &AddonVersion{"1.3.0", 4},
+				Dex:     &AddonVersion{"2.16.0", 5},
+				Gangway: &AddonVersion{"3.1.0-rev4", 4},
+				PSP:     &AddonVersion{"", 2},
 			},
 		},
 		"1.16.2": KubernetesVersion{


### PR DESCRIPTION
## Why is this PR needed?

Remove metrics server