### PR TITLE
Remove repository mirroring

### DIFF
--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -35,7 +35,7 @@ terraform:
     cpu: 2
 
 packages:
-  mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
+# mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
   additional_pkgs:
   - "ca-certificates-suse"
 


### PR DESCRIPTION
## Why is this PR needed?

Now that tests are running in NUE using mirrors from PRV
is not longer needed and introduces potential issues due
to lack of sync.

## What does this PR do?

Changes testrunner's config for dropping the mirror

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:
    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
