### PR TITLE
Update for Kubernetes v1.18.0

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -3,8 +3,8 @@ import signal
 import time
 import yaml
 
-PREVIOUS_VERSION = "1.16.2"
-CURRENT_VERSION = "1.17.4"
+PREVIOUS_VERSION = "1.17.4"
+CURRENT_VERSION = "1.18.0"
 
 
 def check_nodes_ready(kubectl):

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -81,6 +81,27 @@ type ClusterAddonsKnownVersions = func(clusterVersion *version.Version) AddonsVe
 
 var (
 	supportedVersions = KubernetesVersions{
+		"1.18.0": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.18.0",
+				ContainerRuntimeVersion: "1.17.0",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.18.0"},
+				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
+				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.2"},
+				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.5.3", 2},
+				Kured:         &AddonVersion{"1.3.0", 4},
+				Dex:           &AddonVersion{"2.19.0", 6},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
+				MetricsServer: &AddonVersion{"0.3.6", 0},
+				PSP:           &AddonVersion{"", 2},
+			},
+		},
 		"1.17.4": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.17.4",


### PR DESCRIPTION
It is adding Kubernetes v1.18 and all necessary containers to skuba.

It depends on: https://github.com/SUSE/skuba/pull/1024