### PR TITLE
Migrate the usage of hyperkube

### DIFF
--- a/internal/pkg/skuba/kubeadm/images.go
+++ b/internal/pkg/skuba/kubeadm/images.go
@@ -26,7 +26,6 @@ import (
 )
 
 func setContainerImagesWithClusterVersion(initConfiguration *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
-	initConfiguration.UseHyperKubeImage = true
 	initConfiguration.ImageRepository = skuba.ImageRepository
 	initConfiguration.KubernetesVersion = kubernetes.ComponentVersionForClusterVersion(kubernetes.Hyperkube, clusterVersion)
 	initConfiguration.Etcd.Local = &kubeadmapi.LocalEtcd{

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -368,3 +368,20 @@ func TestMajorMinorVersion(t *testing.T) {
 		})
 	}
 }
+
+// Compiler ensures we don't remove some code that's still deprecating.
+// This ensure code _removal_ when ready to do so.
+func TestEnsureHyperKubeIsRemovedForSupportedVersions(t *testing.T) {
+	for kubernetesVersionStr := range supportedVersions {
+		kubernetesVersion := version.MustParseSemantic(kubernetesVersionStr)
+		versionComparedTo118, err := kubernetesVersion.Compare("1.18.0")
+		if err != nil {
+			t.Fatalf("our versions should always be valid semver and something bad happened: %+v", err)
+		}
+		// If we support at least a version using HyperKube (i.e. below 1.18), bail out.
+		if versionComparedTo118 == -1 {
+			return
+		}
+	}
+	t.Errorf("please, remove HyperKube booleans (usehyperkube, needshyperkube) from code and remove this test.")
+}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -96,6 +96,15 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		if err := node.AddTargetInformationToInitConfigurationWithClusterVersion(target, initCfg, nodeVersionInfoUpdate.Update.APIServerVersion); err != nil {
 			return errors.Wrap(err, "error adding target information to init configuration")
 		}
+
+		// Upgrade 1.17 to 1.18.
+		// This updated UseHyperKube field in-memory (unsets it).
+		// Note: The cluster cm is uploaded at the end of the kubeadm process, as usual.
+		// The whole paragraph can be removed when upgrading from 1.17 is removed.
+		if currentClusterVersion.Minor() == 17 {
+			initCfg.UseHyperKubeImage = false
+		}
+
 		kubeadm.UpdateClusterConfigurationWithClusterVersion(initCfg, nodeVersionInfoUpdate.Update.APIServerVersion)
 		initCfgContents, err = kubeadmconfigutil.MarshalInitConfigurationToBytes(initCfg, schema.GroupVersion{
 			Group:   "kubeadm.k8s.io",


### PR DESCRIPTION
For 1.18 onwards, we shouldn't have UseHyperKube set to true.

Closes: SUSE/avant-garde#1431

