### PR TITLE
Remove openstack e2e tests from CI

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -30,7 +30,6 @@
     repo-owner: SUSE
     repo-credentials: github-token
     platform:
-        - openstack
         - vmware
     test:
         - 'test_node_reboot'


### PR DESCRIPTION
## Why is this PR needed?

Removing e2e tests from OpenStack because we are not looking at them and, sporadically, they seem to have a bad interaction with QA tests, as sometimes resources are not properly cleared it eats quota.

## What does this PR do?

Remove daily e2e OpenStack tests in the CI

