### PR TITLE
FIX: check node timeout set to None

### DIFF
--- a/ci/infra/testrunner/checks/checks.py
+++ b/ci/infra/testrunner/checks/checks.py
@@ -73,6 +73,13 @@ class Checker:
 
 
     def check_node(self, role, node, checks=None, stage=None, timeout=180, backoff=20):
+
+        #Prevent defaults to be accidentally overridden by callers with None
+        if timeout is None:
+            timeout = 180
+        if backoff is None:
+            backoff = 20
+
         if checks:
             check_names = checks
             checks = []


### PR DESCRIPTION
## Why is this PR needed?

If the caller doesn't have a sensible default for timeout and passes None,
the default value is overridden. 

Fixes https://github.com/SUSE/avant-garde/issues/1489


## What does this PR do?

As the function is called from multiple points, a safety check is added to ensure sensible default are enforced. Same applies for backoff

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
