### PR TITLE
Remove hostPorts from unprivileged psp

### DIFF
--- a/internal/pkg/skuba/addons/psp.go
+++ b/internal/pkg/skuba/addons/psp.go
@@ -300,9 +300,6 @@ spec:
   hostPID: false
   hostIPC: false
   hostNetwork: false
-  hostPorts:
-  - min: 0
-    max: 65535
   # SELinux
   seLinux:
     # SELinux is unused in CaaSP

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -106,7 +106,7 @@ var (
 				Dex:           &AddonVersion{"2.16.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 1},
-				PSP:           &AddonVersion{"", 3},
+				PSP:           &AddonVersion{"", 4},
 			},
 		},
 		"1.16.2": KubernetesVersion{


### PR DESCRIPTION
## Why is this PR needed?

`hostPorts` by definition require to use `hostNetwork` so having them allowed in the psp where  `hostNetwork` is forbidden is not correct and does not work.

This introduces no regression as this was not working before.

Signed-off-by: lcavajani <lcavajani@suse.com>


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
