### PR TITLE
Fix upgrade tests

### DIFF
--- a/ci/infra/testrunner/tests/test_upgrade_apply_all_fine.py
+++ b/ci/infra/testrunner/tests/test_upgrade_apply_all_fine.py
@@ -4,12 +4,12 @@ from tests.utils import setup_kubernetes_version
 
 
 @pytest.mark.disruptive
-def test_upgrade_apply_all_fine(setup, platform, skuba, kubectl):
+def test_upgrade_apply_all_fine(provision, platform, skuba, kubectl):
     """
     Starting from a up-to-date cluster, check what node upgrade apply reports.
     """
 
-    setup_kubernetes_version(platform, skuba, kubectl)
+    setup_kubernetes_version(skuba, kubectl)
 
     # node upgrade apply
     masters = platform.get_num_nodes("master")

--- a/ci/infra/testrunner/tests/test_upgrade_apply_from_previous.py
+++ b/ci/infra/testrunner/tests/test_upgrade_apply_from_previous.py
@@ -4,12 +4,12 @@ from tests.utils import PREVIOUS_VERSION, setup_kubernetes_version, node_is_read
 
 
 @pytest.mark.disruptive
-def test_upgrade_apply_from_previous(setup, platform, skuba, kubectl):
+def test_upgrade_apply_from_previous(provision, platform, skuba, kubectl):
     """
     Starting from an outdated cluster, check what node upgrade apply reports.
     """
 
-    setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
+    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     for role in ("master", "worker"):
         num_nodes = platform.get_num_nodes(role)

--- a/ci/infra/testrunner/tests/test_upgrade_apply_user_lock.py
+++ b/ci/infra/testrunner/tests/test_upgrade_apply_user_lock.py
@@ -4,12 +4,12 @@ from tests.utils import PREVIOUS_VERSION, setup_kubernetes_version, node_is_read
 
 
 @pytest.mark.disruptive
-def test_upgrade_apply_user_lock(setup, platform, kubectl, skuba):
+def test_upgrade_apply_user_lock(provision, platform, kubectl, skuba):
     """
     Starting from an outdated cluster, check what node upgrade apply reports.
     """
 
-    setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
+    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     # lock kured
     kubectl_cmd = (

--- a/ci/infra/testrunner/tests/test_upgrade_plan_all_fine.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_all_fine.py
@@ -4,12 +4,12 @@ from tests.utils import setup_kubernetes_version
 
 
 @pytest.mark.disruptive
-def test_upgrade_plan_all_fine(setup, skuba, kubectl, platform):
+def test_upgrade_plan_all_fine(provision, skuba, kubectl, platform):
     """
     Starting from a up-to-date cluster, check what cluster/node plan report.
     """
 
-    setup_kubernetes_version(platform, skuba, kubectl)
+    setup_kubernetes_version(skuba, kubectl)
     out = skuba.cluster_upgrade_plan()
 
     assert out.find(

--- a/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
@@ -4,12 +4,12 @@ from tests.utils import setup_kubernetes_version, PREVIOUS_VERSION, CURRENT_VERS
 
 
 @pytest.mark.disruptive
-def test_upgrade_plan_from_previous(setup, skuba, kubectl, platform):
+def test_upgrade_plan_from_previous(provision, skuba, kubectl, platform):
     """
     Starting from an outdated cluster, check what cluster/node plan report.
     """
 
-    setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
+    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     # cluster upgrade plan
     out = skuba.cluster_upgrade_plan()

--- a/ci/infra/testrunner/tests/test_upgrade_plan_from_previous_with_upgraded_control_plane.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_from_previous_with_upgraded_control_plane.py
@@ -4,12 +4,12 @@ from tests.utils import PREVIOUS_VERSION, CURRENT_VERSION, setup_kubernetes_vers
 
 
 @pytest.mark.disruptive
-def test_upgrade_plan_from_previous_with_upgraded_control_plane(setup, skuba, kubectl, platform):
+def test_upgrade_plan_from_previous_with_upgraded_control_plane(provision, skuba, kubectl, platform):
     """
     Starting from an updated control plane, check what cluster/node plan report.
     """
 
-    setup_kubernetes_version(platform, skuba, kubectl, PREVIOUS_VERSION)
+    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     masters = platform.get_num_nodes("master")
     for n in range(0, masters):


### PR DESCRIPTION
## Why is this PR needed?

Upgrade tests are failing due to a python error. Once this was fixed, the tests were failing due to a improper platform provisioning/teardown.

Fixes https://github.com/SUSE/avant-garde/issues/1433

## What does this PR do?

- Remove the extra parameter passed to the setup_kubernetes_version
- Replace the updated fixture "setup" used for provisioning the
cluster with the "provision" fixture.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
