### PR TITLE
Improve test failure reporting

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -500,6 +500,9 @@ optional arguments:
                         when you have already bootstrapped the cluster.
                         'deployed' For when you already have a fully deployed
                         cluster.
+  --traceback {long,short,line,no}
+                        level of detail in traceback for test failure
+
 ```
 
 

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -229,11 +229,15 @@ def main():
         Logger.config_logger(conf, level=options.log_level)
         options.conf = conf
         options.func(options)
+    except SystemExit as ex:
+       if ex.code > 0:
+          logger.error(f'Command {options.command} ended with error code {ex.code}')
+          sys.exit(ex.code)
     except Exception as ex:
-        logger.error("Exception executing testrunner command '{}': {}".format(
-            options.command, ex), exc_info=True)
+        logger.error(f'Exception {ex} executing command {options.command}', exc_info=True)
         sys.exit(255)
 
+    sys.exit(0)
 
 if __name__ == '__main__':
     main()

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -92,7 +92,7 @@ def test(options):
     test_driver = TestDriver(options.conf, options.platform)
     test_driver.run(module=options.module, test_suite=options.test_suite, test=options.test,
                     verbose=options.verbose, collect=options.collect, skip_setup=options.skip_setup,
-                    mark=options.mark, junit=options.junit)
+                    mark=options.mark, traceback=options.traceback, junit=options.junit)
 
 
 def ssh(options):
@@ -215,6 +215,8 @@ def main():
                                 "'provisioned' For when you have already provisioned the nodes.\n"
                                 "'bootstrapped' For when you have already bootstrapped the cluster.\n"
                                 "'deployed' For when you already have a fully deployed cluster.")
+    test_args.add_argument("--traceback", default="short", choices=['long', 'short', 'line', 'no'],
+                           help="level of detail in traceback for test failure")
     cmd_test = commands.add_parser(
         "test", parents=[test_args], help="execute tests")
     cmd_test.set_defaults(func=test)

--- a/ci/infra/testrunner/tests/driver.py
+++ b/ci/infra/testrunner/tests/driver.py
@@ -14,17 +14,6 @@ PYTEST_RC = {
     5: "no tests were collected"
 }
 
-
-class PyTestOpts:
-
-    NO_CAPTURE_LOGS = "--show-capture=no"
-
-    SHOW_OUTPUT = "-s"
-
-    VERBOSE = "-v"
-
-    COLLECT_TESTS = "--collect-only"
-
 class TestDriver:
     def __init__(self, conf, platform):
         self.conf = conf
@@ -32,7 +21,7 @@ class TestDriver:
 
     def run(self, module=None, test_suite=None,
             test=None, verbose=False, collect=False,
-            skip_setup=None, mark=None, junit=None):
+            skip_setup=None, mark=None, junit=None, traceback="short"):
         opts = []
 
         vars_opt = "--vars={}".format(self.conf.yaml_path)
@@ -42,16 +31,16 @@ class TestDriver:
         opts.append(platform_opt)
 
         if verbose:
-            opts.append(PyTestOpts.SHOW_OUTPUT)
+            opts.append("-s")
 
         # Dont capture logs
-        opts.append(PyTestOpts.NO_CAPTURE_LOGS)
+        opts.append("--show-capture=no")
 
         # generete detailed test results
-        opts.append(PyTestOpts.VERBOSE)
+        opts.append("-v")
 
         if collect:
-            opts.append(PyTestOpts.COLLECT_TESTS)
+            opts.append("--collect-only")
 
         if skip_setup is not None:
             opts.append(f"--skip-setup={skip_setup}")
@@ -61,6 +50,8 @@ class TestDriver:
 
         if mark is not None:
             opts.append(f'-m {mark}')
+
+        opts.append(f'--tb={traceback}')
 
         test_path = module if module is not None else "tests"
 

--- a/ci/infra/testrunner/tests/driver.py
+++ b/ci/infra/testrunner/tests/driver.py
@@ -5,6 +5,15 @@ import pytest
 FILEPATH = os.path.realpath(__file__)
 TESTRUNNER_DIR = os.path.dirname(os.path.dirname(FILEPATH))
 
+PYTEST_RC = {
+    0: "all tests passed successfully",
+    1: "some of the tests failed",
+    2: "execution was interrupted by the user",
+    3: "internal error happened while executing tests",
+    4: "pytest command line usage error",
+    5: "no tests were collected"
+}
+
 
 class PyTestOpts:
 
@@ -15,7 +24,6 @@ class PyTestOpts:
     VERBOSE = "-v"
 
     COLLECT_TESTS = "--collect-only"
-
 
 class TestDriver:
     def __init__(self, conf, platform):
@@ -74,5 +82,10 @@ class TestDriver:
 
         result = pytest.main(args=opts)
 
-        if not junit and result > 0:
-            raise AssertionError("Running {} failed.\nExit Code: {}".format(test_path, result))
+        if result in [0, 1]:
+            raise SystemExit(result)
+
+        if result in [2, 3, 4, 5]:
+            raise Exception(f'error executing test {PYTEST_RC[result]}')
+
+        raise Exception(f'unexpected return code from pytest {result}')


### PR DESCRIPTION
## Why is this PR needed?

Presently, reports from test failure are hard to interpret for several reasons:
1.  Even if e2e tests fail, but the stage is marked as success in the jenkins interface. 
2. The failed tests generate a verbose traceback that makes hard to identify the source of the failure

Fixes https://github.com/SUSE/avant-garde/issues/1454

## What does this PR do?

Captures the return code from pytest in the testrunner's TestDriver and reports it as a normal termination or an exception depending on its severity. Also, changes testrunner for reporting exit codes from commands, reported as SystemExit exceptions. 

Finally, this PR also introduces a new option to the testrunner for setting the detail level of tracebak for test failures.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
