### PR TITLE
Refactor cluster check logic

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -507,6 +507,8 @@ the node's role are executed.
 ```
   -c CHECKS [CHECKS ...], --check CHECKS [CHECKS ...]
                         check to be executed (multiple checks can be specified)
+  -s STAGE, -stage STAGE
+                        only execute checks that apply to this stage
 ```
 
 ### Test command

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -501,7 +501,13 @@ Executes command in a node
 
 #### Check command
 
-Checkes the status of a node
+Checks the status of a node. If no check is specified, all checks that apply to
+the node's role are executed.
+
+```
+  -c CHECKS [CHECKS ...], --check CHECKS [CHECKS ...]
+                        check to be executed (multiple checks can be specified)
+```
 
 ### Test command
 

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -183,6 +183,12 @@ skuba:
   verbosity: 5
 ```
 
+### Kubectl
+
+The kubectl section defines the configuration of the kubectl tool. 
+* binpath: path to the kubectl binary. Defaults to `/usr/bin/kubectl`
+* kubeconf: path to the kubeconfig file. defaults to `<workspace>/test-cluster/admin.conf`
+
 ### Log
 
 Testrunner sends output to both a console and file logger handlers, configured using the following `log` variables:

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -22,7 +22,7 @@
   - [Provision](#provision-command)
   - [Node commands](#node-commands)
     - [Node Upgrade](#node-upgrade-command)
-  - [Ssh](#ssh-command)
+    - [Ssh](#ssh-command)
   - [Test](#test-command)
 - [Examples](#examples)
   - [Create K8s Cluster](#create-k8s-cluster)
@@ -395,6 +395,7 @@ positional arguments:
     status              check K8s cluster status
     cluster-upgrade-plan
                         Cluster upgrade plan
+    check-node          check node health
     join-node           add node in k8s cluster with the given role.
     remove-node         remove node from k8s cluster.
     node-upgrade        upgrade kubernetes version in node
@@ -440,16 +441,6 @@ optional arguments:
                         timeout for waiting a node to become ready (seconds)
 ```
 
-### Node commands
-
-```
-  -h, --help            show this help message and exit
-  -r {master,worker}, --role {master,worker}
-                        role of the node to be added or deleted. eg: --role
-                        master
-  -n NODE, --node NODE  node to be added or deleted. eg: -n 0
-
-```
 ### Join nodes
 
 ```
@@ -485,23 +476,26 @@ Joins node to cluster with the given role
 
 #### Node Upgrade command
 
+Upgrades node
+
 ```
   -h, --help            show this help message and exit
   -a {plan,apply}, --action {plan,apply}
                         action: plan or apply upgrade
 ```
 
-### Ssh command
+#### Ssh command
+
+Executes command in a node
 
 ```
-  -h, --help            show this help message and exit
-  -r {master,worker}, --role {master,worker}
-                        role of the node to be added or deleted. eg: --role
-                        master
-  -n NODE, --node NODE  node to be added or deleted. eg: -n 0
   -c ..., --cmd ...     remote command and its arguments. e.g ls -al. Must be
                         last argument for ssh command
 ```
+
+#### Check command
+
+Checkes the status of a node
 
 ### Test command
 
@@ -529,7 +523,6 @@ optional arguments:
                         level of detail in traceback for test failure
 
 ```
-
 
 ## Examples 
 

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -461,6 +461,28 @@ optional arguments:
   -t TIMEOUT, --timeout TIMEOUT
                         timeout for waiting the master nodes to become ready (seconds)
 ```
+
+### Node commands
+
+Common parameters
+
+```
+  -h, --help            show this help message and exit
+  -r {master,worker}, --role {master,worker}
+                        role of the node to be added or deleted. eg: --role
+                        master
+  -n NODE, --node NODE  node to be added or deleted. eg: -n 0
+
+```
+#### Join Node
+
+Joins node to cluster with the given role
+
+```
+  -t TIMEOUT, --timeout TIMEOUT
+                        timeout for waiting a node to become ready (seconds)
+```
+
 #### Node Upgrade command
 
 ```

--- a/ci/infra/testrunner/checks/__init__.py
+++ b/ci/infra/testrunner/checks/__init__.py
@@ -1,0 +1,1 @@
+from checks.checks import Checker

