### PR TITLE
Migrate to individual container details

### DIFF
--- a/internal/pkg/skuba/kubeadm/images.go
+++ b/internal/pkg/skuba/kubeadm/images.go
@@ -27,7 +27,7 @@ import (
 
 func setContainerImagesWithClusterVersion(initConfiguration *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
 	initConfiguration.ImageRepository = skuba.ImageRepository
-	initConfiguration.KubernetesVersion = kubernetes.ComponentVersionForClusterVersion(kubernetes.Hyperkube, clusterVersion)
+	initConfiguration.KubernetesVersion = kubernetes.ComponentVersionForClusterVersion(kubernetes.APIServer, clusterVersion)
 	initConfiguration.Etcd.Local = &kubeadmapi.LocalEtcd{
 		ImageMeta: kubeadmapi.ImageMeta{
 			ImageRepository: skuba.ImageRepository,

--- a/internal/pkg/skuba/kubernetes/node_version.go
+++ b/internal/pkg/skuba/kubernetes/node_version.go
@@ -64,9 +64,9 @@ func (si StaticVersionInquirer) NodeVersionInfoForClusterVersion(node *v1.Node, 
 		KubeletVersion:          version.MustParseSemantic(ComponentVersionForClusterVersion(Kubelet, clusterVersion)),
 	}
 	if IsControlPlane(node) {
-		res.APIServerVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(Hyperkube, clusterVersion))
-		res.ControllerManagerVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(Hyperkube, clusterVersion))
-		res.SchedulerVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(Hyperkube, clusterVersion))
+		res.APIServerVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(APIServer, clusterVersion))
+		res.ControllerManagerVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(ControllerManager, clusterVersion))
+		res.SchedulerVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(Scheduler, clusterVersion))
 		res.EtcdVersion = version.MustParseSemantic(ComponentVersionForClusterVersion(Etcd, clusterVersion))
 	}
 	return res

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -42,10 +42,14 @@ const (
 	Kubelet          Component = "kubelet"
 	ContainerRuntime Component = "cri-o"
 
-	Hyperkube Component = "hyperkube"
-	Etcd      Component = "etcd"
-	CoreDNS   Component = "coredns"
-	Pause     Component = "pause"
+	APIServer         Component = "apiserver"
+	ControllerManager Component = "controllermanager"
+	Scheduler         Component = "scheduler"
+	Proxy             Component = "proxy"
+	Hyperkube         Component = "hyperkube"
+	Etcd              Component = "etcd"
+	CoreDNS           Component = "coredns"
+	Pause             Component = "pause"
 
 	Tooling Component = "tooling"
 )
@@ -81,17 +85,44 @@ type ClusterAddonsKnownVersions = func(clusterVersion *version.Version) AddonsVe
 
 var (
 	supportedVersions = KubernetesVersions{
+		"1.18.0": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.18.0",
+				ContainerRuntimeVersion: "1.17.0",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				APIServer:         &ContainerImageTag{Name: "api-server", Tag: "v1.18.0"},
+				ControllerManager: &ContainerImageTag{Name: "controller-manager", Tag: "v1.18.0"},
+				Scheduler:         &ContainerImageTag{Name: "scheduler", Tag: "v1.18.0"},
+				Proxy:             &ContainerImageTag{Name: "proxy", Tag: "v1.18.0"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.2"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.5.3", 2},
+				Kured:         &AddonVersion{"1.3.0", 4},
+				Dex:           &AddonVersion{"2.23.0", 6},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
+				MetricsServer: &AddonVersion{"0.3.6", 0},
+				PSP:           &AddonVersion{"", 2},
+			},
+		},
 		"1.17.4": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.17.4",
 				ContainerRuntimeVersion: "1.17.0",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
