### PR TITLE
Add provision and deploy stages to e2e tests

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -7,13 +7,16 @@ JENKINS_JOBS_DIR = ${MKFILE_DIR}/jenkins
 JENKINS_JOB_CONFIG ?= ${JENKINS_JOBS_DIR}/jenkins_jobs.ini
 PLATFORM ?= openstack
 ifdef SUITE
-SUITE_CMD=--suite ${SUITE}.py
+SUITE_OPT=--suite ${SUITE}.py
 endif
 ifdef TEST
 ifndef SUITE
 $(error SUITE is required for selecting a test )
 endif
-TEST_CMD=--test ${TEST}
+TEST_OPT=--test ${TEST}
+endif
+ifdef SKIP_SETUP
+SKIP_SETUP_OPT=--skip-setup ${SKIP_SETUP}
 endif
 
 .PHONY: all
@@ -82,7 +85,7 @@ post_run: gather_logs cleanup
 # e2e Tests
 .PHONY: test
 test:
-	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose ${SUITE_CMD} ${TEST_CMD}
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose ${SUITE_OPT} ${TEST_OPT} ${SKIP_SETUP_OPT}
 
 .PHONY: test_pr
 test_pr:

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -18,6 +18,9 @@ endif
 ifdef SKIP_SETUP
 SKIP_SETUP_OPT=--skip-setup ${SKIP_SETUP}
 endif
+ifdef KUBERNETES_VERSION
+K8S_VERSION_OPT=--kubernetes-version ${KUBERNETES_VERSION}
+endif
 
 .PHONY: all
 all: provision deploy
@@ -30,7 +33,7 @@ provision:
 
 .PHONY: bootstrap
 bootstrap:
-	${TEST_RUNNER} --platform ${PLATFORM} bootstrap
+	${TEST_RUNNER} --platform ${PLATFORM} bootstrap ${K8S_VERSION_OPT}
 
 .PHONY: join_nodes 
 join_nodes:
@@ -38,7 +41,7 @@ join_nodes:
 
 .PHONY: deploy 
 deploy:
-	${TEST_RUNNER} --platform ${PLATFORM} deploy
+	${TEST_RUNNER} --platform ${PLATFORM} deploy ${K8s_VERSION_OPT}
 
 .PHONY: check_cluster
 check_cluster:

--- a/ci/infra/testrunner/tests/test_upgrade_apply_all_fine.py
+++ b/ci/infra/testrunner/tests/test_upgrade_apply_all_fine.py
@@ -1,15 +1,11 @@
 import pytest
 
-from tests.utils import setup_kubernetes_version
-
 
 @pytest.mark.disruptive
-def test_upgrade_apply_all_fine(provision, platform, skuba, kubectl):
+def test_upgrade_apply_all_fine(deployment, platform, skuba, kubectl):
     """
     Starting from a up-to-date cluster, check what node upgrade apply reports.
     """
-
-    setup_kubernetes_version(skuba, kubectl)
 
     # node upgrade apply
     masters = platform.get_num_nodes("master")

--- a/ci/infra/testrunner/tests/test_upgrade_apply_from_previous.py
+++ b/ci/infra/testrunner/tests/test_upgrade_apply_from_previous.py
@@ -1,15 +1,13 @@
 import pytest
 
-from tests.utils import PREVIOUS_VERSION, setup_kubernetes_version, node_is_ready, node_is_upgraded
+from tests.utils import node_is_ready, node_is_upgraded
 
 
 @pytest.mark.disruptive
-def test_upgrade_apply_from_previous(provision, platform, skuba, kubectl):
+def test_upgrade_apply_from_previous(deployment, platform, skuba, kubectl):
     """
     Starting from an outdated cluster, check what node upgrade apply reports.
     """
-
-    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     for role in ("master", "worker"):
         num_nodes = platform.get_num_nodes(role)

--- a/ci/infra/testrunner/tests/test_upgrade_apply_user_lock.py
+++ b/ci/infra/testrunner/tests/test_upgrade_apply_user_lock.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.utils import PREVIOUS_VERSION, setup_kubernetes_version, node_is_ready, node_is_upgraded, wait
+from tests.utils import PREVIOUS_VERSION, node_is_ready, node_is_upgraded, wait
 
 
 @pytest.mark.disruptive
@@ -8,8 +8,6 @@ def test_upgrade_apply_user_lock(provision, platform, kubectl, skuba):
     """
     Starting from an outdated cluster, check what node upgrade apply reports.
     """
