### PR TITLE
Fix bug in the terraform config example

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -7,7 +7,7 @@ libvirt_uri = ""
 # Note this value will be appended to the libvirt_uri as a 'keyfile' query: <libvirt_uri>?keyfile=<libvirt_keyfile>
 # EXAMPLE:
 # libvirt_keyfile = "~/.ssh/custom_id"
-libvirt_uri = ""
+libvirt_keyfile = ""
 
 # URL of the image to use
 # EXAMPLE:


### PR DESCRIPTION
The config is defining twice the variable libvirt_uri. Seems obvious
that the second definition wanted to define libvirt_keyfile instead

Signed-off-by: Manuel Buil <mbuil@suse.com>

## Why is this PR needed?

Does it fix an issue? addresses a business case?

Yes, if we execute with this config file, we will get an error from terraform. It complains with

```
The argument "libvirt_uri" was already set at terraform.tfvars:4,1-12. Each
argument may be set only once.
```

## What does this PR do?

It fixes a double definition of the same variable in the libvirt configuration

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

Launch terraform with the config file

### Status **AFTER** applying the patch

The error disappears and terraform, using libvirt provider, can be used

## Docs

--
# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
