### PR TITLE
Allow support for trustworthy JWTs in the API Server

### DIFF
--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -124,6 +124,7 @@ func RemoveAPIEndpointFromConfigMap(client clientset.Interface, node *corev1.Nod
 func UpdateClusterConfigurationWithClusterVersion(initCfg *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
 	setApiserverAdmissionPlugins(initCfg, clusterVersion)
 	setContainerImagesWithClusterVersion(initCfg, clusterVersion)
+	setApiserverArgs(initCfg)
 }
 
 func setApiserverAdmissionPlugins(initCfg *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
@@ -158,4 +159,9 @@ func setApiserverAdmissionPlugins(initCfg *kubeadmapi.InitConfiguration, cluster
 	admissionPlugins = append(admissionPlugins, "PodSecurityPolicy")
 	admissionPlugins = skubautil.UniqueStringSlice(admissionPlugins)
 	initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = strings.Join(admissionPlugins, ",")
+}
+
+func setApiserverArgs(initCfg *kubeadmapi.InitConfiguration) {
+	initCfg.APIServer.ExtraArgs["service-account-issuer"] = "kubernetes.default.svc"
+	initCfg.APIServer.ExtraArgs["service-account-signing-key-file"] = "/etc/kubernetes/pki/sa.key"
 }

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -215,11 +215,13 @@ func writeKubeadmInitConf(initConfiguration InitConfiguration) error {
 				CertSANs: []string{initConfiguration.ControlPlaneHost()},
 				ControlPlaneComponent: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: map[string]string{
-						"oidc-issuer-url":     fmt.Sprintf("https://%s:32000", initConfiguration.ControlPlaneHost()),
-						"oidc-client-id":      "oidc",
-						"oidc-ca-file":        "/etc/kubernetes/pki/ca.crt",
-						"oidc-username-claim": "email",
-						"oidc-groups-claim":   "groups",
+						"oidc-issuer-url":                  fmt.Sprintf("https://%s:32000", initConfiguration.ControlPlaneHost()),
+						"oidc-client-id":                   "oidc",
+						"oidc-ca-file":                     "/etc/kubernetes/pki/ca.crt",
+						"oidc-username-claim":              "email",
+						"oidc-groups-claim":                "groups",
+						"service-account-issuer":           "kubernetes.default.svc",
+						"service-account-signing-key-file": "/etc/kubernetes/pki/sa.key",
 					},
 				},
 			},


### PR DESCRIPTION
## Why is this PR needed?

Applications like Istio with enabled Secure Gateways / Secret Discovery
Service (SDS) rely on trustworthy JWT's. Those can be enabled by the API
Server flags `--service-account-issue` and
`--service-account-signing-key-file`.

To achieve that we now change the `kubeadm-init.conf` to enable those
flags per default.

## What does this PR do?

Enable the mentioned kube-apiserver flags.

## Anything else a reviewer needs to know?

Kubeflows internal Istio deployment relies on that for example.

## Info for QA

None

### Related info

None

### Status **BEFORE** applying the patch

Trustworthy JWTs are not enabled.

### Status **AFTER** applying the patch

Trustworthy JWTs work as expected.

## Docs

None, or do we have to document that somewhere?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
