### PR TITLE
Return err when there is a failure upgrading

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -168,6 +168,7 @@ func DeployAddons(client clientset.Interface, addonConfiguration AddonConfigurat
 				klog.V(1).Infof("%q addon correctly applied", addonName)
 			} else {
 				klog.Errorf("failed to apply %q addon (%v)", addonName, err)
+				return err
 			}
 		} else {
 			klog.V(1).Infof("skipping %q addon apply", addonName)


### PR DESCRIPTION
Currently we are logging the error but not returning error. As a
consequence, the upgrade might fail but we still get the successful
message. For example:

E0422 08:25:36.316862   19710 addons.go:334] failed to run kubectl delete: error: the path "/tmp/skuba-addon-cilium478546698/base/cilium-preflight.yaml" does not exist
E0422 08:25:36.317170   19710 addons.go:170] failed to apply "cilium" addon (exit status 1)
[apply] Successfully upgraded addons

Signed-off-by: Manuel Buil <mbuil@suse.com>

## Why is this PR needed?

Fixing a bug.

Currently we are logging the error but not returning error. As a
consequence, the upgrade might fail but we still get the successful
message. For example:

E0422 08:25:36.316862   19710 addons.go:334] failed to run kubectl delete: error: the path "/tmp/skuba-addon-cilium478546698/base/cilium-preflight.yaml" does not exist
E0422 08:25:36.317170   19710 addons.go:170] failed to apply "cilium" addon (exit status 1)
[apply] Successfully upgraded addons

## What does this PR do?

Adds a return err. Currently we were only logging it

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

### Status **BEFORE** applying the patch
Run an upgrade that fails and you'll see the success message

### Status **AFTER** applying the patch
If the upgrade fails, we should see:
"[apply] Failed to deploy addons"

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