--- a/ci/infra/testrunner/checks/checks.py
+++ b/ci/infra/testrunner/checks/checks.py
@@ -1,0 +1,86 @@
+import time
+
+import platforms
+from utils.utils import Utils
+
+_checks = {}
+
+def check(name=None, roles=[], check_timeout=300, check_backoff=20):
+    """Decorator for waiting a check to become true.
+       Can receve the following arguments when invoking the check function
+       name: name of the check (used for reporting, if not defined, check
+             function is used
+       roles: list of node roles this check applies
+       check_timeout: the timeout for the check
+       check_backoff: the backoff between retries
+
+      The check_timout and check_backoff parameters can be overidden when
+      calling the check_node function
+    """
+    def checker(check):
+        def wait_condition(*args, **kwargs):
+            _name  = name
+            if not _name:
+               _name = check.__name__
+
+            timeout = kwargs.pop('check_timeout', check_timeout)
+            backoff = kwargs.pop('check_backoff', check_backoff)
+            deadline = int(time.time()) + timeout
+            while True:
+                last_error = None
+                try:
+                    if check(*args, **kwargs):
+                        return True
+                except Exception as ex:
+                    last_error = ex
+
+                if int(time.time()) >= deadline:
+                    msg = (f'condition {_name} not satisfied after {timeout} seconds'
+                           f'{". Last error:"+str(last_error) if last_error else ""}')
+                    raise AssertionError(msg)
+
+                time.sleep(backoff)
+
+        for role in roles:
+           role_checks = _checks.get(role, [])
+           role_checks.append(wait_condition)
+           _checks[role] = role_checks
+
+        return wait_condition
+
+    return checker
+
+
+class Checker:
+
+    def __init__(self, conf, platform):
+        self.conf = conf
+        self.utils = Utils(self.conf)
+        self.utils.setup_ssh()
+        self.platform = platforms.get_platform(conf, platform)
+
+
+    def check_node(self, role, node, timeout=180, backoff=20):
+        start   = int(time.time())
+        for check in _checks.get(role, []):
+            remaining = timeout-(int(time.time())-start)
+            check(self.platform, role, node, check_timeout=remaining, check_backoff=backoff)
+
+
+@check(name="apiserver healthz", roles=['master'])
+def check_apiserver_healthz(platform, role, node):
+     cmd =   'curl -Ls --insecure https://localhost:6443/healthz'
+     output = platform.ssh_run(role, node, cmd)
+     return output.find("ok") > -1
+
+@check(name="etcd health", roles=['master'])
+def check_etcd_health(platform, role, node):
+    cmd = ('sudo curl -Ls --cacert /etc/kubernetes/pki/etcd/ca.crt '
+           '--key /etc/kubernetes/pki/etcd/server.key '
+           '--cert /etc/kubernetes/pki/etcd/server.crt '
+           'https://localhost:2379/health')
+    output = platform.ssh_run(role, node, cmd)
+    return output.find("true") > -1
+
+
+

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -1,6 +1,3 @@
-import platforms
-
-from skuba.skuba import Skuba
 from utils.utils import (Utils)
 from time import sleep
 
@@ -9,17 +6,19 @@ class Kubectl:
     def __init__(self, conf, platform):
         self.conf = conf
         self.utils = Utils(self.conf)
-        self.platform = platforms.get_platform(conf, platform)
-        self.skuba = Skuba(conf, platform)
 
     def run_kubectl(self, command, stdin=None):
-        kubeconfig = self.skuba.get_kubeconfig()
+        kubeconfig = self.get_kubeconfig()
 
         shell_cmd = "kubectl --kubeconfig={} {}".format(kubeconfig, command)
         try:
             return self.utils.runshellcommand(shell_cmd, stdin=stdin)
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(shell_cmd)) from ex
+
+    def get_kubeconfig(self):
+        path = "{cwd}/test-cluster/admin.conf".format(cwd=self.conf.workspace)
+        return path
 
     def get_node_names_by_role(self, role):
         """Returns a list of node names for a given role

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -5,20 +5,16 @@ class Kubectl:
 
     def __init__(self, conf, platform):
         self.conf = conf
+        self.binpath = conf.kubectl.binpath
+        self.kubeconfig = conf.kubectl.kubeconfig
         self.utils = Utils(self.conf)
 
     def run_kubectl(self, command, stdin=None):
-        kubeconfig = self.get_kubeconfig()
-
-        shell_cmd = "kubectl --kubeconfig={} {}".format(kubeconfig, command)
+        shell_cmd = f'{self.binpath} --kubeconfig={self.kubeconfig} {command}'
         try:
             return self.utils.runshellcommand(shell_cmd, stdin=stdin)
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(shell_cmd)) from ex
-
-    def get_kubeconfig(self):
-        path = "{cwd}/test-cluster/admin.conf".format(cwd=self.conf.workspace)
-        return path
 
     def get_node_names_by_role(self, role):
         """Returns a list of node names for a given role

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -211,11 +211,6 @@ class Skuba:
         output = self.utils.runshellcommand(cmd)
         return output.count(role)
 
