### PR TITLE
Use dynamic addresses in libvirt

### DIFF
--- a/ci/infra/libvirt/cloud-init/commands.tpl
+++ b/ci/infra/libvirt/cloud-init/commands.tpl
@@ -1,1 +1,4 @@
+# FIXME: wait to prevent race condition that makes zypper install to fail
+# retriving metadata from repositories
+  - sleep 30
   - [ zypper, -n, install, ${packages} ]

--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -42,7 +42,7 @@ data "template_file" "haproxy_apiserver_backends_master" {
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
-    ip   = cidrhost(var.network_cidr, 512 + count.index)
+    ip   = libvirt_domain.master[count.index].network_interface.0.addresses.0,
   }
 }
 
@@ -52,7 +52,7 @@ data "template_file" "haproxy_gangway_backends_master" {
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
-    ip   = cidrhost(var.network_cidr, 512 + count.index)
+    ip   = libvirt_domain.master[count.index].network_interface.0.addresses.0,
   }
 }
 
@@ -62,7 +62,7 @@ data "template_file" "haproxy_dex_backends_master" {
 
   vars = {
     fqdn = "${var.stack_name}-master-${count.index}.${var.dns_domain}"
-    ip   = cidrhost(var.network_cidr, 512 + count.index)
+    ip   = libvirt_domain.master[count.index].network_interface.0.addresses.0,
   }
 }
 
@@ -136,7 +136,6 @@ resource "libvirt_domain" "lb" {
   network_interface {
     network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-lb"
-    addresses      = [cidrhost(var.network_cidr, 256)]
     wait_for_lease = true
   }
 
@@ -153,7 +152,7 @@ resource "null_resource" "lb_wait_cloudinit" {
   connection {
     host = element(
       libvirt_domain.lb.*.network_interface.0.addresses.0,
-      count.index,
+      count.index
     )
     user     = var.username
     password = var.password
@@ -178,7 +177,7 @@ resource "null_resource" "lb_push_haproxy_cfg" {
   connection {
     host = element(
       libvirt_domain.lb.*.network_interface.0.addresses.0,
-      count.index,
+      count.index
     )
     user  = var.username
     type  = "ssh"

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -88,7 +88,6 @@ resource "libvirt_domain" "master" {
   network_interface {
     network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-master-${count.index}"
-    addresses      = [cidrhost(var.network_cidr, 512 + count.index)]
     wait_for_lease = true
   }
 
@@ -105,7 +104,7 @@ resource "null_resource" "master_wait_cloudinit" {
   connection {
     host = element(
       libvirt_domain.master.*.network_interface.0.addresses.0,
-      count.index,
+      count.index
     )
     user     = var.username
     password = var.password
@@ -128,7 +127,7 @@ resource "null_resource" "master_reboot" {
       user = var.username
       host = element(
         libvirt_domain.master.*.network_interface.0.addresses.0,
-        count.index,
+        count.index
       )
     }
 

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -88,7 +88,6 @@ resource "libvirt_domain" "worker" {
   network_interface {
     network_id     = libvirt_network.network.id
     hostname       = "${var.stack_name}-worker-${count.index}"
-    addresses      = [cidrhost(var.network_cidr, 768 + count.index)]
     wait_for_lease = true
   }
 
@@ -105,7 +104,7 @@ resource "null_resource" "worker_wait_cloudinit" {
   connection {
     host = element(
       libvirt_domain.worker.*.network_interface.0.addresses.0,
-      count.index,
+      count.index
     )
     user     = var.username
     password = var.password


### PR DESCRIPTION
## Why is this PR needed?

Existing terraform configuration for libvirt assigs fixed addresses to instances. This prevents multiple clusters to be deployed on the same network, as described in https://github.com/SUSE/avant-garde/issues/1297

## What does this PR do?

Modifies terraform files to use addresses dynamically assigned by the network using dhcp.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
