### PR TITLE
Do not crash with different addon subset

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -198,7 +198,6 @@ func AddonVersionWithAvailableVersions(addon Addon, clusterVersion *version.Vers
 	if addonVersion, found := currentKubernetesVersion.AddonsVersion[addon]; found {
 		return addonVersion
 	}
-	klog.Errorf("unknown addon %q version", addon)
 	return nil
 }
 

--- a/pkg/skuba/actions/cluster/images/images.go
+++ b/pkg/skuba/actions/cluster/images/images.go
@@ -35,6 +35,9 @@ func Images() error {
 
 		for addonName, addon := range addons.Addons {
 			addonVersion := kubernetes.AddonVersionForClusterVersion(addonName, version)
+			if addonVersion == nil {
+				continue
+			}
 			imageList := addon.Images(addonVersion.Version)
 			for _, image := range imageList {
 				fmt.Printf("%-10v %v\n", version, image)


### PR DESCRIPTION
## Why is this PR needed?

When different Kubernetes versions have a different addon subset, test
for the addon version existence, if there is no addon version for that
specific Kubernetes version, just ignore it.

Also, do not print the "unknown addon" informative message log, since
it can lead to confusion; this has been reported both when running
`skuba cluster images` and `skuba cluster init` as well, when there
are different Kubernetes versions with different subset of addons.

Fixes https://github.com/SUSE/avant-garde/issues/1408

cc/ @atighineanu since, you reported the warning message as well with `skuba cluster init`, also handled here.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