-    @step
-    def get_kubeconfig(self):
-        path = "{cwd}/test-cluster/admin.conf".format(cwd=self.conf.workspace)
-        return path
-
     def _run_skuba(self, cmd, cwd=None, verbosity=None, ignore_errors=False):
         """Running skuba command in cwd.
         The cwd defautls to {workspace}/test-cluster but can be overrided

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -3,6 +3,7 @@ import os
 import time
 
 import platforms
+from checks import Checker
 from utils.format import Format
 from utils.utils import (step, Utils)
 
@@ -18,6 +19,7 @@ class Skuba:
         self.platform = platforms.get_platform(conf, platform)
         self.cwd = "{}/test-cluster".format(self.conf.workspace)
         self.utils.setup_ssh()
+        self.checker = Checker(conf, platform)
 
     def _verify_skuba_bin_dependency(self):
         if not os.path.isfile(self.binpath):
@@ -54,7 +56,7 @@ class Skuba:
         self.cluster_bootstrap(kubernetes_version=kubernetes_version,
                                cloud_provider=cloud_provider,
                                timeout=timeout)
-        self.join_nodes()
+        self.join_nodes(timeout=timeout)
 
 
     @step
@@ -95,12 +97,11 @@ class Skuba:
                f'{master0_ip} {master0_name}')
         self._run_skuba(cmd)
 
-        if timeout:
-            self._wait_master_ready(0, timeout=timeout)
+        self.checker.check_node("master", 0, timeout=timeout)
 
 
     @step
-    def node_join(self, role="worker", nr=0):
+    def node_join(self, role="worker", nr=0, timeout=None):
         self._verify_bootstrap_dependency()
 
         ip_addrs = self.platform.get_nodes_ipaddrs(role)
@@ -110,95 +111,30 @@ class Skuba:
             raise ValueError("Node number cannot be negative")
 
         if nr >= len(ip_addrs):
-            raise Exception(Format.alert("Node {role}-{nr} is not deployed in "
-                                         "infrastructure".format(role=role, nr=nr)))
+            raise Exception(f'Node {role}-{nr} is not deployed in '
+                            'infrastructure')
 
         cmd = (f'node join --role {role} --user {self.conf.terraform.nodeuser} '
                f' --sudo --target {ip_addrs[nr]} {node_names[nr]}')
         try:
             self._run_skuba(cmd)
         except Exception as ex:
-            raise Exception("Error executing cmd {}") from ex
+            raise Exception(f'Error joining node {role}-{nr}') from ex
 
+        self.checker.check_node(role, nr, timeout=timeout)
 
-    def join_nodes(self, masters=None, workers=None, timeout=180):
+    def join_nodes(self, masters=None, workers=None, timeout=None):
         if masters is None:
             masters = self.platform.get_num_nodes("master")
         if workers is None:
             workers = self.platform.get_num_nodes("worker")
 
         for node in range(1, masters):
-            self.node_join("master", node)
-            self._wait_master_ready(node, timeout=timeout)
+            self.node_join("master", node, timeout=timeout)
 
         for node in range(0, workers):
-            self.node_join("worker", node)
+            self.node_join("worker", node, timeout=timeout)
 
-
-    def _wait_master_ready(self, node, timeout=180, backoff=20):
-        start = int(time.time())
-        self._wait_etcd_ready(node, timeout=timeout, backoff=backoff)
-        remaining = timeout-(int(time.time())-start)
-        self._wait_apiserver_ready(node, timeout=remaining, backoff=backoff)
-
-
-    def _wait_node_joined(self, role, node, timeout=60, backoff=10):
-        node_name = self.platform.get_nodes_names(role)[node]
-        deadline = int(time.time()) + timeout
-        while True:
-            last_error = None
-            try:
-                status = self.cluster_status()
-                if status.find(node_name) > -1:
-                    return
-            except Exception as ex:
-                last_error = ex
-
-            if int(time.time()) >= deadline:
-                raise Exception((f'Node {node_name} not shown ready after {timeout} seconds'
-                                 f'{". Last error:"+str(last_error) if last_error else ""}'))
-            time.sleep(backoff)
-
-
-    def _wait_apiserver_ready(self, node, timeout=60, backoff=10):
-        apiserver_healthz = 'curl -Ls --insecure https://localhost:6443/healthz'
-
-        try:
-            self._wait_condition("master", node, apiserver_healthz, 'ok', timeout=timeout, backoff=backoff)
-        except AssertionError as ex:
-            node_name = self.platform.get_nodes_names("master")[node]
-            raise Exception(f'Error waiting apiserver at {node_name} to become ready') from ex
-
-
-    def _wait_etcd_ready(self, node, timeout=60, backoff=10):
-        etcd_health_check = ('sudo curl -Ls --cacert /etc/kubernetes/pki/etcd/ca.crt '
-                             '--key /etc/kubernetes/pki/etcd/server.key '
-                             '--cert /etc/kubernetes/pki/etcd/server.crt '
-                             'https://localhost:2379/health')
-
-        try:
-           self._wait_condition("master", node, etcd_health_check, 'true', timeout=timeout, backoff=backoff)
-        except AssertionError as ex:
-            node_name = self.platform.get_nodes_names("master")[node]
-            raise Exception(f'Error waiting etcd at {node_name} to become ready') from ex
-
-
-    def _wait_condition(self, role, node, command, condition, timeout=60, backoff=10):
-
-        deadline = int(time.time()) + timeout
-        while True:
-            last_error = None
-            try:
-                result = self.platform.ssh_run(role, node, command)
-                if result.find(condition) > -1:
-                    return
-            except Exception as ex:
-                last_error = ex
-
-            if int(time.time()) >= deadline:
-                raise AssertionError((f'condition not satisfied after {timeout} seconds'
-                                      f'{". Last error:"+str(last_error) if last_error else ""}'))
-            time.sleep(backoff)
 
     @step
     def node_remove(self, role="worker", nr=0):

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -91,7 +91,7 @@ def node_upgrade(options):
 
 def node_check(options):
     Checker(options.conf, options.platform).check_node(
-        role=options.role, node=options.node)
+        checks=options.checks, role=options.role, node=options.node)
 
 def test(options):
     test_driver = TestDriver(options.conf, options.platform)
@@ -200,6 +200,8 @@ def main():
 
     cmd_check_node = commands.add_parser("check-node", parents=[node_args],
                                           help="check node health")
+    cmd_check_node.add_argument("-c", "--check", dest="checks", nargs='+',
+                                help="check to be executed (multiple checks can be specified")
     cmd_check_node.set_defaults(func=node_check)
 
     # Start Join Nodes

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -14,6 +14,7 @@ from skuba import Skuba
 from kubectl import Kubectl
 from tests import TestDriver
 from utils import BaseConfig, Logger, Utils
+from checks import Checker
 
 __version__ = "0.0.3"
 
@@ -80,16 +81,17 @@ def join_nodes(options):
         timeout=options.timeout
     )
 
-
 def remove_node(options):
     Skuba(options.conf, options.platform).node_remove(
         role=options.role, nr=options.node)
-
 
 def node_upgrade(options):
     Skuba(options.conf, options.platform).node_upgrade(
         action=options.upgrade_action, role=options.role, nr=options.node)
 
+def node_check(options):
+    Checker(options.conf, options.platform).check_node(
+        role=options.role, node=options.node)
 
 def test(options):
     test_driver = TestDriver(options.conf, options.platform)
@@ -195,6 +197,10 @@ def main():
     cmd_node_upgrade.add_argument("-a", "--action", dest="upgrade_action",
                                   help="action: plan or apply upgrade", choices=["plan", "apply"])
     cmd_node_upgrade.set_defaults(func=node_upgrade)
+
+    cmd_check_node = commands.add_parser("check-node", parents=[node_args],
+                                          help="check node health")
+    cmd_check_node.set_defaults(func=node_check)
 
     # Start Join Nodes
     cmd_join_nodes = commands.add_parser("join-nodes",

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -91,7 +91,8 @@ def node_upgrade(options):
 
 def node_check(options):
     Checker(options.conf, options.platform).check_node(
-        checks=options.checks, role=options.role, node=options.node)
+         role=options.role, node=options.node,
+         checks=options.checks, stage=options.stage)
 
 def test(options):
     test_driver = TestDriver(options.conf, options.platform)
@@ -202,6 +203,8 @@ def main():
                                           help="check node health")
     cmd_check_node.add_argument("-c", "--check", dest="checks", nargs='+',
                                 help="check to be executed (multiple checks can be specified")
+    cmd_check_node.add_argument("-s", "--stage", dest="stage", 
+                                help="only execute checks that apply to this stage")
     cmd_check_node.set_defaults(func=node_check)
 
     # Start Join Nodes

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -69,7 +69,7 @@ def get_logs(options):
 
 def join_node(options):
     Skuba(options.conf, options.platform).node_join(
-        role=options.role, nr=options.node)
+        role=options.role, nr=options.node, timeout=options.timeout)
 
 
 def join_nodes(options):
@@ -178,9 +178,12 @@ def main():
                            help='role of the node to be added or deleted. eg: --role master')
     node_args.add_argument("-n", "--node", dest="node", type=int,
                            help='node to be added or deleted.  eg: -n 0')
+   # End of common parameters
 
     cmd_join_node = commands.add_parser("join-node", parents=[node_args],
                                         help="add node in k8s cluster with the given role.")
+    cmd_join_node.add_argument("-t", "--timeout", type=int, default=180,
+                                help="timeout for waiting the node to become ready (seconds)")
     cmd_join_node.set_defaults(func=join_node)
 
     cmd_rem_node = commands.add_parser("remove-node", parents=[node_args],

--- a/ci/infra/testrunner/tests/test_nginx_deployment.py
+++ b/ci/infra/testrunner/tests/test_nginx_deployment.py
@@ -3,8 +3,8 @@ import requests
 
 
 @pytest.mark.pr
-def test_nginx_deployment(deployment, kubectl):
-    workers = kubectl.skuba.num_of_nodes("worker")
+def test_nginx_deployment(deployment, platform, skuba, kubectl):
+    workers = skuba.num_of_nodes("worker")
     kubectl.run_kubectl("create deployment nginx --image=nginx:stable-alpine")
     kubectl.run_kubectl("scale deployment nginx --replicas={replicas}".format(replicas=workers))
     kubectl.run_kubectl("expose deployment nginx --port=80 --type=NodePort")
@@ -16,7 +16,7 @@ def test_nginx_deployment(deployment, kubectl):
     nodePort = kubectl.run_kubectl("get service/nginx -o jsonpath='{ .spec.ports[0].nodePort }'")
 
     wrk_idx = 0
-    ip_addresses = kubectl.skuba.platform.get_nodes_ipaddrs("worker")
+    ip_addresses = platform.get_nodes_ipaddrs("worker")
 
     url = "{protocol}://{ip}:{port}{path}".format(protocol="http", ip=str(ip_addresses[wrk_idx]), port=str(nodePort), path="/")
     r = requests.get(url)

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -29,6 +29,7 @@ class BaseConfig:
         obj.test = BaseConfig.Test()
         obj.log = BaseConfig.Log()
         obj.packages = BaseConfig.Packages()
+        obj.kubectl = BaseConfig.Kubectl()
 
         config_classes = (
             BaseConfig.Packages,
@@ -38,6 +39,7 @@ class BaseConfig:
             BaseConfig.Openstack,
             BaseConfig.Terraform,
             BaseConfig.Skuba,
+            BaseConfig.Kubectl,
             BaseConfig.VMware,
             BaseConfig.Libvirt
         )
@@ -86,6 +88,12 @@ class BaseConfig:
             self.binpath = None
             self.srcpath = None
             self.verbosity = 5
+
+    class Kubectl:
+        def __init__(self):
+            super().__init__()
+            self.binpath = "/usr/bin/kubectl"
+            self.kubeconfig = None
 
     class Test:
         def __init__(self):
@@ -167,6 +175,9 @@ class BaseConfig:
 
         if not conf.skuba.srcpath:
             conf.skuba.srcpath = os.path.realpath(os.path.join(conf.workspace, "skuba"))
+
+        if not conf.kubectl.kubeconfig:
+            conf.kubectl.kubeconfig =  os.path.realpath(os.path.join(conf.workspace, "test-cluster", "admin.conf"))
 
         if not conf.terraform.tfdir:
             conf.terraform.tfdir = os.path.join(conf.skuba.srcpath, "ci/infra/")

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -8,6 +8,10 @@ skuba:
   srcpath: "" # path to skuba source
   verbosity: 10  # default value passed to skuba with -v
 
+#Kubectl setup
+#kubectl:
+#  path: #path to kubectl binary (defaults to /usr/bin/kubectl)
+
 # platform settings
 terraform:
   internal_net: "" # name of the internal network


### PR DESCRIPTION
## Why is this PR needed?

Existing code for checking cluster sanity is mixed with logic for deploying the cluster (bootstrap, node join). The resulting code is complex and adding additional checks results hard.  Also results impossible to check a node once the corresponding function is executed (for example, once a node joins the cluster).

Fixes https://github.com/SUSE/avant-garde/issues/1462

## What does this PR do?

Move the checks into a separate module and re-factors the check codes using decorator that executes most of the boilerplate logic, facilitating the development of check functions. Check functions can be associated with a node role.

Implements a check-node command in the testrunner for checking a node.  

TODO:
- [x] Select checks depending on a node stage (provisioned, joined)
- [x] Order checks to prevent checks to be executed if a requisite check fails
- [x] rebase once #1025 is merged

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
