### PR TITLE
Delete pods before trying to upgrade the crio package

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -29,6 +29,8 @@ import (
 func init() {
 	stateMap["cri.configure"] = criConfigure
 	stateMap["cri.start"] = criStart
+	stateMap["cri.stop"] = criStop
+	stateMap["cri.wipe-pods"] = criWipePods
 }
 
 func criConfigure(t *Target, data interface{}) error {
@@ -60,5 +62,15 @@ func criConfigure(t *Target, data interface{}) error {
 
 func criStart(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "enable", "--now", "crio")
+	return err
+}
+
+func criStop(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "stop", "crio")
+	return err
+}
+
+func criWipePods(t *Target, data interface{}) error {
+	_, _, err := t.ssh("crictl", "rmp", "-fa")
 	return err
 }

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -40,7 +40,8 @@ func init() {
 	stateMap["kubernetes.bootstrap.upload-secrets"] = kubernetesUploadSecrets(KubernetesUploadSecretsContinueOnError)
 	stateMap["kubernetes.join.upload-secrets"] = kubernetesUploadSecrets(KubernetesUploadSecretsFailOnError)
 	stateMap["kubernetes.install-node-pattern"] = kubernetesInstallNodePattern
-	stateMap["kubernetes.restart-services"] = kubernetesRestartServices
+	stateMap["kubernetes.start-kubelet"] = kubernetesStartKubelet
+	stateMap["kubernetes.stop-kubelet"] = kubernetesStopKubelet
 }
 
 func kubernetesUploadSecrets(errorHandling KubernetesUploadSecretsErrorBehavior) Runner {
@@ -77,7 +78,12 @@ func kubernetesInstallNodePattern(t *Target, data interface{}) error {
 	return err
 }
 
-func kubernetesRestartServices(t *Target, data interface{}) error {
-	_, _, err := t.ssh("systemctl", "restart", "crio", "kubelet")
+func kubernetesStartKubelet(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "enable", "--now", "kubelet")
+	return err
+}
+
+func kubernetesStopKubelet(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "stop", "kubelet")
 	return err
 }

--- a/internal/pkg/skuba/kubernetes/retry/retry.go
+++ b/internal/pkg/skuba/kubernetes/retry/retry.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package retry
+
+import "k8s.io/apimachinery/pkg/util/wait"
+
+// OnAnyError retries the fn function with backoff strategy in the
+// light of any error
+func OnAnyError(backoff wait.Backoff, fn func() error) error {
+	return OnError(
+		backoff,
+		func(error) bool {
+			return true
+		},
+		fn,
+	)
+}
+
+// OnError executes the provided function repeatedly, retrying if the server returns a specified
+// error. Callers should preserve previous executions if they wish to retry changes. It performs an
+// exponential backoff.
+//
+//     var pod *api.Pod
+//     err := retry.OnError(DefaultBackoff, errors.IsConflict, func() (err error) {
+//       pod, err = c.Pods("mynamespace").UpdateStatus(podStatus)
+//       return
+//     })
+//     if err != nil {
+//       // may be conflict if max retries were hit
+//       return err
+//     }
+//     ...
+//
+// Extracted from k8s.io/kubernetes/staging/src/k8s.io/client-go/util/retry package,
+// available in 1.16.0 or newer.
+func OnError(backoff wait.Backoff, errorFunc func(error) bool, fn func() error) error {
+	var lastConflictErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case errorFunc(err):
+			lastConflictErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastConflictErr
+	}
+	return err
+}


### PR DESCRIPTION
Make sure we delete all existing pods in the target node before we try
to upgrade the crio and kubelet packages.

As a result of this, we also need to make sure that whatever comes
after that requires the API Server to be up appropriately retries the
request until it succeeds or timeouts.

## Why is this PR needed?

Fixes: https://github.com/SUSE/avant-garde/issues/1451

**This will need a backport to the 4.2 branch**

/cc @saschagrunert 