### PR TITLE
Fix: setup fixture cleanup fails

### DIFF
--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -94,8 +94,11 @@ def platform(conf, target):
 @pytest.fixture
 def setup(request, platform, skuba):
     def cleanup():
-        platform.gather_logs()
-        platform.cleanup()
+        # if platform was not allocated, gather_logs may fail. Ignore.
+        try:
+            platform.gather_logs()
+        finally:
+            platform.cleanup()
 
     request.addfinalizer(cleanup)
 


### PR DESCRIPTION
## Why is this PR needed?

The setup fixture's cleanup tries to retrieve the logs from nodes.
If the platform could not be allocated, it fails preventing the
actual cluster cleanup to be executed.

Fixes https://github.com/SUSE/avant-garde/issues/1432

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Ignores exceptions trying to retrieve logs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
