### PR TITLE
Fix LB tf files

### DIFF
--- a/ci/infra/libvirt/output.tf
+++ b/ci/infra/libvirt/output.tf
@@ -1,5 +1,5 @@
 output "ip_load_balancer" {
-  value = var.create_lb ? "{ \"${libvirt_domain.lb.0.network_interface.0.hostname}\" = \"${libvirt_domain.lb.0.network_interface.0.addresses.0}\" }" : "not created"
+  value = var.create_lb ? zipmap(libvirt_domain.lb.*.network_interface.0.hostname, libvirt_domain.lb.*.network_interface.0.addresses.0) : {}
 }
 
 output "ip_masters" {

--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -22,6 +22,7 @@
         "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/"
     },
     "lb_repositories": {
+        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP1/",
         "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/",
         "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/",
         "ha_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/",


### PR DESCRIPTION
## Why is this PR needed?

Changes introduced in https://github.com/SUSE/skuba/pull/1020 made the provisioning process to fail due to a clound-init failure. Also, the output for the lb ip address had a wrong format.

Fixes https://github.com/SUSE/avant-garde/issues/1470

## What does this PR do?

- sets the lb ip address as a map instead of a string
- adds the suse certificate repository to the lb

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