-
-    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     # lock kured
     kubectl_cmd = (

--- a/ci/infra/testrunner/tests/test_upgrade_plan_all_fine.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_all_fine.py
@@ -1,15 +1,11 @@
 import pytest
 
-from tests.utils import setup_kubernetes_version
-
-
 @pytest.mark.disruptive
 def test_upgrade_plan_all_fine(provision, skuba, kubectl, platform):
     """
     Starting from a up-to-date cluster, check what cluster/node plan report.
     """
 
-    setup_kubernetes_version(skuba, kubectl)
     out = skuba.cluster_upgrade_plan()
 
     assert out.find(

--- a/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
@@ -1,15 +1,13 @@
 import pytest
 
-from tests.utils import setup_kubernetes_version, PREVIOUS_VERSION, CURRENT_VERSION
+from tests.utils import PREVIOUS_VERSION, CURRENT_VERSION
 
 
 @pytest.mark.disruptive
-def test_upgrade_plan_from_previous(provision, skuba, kubectl, platform):
+def test_upgrade_plan_from_previous(deployment, skuba, kubectl, platform):
     """
     Starting from an outdated cluster, check what cluster/node plan report.
     """
-
-    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     # cluster upgrade plan
     out = skuba.cluster_upgrade_plan()

--- a/ci/infra/testrunner/tests/test_upgrade_plan_from_previous_with_upgraded_control_plane.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_from_previous_with_upgraded_control_plane.py
@@ -1,15 +1,13 @@
 import pytest
 
-from tests.utils import PREVIOUS_VERSION, CURRENT_VERSION, setup_kubernetes_version, node_is_ready, node_is_upgraded
+from tests.utils import PREVIOUS_VERSION, CURRENT_VERSION, node_is_ready, node_is_upgraded
 
 
 @pytest.mark.disruptive
-def test_upgrade_plan_from_previous_with_upgraded_control_plane(provision, skuba, kubectl, platform):
+def test_upgrade_plan_from_previous_with_upgraded_control_plane(deployment, skuba, kubectl, platform):
     """
     Starting from an updated control plane, check what cluster/node plan report.
     """
-
-    setup_kubernetes_version(skuba, kubectl, PREVIOUS_VERSION)
 
     masters = platform.get_num_nodes("master")
     for n in range(0, masters):

--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -119,25 +119,6 @@ def wait(func, *args, **kwargs):
     raise Exception("Failed waiting for function {} after {} attemps due to {}".format(func.__name__, attempts, reason))
 
 
-def setup_kubernetes_version(skuba, kubectl, kubernetes_version=None):
-    """
-    Initialize the cluster with the given kubernetes_version, bootstrap it and
-    join nodes.
-    """
-
-    skuba.cluster_init(kubernetes_version)
-    skuba.node_bootstrap()
-
-    skuba.join_nodes()
-
-    wait(check_nodes_ready,
-         kubectl,
-         wait_delay=60,
-         wait_backoff=30,
-         wait_elapsed=60*10,
-         wait_allow=(AssertionError))
-
-
 def create_skuba_config(kubectl, configmap_data, dry_run=False):
     return kubectl.run_kubectl(
         'create configmap skuba-config --from-literal {0} -o yaml --namespace kube-system {1}'.format(

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -35,10 +35,14 @@
         - 'test_node_reboot'
         - 'test_upgrade_plan_all_fine'
         - 'test_upgrade_plan_from_previous'
+          kubernetes_version: '1.16.2"
         - 'test_upgrade_plan_from_previous_with_upgraded_control_plane'
+          kubernetes_version: '1.16.2"
         - 'test_upgrade_apply_all_fine'
         - 'test_upgrade_apply_from_previous'
+          kubernetes_version: '1.16.2"
         - 'test_upgrade_apply_user_lock'
+          kubernetes_version: '1.16.2"
         - 'test_cilium'
         - 'test_nginx_deployment'
         - 'test_dockercaps'

--- a/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
@@ -23,9 +23,22 @@ pipeline {
             sh(script: "pushd skuba; make -f Makefile install; popd", label: 'Build Skuba')
         } }
 
+        stage('Provision cluster') {
+            steps {
+                sh(script: 'make -f skuba/ci/Makefile provision', label: 'Provision')
+            }
+        }
+
+        stage('Deploy cluster') {
+            steps {
+                sh(script: 'make -f skuba/ci/Makefile deploy', label: 'Deploy')
+                sh(script: 'make -f skuba/ci/Makefile check_cluster', label: 'Check cluster')
+            }
+        }
+
         stage('Run Skuba e2e Test') {
             steps {
-                sh(script: "make -f skuba/ci/Makefile test SUITE=${E2E_MAKE_TARGET_NAME}", label: "${E2E_MAKE_TARGET_NAME}")
+                sh(script: "make -f skuba/ci/Makefile test SUITE=${E2E_MAKE_TARGET_NAME} SKIP_SETUP='deployed'", label: "${E2E_MAKE_TARGET_NAME}")
             }
         }
    }

--- a/ci/jenkins/templates/e2e-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-daily-template.yaml
@@ -23,6 +23,10 @@
             name: E2E_MAKE_TARGET_NAME
             default: '{test}'
             description: The make target to run (only e2e tests)
+        - string:
+              name: KUBERNETES_VERSION 
+              default: '{kubernetes_version}'
+              description: version of kubernetes to install
     pipeline-scm:
         scm:
             - git:


### PR DESCRIPTION
## Why is this PR needed?

E2E tests provision and deploy clusters using fixtures. It makes difficult to detect situations when the provisioning fails due to infrastructure issues or the deployment fails due to issues with packages or images required by skuba.

## What does this PR do?

Separate the provision and deploying from e2e tests and adds cluster sanity tests.
Adds the skip setup option to e2e test target to prevent tests to deploy a cluster using fixtures.

TODO:
- [ ] Handle the special case of upgrade tests, which must deploy the cluster specifying the kubernetes version

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
