### PR TITLE
Fix PSP for kubelet disarm job, bsc#1138908

### DIFF
--- a/internal/pkg/skuba/addons/psp.go
+++ b/internal/pkg/skuba/addons/psp.go
@@ -119,6 +119,25 @@ subjects:
   name: kube-proxy
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-disarm
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:kube-disarm
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kube-disarm
+  namespace: kube-system
+---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -98,6 +98,7 @@ func disarmKubeletJobSpec(node *v1.Node, clusterVersion *version.Version) batchv
 	return batchv1.JobSpec{
 		Template: v1.PodTemplateSpec{
 			Spec: v1.PodSpec{
+				ServiceAccountName: "kube-disarm",
 				Containers: []v1.Container{
 					{
 						Name:  disarmKubeletJobName(node),

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -97,7 +97,7 @@ var (
 				Kured:   &AddonVersion{"1.3.0", 4},
 				Dex:     &AddonVersion{"2.16.0", 5},
 				Gangway: &AddonVersion{"3.1.0-rev4", 4},
-				PSP:     &AddonVersion{"", 2},
+				PSP:     &AddonVersion{"", 3},
 			},
 		},
 		"1.16.2": KubernetesVersion{


### PR DESCRIPTION
## Why is this PR needed?

This is a pick of PR https://github.com/SUSE/skuba/pull/1043 from the master branch to release-caasp-4.2.0.   This has been tested locally and it succeeded (thanks to @mjura  and @suseclee ).

This is fixing issue with `skuba node remove`
```
Events:
  Type     Reason        Age                 From            Message
  ----     ------        ----                ----            -------
  Warning  FailedCreate  17m (x5 over 27m)   job-controller  Error creating: pods "caasp-kubelet-disarm-2252cf16586356ab302f21910a903fdce1075aa0-" is forbidden: unable to validate against any pod security policy: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]
  Warning  FailedCreate  5m1s (x4 over 26m)  job-controller  Error creating: pods "caasp-kubelet-disarm-2252cf16586356ab302f21910a903fdce1075aa0-" is forbidden: unable to validate against any pod security policy: [spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]
```

Fixes # https://github.com/SUSE/avant-garde/issues/1455

## What does this PR do?

```
skuba node remove -v5 caasp-worker-mjura-0
** This is an UNTAGGED version and NOT intended for production usage. **
[remove-node] removing worker node caasp-worker-mjura-0 (drain timeout: 0s)
W0409 09:19:28.576326    4751 replica.go:346] waiting for deployment be available: 5
I0409 09:19:33.952760    4751 replica.go:334] deployment oidc-dex is available
W0409 09:19:34.897862    4751 replica.go:346] waiting for deployment be available: 5
I0409 09:19:40.155982    4751 replica.go:334] deployment oidc-gangway is available
I0409 09:19:43.772072    4751 nodes.go:109] node caasp-worker-mjura-0 correctly drained
I0409 09:19:44.234194    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:45.439346    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:46.662218    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:48.068500    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:49.277455    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:50.698383    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:52.101764    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:53.317702    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:54.523047    4751 jobs.go:71] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de is active, waiting...
I0409 09:19:55.741637    4751 jobs.go:74] job caasp-kubelet-disarm-fbfbfa882e80bafa4526fc70391d66a094f4c5de executed successfully
[remove-node] node caasp-worker-mjura-0 successfully removed from the cluster
```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
