### PR TITLE
Use an already existing virtual network

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -134,7 +134,8 @@ resource "libvirt_domain" "lb" {
   }
 
   network_interface {
-    network_id     = libvirt_network.network.id
+    network_name   = var.network_name
+    network_id     = var.network_name == "" ? libvirt_network.network.0.id : null
     hostname       = "${var.stack_name}-lb"
     wait_for_lease = true
   }

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -86,7 +86,8 @@ resource "libvirt_domain" "master" {
   }
 
   network_interface {
-    network_id     = libvirt_network.network.id
+    network_name   = var.network_name
+    network_id     = var.network_name == "" ? libvirt_network.network.0.id : null
     hostname       = "${var.stack_name}-master-${count.index}"
     wait_for_lease = true
   }

--- a/ci/infra/libvirt/network.tf
+++ b/ci/infra/libvirt/network.tf
@@ -1,4 +1,5 @@
 resource "libvirt_network" "network" {
+  count  = var.network_name == "" ? 1 : 0
   name   = "${var.stack_name}-network"
   mode   = var.network_mode
   domain = var.dns_domain

--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -1,6 +1,7 @@
 {
     "libvirt_uri": "qemu:///system",
     "libvirt_keyfile": "",
+    "network_name": "",
     "pool": "default",
     "image_uri": "",
     "stack_name": "testing",

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -95,6 +95,11 @@ variable "network_mode" {
   description = "Network mode used by the cluster"
 }
 
+variable "network_name" {
+  default     = ""
+  description = "The virtual network name to use. If provided just use the given one (not managed by terraform), otherwise terraform creates a new virtual network resource"
+}
+
 variable "create_lb" {
   type        = bool
   default     = true

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -86,7 +86,8 @@ resource "libvirt_domain" "worker" {
   }
 
   network_interface {
-    network_id     = libvirt_network.network.id
+    network_name   = var.network_name
+    network_id     = var.network_name == "" ? libvirt_network.network.0.id : null
     hostname       = "${var.stack_name}-worker-${count.index}"
     wait_for_lease = true
   }


### PR DESCRIPTION
## Why is this PR needed?

This PR is needed to run multiple clusters over the same libvirt infraesctructure.  Part of SUSE/avant-garde#1297

## What does this PR do?

This PR enables to use an already existing virtual network configuration. So terraform does not require use a new selfcreated virtual network for each deployment.

## Anything else a reviewer needs to know?

Before merging this PR the `caasp-network` needs to be defined within the kvm host.