### PR TITLE
CI: Add checks to cluster deployment

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -37,6 +37,10 @@ join_nodes:
 deploy:
 	${TEST_RUNNER} --platform ${PLATFORM} deploy
 
+.PHONY: check_cluster
+check_cluster:
+	${TEST_RUNNER} --platform ${PLATFORM} check-cluster -s joined
+
 .PHONY: cleanup
 cleanup:
 	${TEST_RUNNER} --platform ${PLATFORM} cleanup

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -459,6 +459,18 @@ optional arguments:
                         timeout for waiting the master nodes to become ready (seconds)
 ```
 
+### Check cluster 
+
+Checks the status of the cluster. If no check is specified, all checks that apply to
+the stage are executed.
+
+```
+  -c CHECKS [CHECKS ...], --check CHECKS [CHECKS ...]
+                        check to be executed (multiple checks can be specified)
+  -s STAGE, -stage STAGE
+                        only execute checks that apply to this stage
+```
+
 ### Node commands
 
 Common parameters

--- a/ci/infra/testrunner/checks/checks.py
+++ b/ci/infra/testrunner/checks/checks.py
@@ -4,15 +4,25 @@ import platforms
 from kubectl import Kubectl
 from utils.utils import Utils
 
-_checks_by_role  = {}
-_checks_by_name  = {}
-_checks_by_stage = {}
 
-def check(description=None, roles=[], stages=[], check_timeout=300, check_backoff=20):
+class Check():
+    def __init__(self, name, description, func, scope, roles=[], stages=[]):
+        self.name = name
+        self.description = description
+        self.func = func
+        self.scope = scope
+        self.roles = roles
+        self.stages = stages
+
+_checks = []
+_checks_by_name = {}
+
+def check(description=None, scope=None, roles=[], stages=[], check_timeout=300, check_backoff=20):
     """Decorator for waiting a check to become true.
        Can receve the following arguments when invoking the check function
        description: used for reporting. if not defined, check
                     function name is used
+       scope: either "cluster" or "node"
        roles: list of node roles this check applies
        stages: list of deployment stages this check applies to (e.g provisioned, joined)
        check_timeout: the timeout for the check
@@ -46,17 +56,17 @@ def check(description=None, roles=[], stages=[], check_timeout=300, check_backof
 
                 time.sleep(backoff)
 
-        _checks_by_name[check.__name__] = wait_condition
+        if scope is None:
+            raise ValueError("scope must be defined: 'cluster' or 'node'")
 
-        for role in roles:
-           role_checks = _checks_by_role.get(role, [])
-           role_checks.append(wait_condition)
-           _checks_by_role[role] = role_checks
-
-        for stage in stages:
-           stage_checks = _checks_by_stage.get(stage, [])
-           stage_checks.append(wait_condition)
-           _checks_by_stage[stage] = stage_checks
+        _check = Check(check.__name__,
+                    description,
+                    wait_condition,
+                    scope,
+                    roles=roles,
+                    stages=stages)
+        _checks.append(_check)
+        _checks_by_name[_check.name] = _check
 
         return wait_condition
 
@@ -72,32 +82,65 @@ class Checker:
         self.platform = platform
 
 
+    def _filter_checks(self, checks, scope=None, stage=None):
+        _filtered = checks
+        if scope:
+            _filtered= [c for c in _filtered if scope == c.scope]
+        if stage:
+            _filtered= [c for c in _filtered if stage in c.stages]
+        return _filtered
+
+    def _filter_by_name(self, names):
+        checks = []
+        for name in names:
+            _check = _checks_by_name.get(name, None)
+            if _check is None:
+                raise ValueError("Check {name} not found")
+            checks.append(_check)
+
+        return checks
+
     def check_node(self, role, node, checks=None, stage=None, timeout=180, backoff=20):
         if checks:
-            check_names = checks
-            checks = []
-            for name in check_names:
-                checks.append(_checks_by_name[name])
+            checks = self._filter_by_name(checks)
+            for check in checks:
+                if check.scope != "node":
+                    raise Exception(f'check {check.name} is not a node check')
         else:
-            checks = _checks_by_role.get(role, [])
-            # filter by stage
-            if stage:
-               checks= [c for c in checks if c in _checks_by_stage.get(stage, [])]
+            if not stage:
+                raise ValueError("stage must be specified")
+            checks = self._filter_checks(_checks, stage=stage, scope="node")
 
         start   = int(time.time())
         for check in checks:
             remaining = timeout-(int(time.time())-start)
-            check(self.conf, self.platform, role, node, check_timeout=remaining, check_backoff=backoff)
+            check.func(self.conf, self.platform, role, node, check_timeout=remaining, check_backoff=backoff)
+
+    def check_cluster(self, checks=None, stage=None, timeout=180, backoff=20):
+        if checks:
+            checks = self._filter_by_name(checks)
+            for check in checks:
+                if check.scope != "cluster":
+                    raise Exception(f'check {check.name} is not a cluster check')
+        else:
+            if not stage:
+                raise ValueError("stage must be specified")
+            checks = self._filter_checks(_checks, stage=stage, scope="cluster")
+
+        start   = int(time.time())
+        for check in checks:
+            remaining = timeout-(int(time.time())-start)
+            check.func(self.conf, self.platform, check_timeout=remaining, check_backoff=backoff)
 
 
-@check(description="apiserver healthz check", roles=['master'])
+@check(description="apiserver healthz check", scope="node", roles=['master'])
 def check_apiserver_healthz(conf, platform, role, node):
      platform = platforms.get_platform(conf, platform)
      cmd =   'curl -Ls --insecure https://localhost:6443/healthz'
      output = platform.ssh_run(role, node, cmd)
      return output.find("ok") > -1
 
-@check(description="etcd health check", roles=['master'])
+@check(description="etcd health check", scope="node", roles=['master'])
 def check_etcd_health(conf, platform, role, node):
     platform = platforms.get_platform(conf, platform)
     cmd = ('sudo curl -Ls --cacert /etc/kubernetes/pki/etcd/ca.crt '
@@ -107,7 +150,7 @@ def check_etcd_health(conf, platform, role, node):
     output = platform.ssh_run(role, node, cmd)
     return output.find("true") > -1
 
-@check(description="check node is ready", roles = ["master", "worker"], stages=["joined"])
+@check(description="check node is ready", scope="node", roles=["master", "worker"], stages=["joined"])
 def check_node_ready(conf, platform, role, node):
     platform = platforms.get_platform(conf, platform)
     node_name = platform.get_nodes_names(role)[node]

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -97,7 +97,7 @@ class Skuba:
                f'{master0_ip} {master0_name}')
         self._run_skuba(cmd)
 
-        self.checker.check_node("master", 0, timeout=timeout)
+        self.checker.check_node("master", 0, stage="joined", timeout=timeout)
 
 
     @step
@@ -121,7 +121,7 @@ class Skuba:
         except Exception as ex:
             raise Exception(f'Error joining node {role}-{nr}') from ex
 
-        self.checker.check_node(role, nr, timeout=timeout)
+        self.checker.check_node(role, nr, stage="joined", timeout=timeout)
 
     def join_nodes(self, masters=None, workers=None, timeout=None):
         if masters is None:

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -94,6 +94,10 @@ def node_check(options):
          role=options.role, node=options.node,
          checks=options.checks, stage=options.stage)
 
+def cluster_check(options):
+    Checker(options.conf, options.platform).check_cluster(
+         checks=options.checks, stage=options.stage)
+
 def test(options):
     test_driver = TestDriver(options.conf, options.platform)
     test_driver.run(module=options.module, test_suite=options.test_suite, test=options.test,
@@ -203,7 +207,7 @@ def main():
                                           help="check node health")
     cmd_check_node.add_argument("-c", "--check", dest="checks", nargs='+',
                                 help="check to be executed (multiple checks can be specified")
-    cmd_check_node.add_argument("-s", "--stage", dest="stage", 
+    cmd_check_node.add_argument("-s", "--stage", dest="stage",
                                 help="only execute checks that apply to this stage")
     cmd_check_node.set_defaults(func=node_check)
 
@@ -249,6 +253,14 @@ def main():
     cmd_inhibit_kured = commands.add_parser("inhibit_kured",
                            help="Prevent kured to reboot nodes")
     cmd_inhibit_kured.set_defaults(func=inhibit_kured)
+
+    cmd_check_cluster = commands.add_parser("check-cluster",
+                                          help="check cluster health")
+    cmd_check_cluster.add_argument("-c", "--check", dest="checks", nargs='+',
+                                help="check to be executed (multiple checks can be specified")
+    cmd_check_cluster.add_argument("-s", "--stage", dest="stage",
+                                help="only execute checks that apply to this stage")
+    cmd_check_cluster.set_defaults(func=cluster_check)
 
     options = parser.parse_args()
     try:

--- a/ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
@@ -103,6 +103,7 @@ pipeline {
         stage('Deploy cluster') {
             steps {
                 sh(script: 'make -f skuba/ci/Makefile deploy', label: 'Deploy')
+                sh(script: 'make -f skuba/ci/Makefile check_cluster', label: 'Check cluster')
             }
         }
 

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -100,6 +100,7 @@ pipeline {
         stage('Deploy cluster') {
             steps {
                 sh(script: 'make -f skuba/ci/Makefile deploy', label: 'Deploy')
+                sh(script: 'make -f skuba/ci/Makefile check_cluster', label: 'Check cluster')
             }
         }
 

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
 
         stage('Deploy cluster') { steps {
             sh(script: 'make -f skuba/ci/Makefile deploy', label: 'Deploy')
+            sh(script: 'make -f skuba/ci/Makefile check_cluster', label: 'Check cluster')
         } }
 
         stage('Inhibit kured reboots') { steps {


### PR DESCRIPTION
## Why is this PR needed?

Developers need to be able to look at a failing test and figure out whether the test is failing or the problem is on the CI/infra side.

Fixes https://github.com/SUSE/avant-garde/issues/1478

## What this PR does

Adds the `check cluster` command to the testrunner along a cluster validation checks, and invokes it in the CI after cluster deployment.


## Note to reviewers

The deployment checks are added to the PR jobs. A follow-up PR will add it to the e2e tests, after refactoring the pipeline to use the deployment command.

## Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