-				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
-				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
-				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
-				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.5.3", 2},
@@ -108,11 +139,14 @@ var (
 				ContainerRuntimeVersion: "1.16.1",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
-				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},
-				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.3.15"},
-				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.6.2"},
-				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
-				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.16.2"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.3.15"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.2"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.5.3", 2},
@@ -129,11 +163,14 @@ var (
 				ContainerRuntimeVersion: "1.15.2",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
-				Hyperkube: &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.2"},
-				Etcd:      &ContainerImageTag{Name: "etcd", Tag: "3.3.11"},
-				CoreDNS:   &ContainerImageTag{Name: "coredns", Tag: "1.3.1"},
-				Pause:     &ContainerImageTag{Name: "pause", Tag: "3.1"},
-				Tooling:   &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.2"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.2"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.2"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.15.2"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.3.11"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.3.1"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:  &AddonVersion{"1.5.3", 2},
@@ -166,17 +203,8 @@ func ComponentVersionForClusterVersion(component Component, clusterVersion *vers
 	return ComponentVersionWithAvailableVersions(component, clusterVersion, supportedVersions)
 }
 
-func ComponentContainerImageWithAvailableVersions(component Component, clusterVersion *version.Version, availableVersions KubernetesVersions) string {
-	currentKubernetesVersion := availableVersions[clusterVersion.String()]
-	if componentVersion, found := currentKubernetesVersion.ComponentContainerVersion[component]; found {
-		return images.GetGenericImage(skuba.ImageRepository, componentVersion.Name, componentVersion.Tag)
-	}
-	klog.Errorf("unknown component %q container image", component)
-	return ""
-}
-
-func AllComponentContainerImagesWithAvailableVersions(clusterVersion *version.Version, availableVersions KubernetesVersions) []Component {
-	currentKubernetesVersion := availableVersions[clusterVersion.String()]
+func AllComponentContainerImagesForClusterVersion(clusterVersion *version.Version) []Component {
+	currentKubernetesVersion := supportedVersions[clusterVersion.String()]
 
 	components := make([]Component, 0)
 	for component := range currentKubernetesVersion.ComponentContainerVersion {
@@ -185,24 +213,21 @@ func AllComponentContainerImagesWithAvailableVersions(clusterVersion *version.Ve
 	return components
 }
 
-func AllComponentContainerImagesForClusterVersion(clusterVersion *version.Version) []Component {
-	return AllComponentContainerImagesWithAvailableVersions(clusterVersion, supportedVersions)
-}
-
 func ComponentContainerImageForClusterVersion(component Component, clusterVersion *version.Version) string {
-	return ComponentContainerImageWithAvailableVersions(component, clusterVersion, supportedVersions)
+	currentKubernetesVersion := supportedVersions[clusterVersion.String()]
+	if componentDetails, found := currentKubernetesVersion.ComponentContainerVersion[component]; found {
+		return images.GetGenericImage(skuba.ImageRepository, componentDetails.Name, componentDetails.Tag)
+	}
+	klog.Errorf("unknown component %q container image", component)
+	return ""
 }
 
-func AddonVersionWithAvailableVersions(addon Addon, clusterVersion *version.Version, availableVersions KubernetesVersions) *AddonVersion {
-	currentKubernetesVersion := availableVersions[clusterVersion.String()]
+func AddonVersionForClusterVersion(addon Addon, clusterVersion *version.Version) *AddonVersion {
+	currentKubernetesVersion := supportedVersions[clusterVersion.String()]
 	if addonVersion, found := currentKubernetesVersion.AddonsVersion[addon]; found {
 		return addonVersion
 	}
 	return nil
-}
-
-func AddonVersionForClusterVersion(addon Addon, clusterVersion *version.Version) *AddonVersion {
-	return AddonVersionWithAvailableVersions(addon, clusterVersion, supportedVersions)
 }
 
 func AllAddonVersionsForClusterVersion(clusterVersion *version.Version) AddonsVersion {

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -65,7 +65,7 @@ func getComponentTestData(component Component, version *version.Version, info *K
 	case ContainerRuntime:
 		name = fmt.Sprintf("get %s version when cluster version is %s", component, version)
 		expectVersion = info.ComponentHostVersion.ContainerRuntimeVersion
-	case Hyperkube, Etcd, CoreDNS, Pause, Tooling:
+	case APIServer, ControllerManager, Scheduler, Proxy, Etcd, CoreDNS, Pause, Tooling:
 		name = fmt.Sprintf("get %s image when cluster version is %s", component, version)
 		imageName = info.ComponentContainerVersion[component].Name
 		expectVersion = info.ComponentContainerVersion[component].Tag
@@ -159,7 +159,7 @@ func TestAllComponentContainerImagesForClusterVersion(t *testing.T) {
 			sort.Slice(actual, func(i int, j int) bool {
 				return actual[i] < actual[j]
 			})
-			expect := []Component{Hyperkube, Etcd, CoreDNS, Pause, Tooling}
+			expect := []Component{APIServer, Scheduler, ControllerManager, Proxy, Etcd, CoreDNS, Pause, Tooling}
 			sort.Slice(expect, func(i int, j int) bool {
 				return expect[i] < expect[j]
 			})

--- a/internal/pkg/skuba/upgrade/node/versions_test.go
+++ b/internal/pkg/skuba/upgrade/node/versions_test.go
@@ -47,9 +47,9 @@ func (ti TestVersionInquirer) NodeVersionInfoForClusterVersion(node *corev1.Node
 		KubeletVersion:          version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.Kubelet, clusterVersion, ti.AvailableVersions)),
 	}
 	if kubernetes.IsControlPlane(node) {
-		res.APIServerVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.Hyperkube, clusterVersion, ti.AvailableVersions))
-		res.ControllerManagerVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.Hyperkube, clusterVersion, ti.AvailableVersions))
-		res.SchedulerVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.Hyperkube, clusterVersion, ti.AvailableVersions))
+		res.APIServerVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.APIServer, clusterVersion, ti.AvailableVersions))
+		res.ControllerManagerVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.ControllerManager, clusterVersion, ti.AvailableVersions))
+		res.SchedulerVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.Scheduler, clusterVersion, ti.AvailableVersions))
 		res.EtcdVersion = version.MustParseSemantic(kubernetes.ComponentVersionWithAvailableVersions(kubernetes.Etcd, clusterVersion, ti.AvailableVersions))
 	}
 	return res
