### PR TITLE
Remove platform parameter from Kubectl class

### DIFF
--- a/ci/infra/testrunner/checks/checks.py
+++ b/ci/infra/testrunner/checks/checks.py
@@ -163,13 +163,13 @@ def check_node_ready(conf, platform, role, node):
     node_name = platform.get_nodes_names(role)[node]
     cmd = ("get nodes {} -o jsonpath='{{range @.status.conditions[*]}}"
            "{{@.type}}={{@.status}};{{end}}'").format(node_name)
-    kubectl = Kubectl(conf, platform)
+    kubectl = Kubectl(conf)
     return kubectl.run_kubectl(cmd).find("Ready=True") != -1
 
 
 @check(description="check system pods ready", scope="cluster", stages=["joined"])
 def check_system_pods_ready(conf, platform):
-    kubectl = Kubectl(conf, platform)
+    kubectl = Kubectl(conf)
     return check_pods_ready(kubectl, namespace="kube-system")
 
 

--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -3,7 +3,7 @@ from time import sleep
 
 class Kubectl:
 
-    def __init__(self, conf, platform):
+    def __init__(self, conf):
         self.conf = conf
         self.binpath = conf.kubectl.binpath
         self.kubeconfig = conf.kubectl.kubeconfig

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -111,7 +111,7 @@ def ssh(options):
 
 
 def inhibit_kured(options):
-    Kubectl(options.conf, options.platform).inhibit_kured()
+    Kubectl(options.conf).inhibit_kured()
 
 
 def main():

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -81,8 +81,8 @@ def skuba(conf, target):
 
 
 @pytest.fixture
-def kubectl(conf, target):
-    return Kubectl(conf, target)
+def kubectl(conf):
+    return Kubectl(conf)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

Remove platform parameter from Kubectl constructor.
It is not longer needed after 30542e3.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
