### PR TITLE
Update skuba to crio v1.18rc1

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -88,7 +88,7 @@ var (
 		"1.18.0": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.18.0",
-				ContainerRuntimeVersion: "1.17.0",
+				ContainerRuntimeVersion: "1.18.0",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
 				APIServer:         &ContainerImageTag{Name: "api-server", Tag: "v1.18.0"},

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -24,6 +24,7 @@ const (
 ## Default        : ""
 ## ServiceRestart : crio
 #
-CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"{{end}}
+### BUG [ CRIO v1.18.0rc1 ] - string parsing issue based on comma separators
+CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities CHOWN --default-capabilities DAC_OVERRIDE --default-capabilities FSETID --default-capabilities FOWNER --default-capabilities NET_RAW --default-capabilities SETGID --default-capabilities SETUID --default-capabilities SETPCAP --default-capabilities NET_BIND_SERVICE --default-capabilities SYS_CHROOT --default-capabilities KILL --default-capabilities MKNOD --default-capabilities AUDIT_WRITE --default-capabilities SETFCAP{{end}}
 `
 )


### PR DESCRIPTION
## Why is this PR needed?

It is upgrading `cri-o` to `v1.18rc1` version

## What does this PR do?

New version `cri-o v1.18rc1`

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)


