### PR TITLE
cleanup kubelet.service file for disarm-kubulete

### DIFF
--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -113,6 +113,7 @@ func disarmKubeletJobSpec(node *v1.Node, clusterVersion *version.Version) batchv
 									"rm -rf /var/lib/etcd/*",
 									"dbus-send --system --print-reply --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.DisableUnitFiles array:string:'kubelet.service' boolean:false",
 									"dbus-send --system --print-reply --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.MaskUnitFiles array:string:'kubelet.service' boolean:false boolean:true",
+									"rm -rf /etc/systemd/system/kubelet.service",
 								},
 								" && ",
 							),
@@ -122,6 +123,7 @@ func disarmKubeletJobSpec(node *v1.Node, clusterVersion *version.Version) batchv
 							VolumeMount("var-lib-kubelet", "/var/lib/kubelet", VolumeMountReadWrite),
 							VolumeMount("var-lib-etcd", "/var/lib/etcd", VolumeMountReadWrite),
 							VolumeMount("var-run-dbus", "/var/run/dbus", VolumeMountReadWrite),
+							VolumeMount("etc-systemd-system", "/etc/systemd/system", VolumeMountReadWrite),
 						},
 						SecurityContext: &v1.SecurityContext{
 							Privileged: &privilegedJob,
@@ -134,6 +136,7 @@ func disarmKubeletJobSpec(node *v1.Node, clusterVersion *version.Version) batchv
 					HostMount("var-lib-kubelet", "/var/lib/kubelet"),
 					HostMount("var-lib-etcd", "/var/lib/etcd"),
 					HostMount("var-run-dbus", "/var/run/dbus"),
+					HostMount("etc-systemd-system", "/etc/systemd/system"),
 				},
 				NodeSelector: map[string]string{
 					"kubernetes.io/hostname": node.ObjectMeta.Name,


### PR DESCRIPTION
## Why is this PR needed?

During Skuba disarms kubelete, kubelet.service file was left over. 

## What does this PR do?

This PR cleans /etc/systemd/system/kubelet.service for disarming kubelet.

## Anything else a reviewer needs to know?

In the removed nodes from cluster, we should not see kubelet.service file.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

After `skuba node remove worker-2`, we see kubelet.service left from the worker-2.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

Do not need to change any Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
