### PR TITLE
Do not automatically classify stderr as err


### DIFF
--- a/internal/pkg/skuba/deployments/ssh/ssh.go
+++ b/internal/pkg/skuba/deployments/ssh/ssh.go
@@ -189,10 +189,8 @@ func readerStreamer(reader io.Reader, outputChan chan<- string, description stri
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		result.Write([]byte(scanner.Text()))
-		if description == "stdout" && !silent {
+		if (description == "stdout" && !silent) || description == "stderr" {
 			klog.V(2).Infof("%s", scanner.Text())
-		} else if description == "stderr" {
-			klog.Errorf("%s", scanner.Text())
 		}
 	}
 	outputChan <- result.String()


### PR DESCRIPTION


Currently, all the stream of stderr data is considered as
an error. Some of the info sent to stderr is an information
for a skuba user, some warnings, some real errors.

This  is a problem, as it confuses the crap out of the deployers.
See also [1].

This fixes it by removing the automatic stderr is a klog.Errorf.
Instead, errors are dealt with in each of the modules consuming ssh, and
further debugging can be added it. The SSH function is therefore cleaner.

[1]: http://mailman.suse.de/mlarch/SuSE/caasp-internal/2020/caasp-internal.2020.03/msg00125.html