@@ -219,11 +219,14 @@ func versionInquirer(versions ...string) kubernetes.VersionInquirer {
 				ContainerRuntimeVersion: version,
 			},
 			ComponentContainerVersion: kubernetes.ComponentContainerVersion{
-				kubernetes.Hyperkube: &kubernetes.ContainerImageTag{Name: "hyperkube", Tag: fmt.Sprintf("v%s", version)},
-				kubernetes.Etcd:      &kubernetes.ContainerImageTag{Name: "etcd", Tag: "3.3.11"},
-				kubernetes.CoreDNS:   &kubernetes.ContainerImageTag{Name: "coredns", Tag: "1.2.6"},
-				kubernetes.Pause:     &kubernetes.ContainerImageTag{Name: "pause", Tag: "3.1"},
-				kubernetes.Tooling:   &kubernetes.ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+				kubernetes.APIServer:         &kubernetes.ContainerImageTag{Name: "hyperkube", Tag: fmt.Sprintf("v%s", version)},
+				kubernetes.ControllerManager: &kubernetes.ContainerImageTag{Name: "hyperkube", Tag: fmt.Sprintf("v%s", version)},
+				kubernetes.Scheduler:         &kubernetes.ContainerImageTag{Name: "hyperkube", Tag: fmt.Sprintf("v%s", version)},
+				kubernetes.Proxy:             &kubernetes.ContainerImageTag{Name: "hyperkube", Tag: fmt.Sprintf("v%s", version)},
+				kubernetes.Etcd:              &kubernetes.ContainerImageTag{Name: "etcd", Tag: "3.3.11"},
+				kubernetes.CoreDNS:           &kubernetes.ContainerImageTag{Name: "coredns", Tag: "1.2.6"},
+				kubernetes.Pause:             &kubernetes.ContainerImageTag{Name: "pause", Tag: "3.1"},
+				kubernetes.Tooling:           &kubernetes.ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: kubernetes.AddonsVersion{
 				kubernetes.Cilium: &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 0},


### PR DESCRIPTION
## Why is this PR needed?

Fixes https://github.com/SUSE/avant-garde/issues/1459

## What does this PR do?

We remove hyperkube, so we need to get rid of that cruft.

## Anything else a reviewer needs to know?

Nope.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

Just ensure that `skuba cluster images` has the same output as usual.

### Related info

Info that can be relevant for QA:
* This is a requirement for 1.18
* https://github.com/SUSE/skuba/pull/1024 is a requirement for this.


### Status **BEFORE** applying the patch

We cannot split hyperkube into different images


### Status **AFTER** applying the patch

We can provision 1.18 with different images.

## Docs

As we don't explicitly list the images to mirror, there shouldn't be an update to do.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
