### PR TITLE
Update crio CaaSP configuration for v1.18.0

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -28,10 +28,35 @@ import (
 
 func init() {
 	stateMap["cri.configure"] = criConfigure
+	stateMap["cri.sysconfig"] = criSysconfig
 	stateMap["cri.start"] = criStart
 }
 
 func criConfigure(t *Target, data interface{}) error {
+	criFiles, err := ioutil.ReadDir(skuba.CriConfDir())
+	if err != nil {
+		return errors.Wrap(err, "Could not read local cri directory: "+skuba.CriConfDir())
+	}
+	defer func() {
+		_, _, err := t.ssh("rm -rf /tmp/crio.conf.d")
+		if err != nil {
+			// If the deferred function has any return values, they are discarded when the function completes
+			// https://golang.org/ref/spec#Defer_statements
+			fmt.Println("Could not delete the crio.conf.d config path")
+		}
+	}()
+
+	for _, f := range criFiles {
+		if err := t.target.UploadFile(filepath.Join(skuba.CriConfDir(), f.Name()), filepath.Join("/tmp/crio.conf.d", f.Name())); err != nil {
+			return err
+		}
+	}
+
+	_, _, err = t.ssh("mv -f /tmp/crio.conf.d/01-caasp.conf /etc/crio/crio.conf.d/01-caasp.conf")
+	return err
+}
+
+func criSysconfig(t *Target, data interface{}) error {
 	criFiles, err := ioutil.ReadDir(skuba.CriDir())
 	if err != nil {
 		return errors.Wrap(err, "Could not read local cri directory: "+skuba.CriDir())

--- a/pkg/skuba/actions/cluster/init/constants.go
+++ b/pkg/skuba/actions/cluster/init/constants.go
@@ -28,10 +28,18 @@ type ScaffoldFile struct {
 }
 
 var (
-	scaffoldFiles = []ScaffoldFile{
-		{
-			Location: skuba.CriDockerDefaultsConfFile(),
-			Content:  criDockerDefaultsConf,
+	criScaffoldFiles = map[string][]ScaffoldFile{
+		"sysconfig": {
+			{
+				Location: skuba.CriDockerDefaultsConfFile(),
+				Content:  criDockerDefaultsConf,
+			},
+		},
+		"criconfig": {
+			{
+				Location: skuba.CriDefaultsConfFile(),
+				Content:  criDefaultsConf,
+			},
 		},
 	}
 

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -115,7 +115,12 @@ func Init(initConfiguration InitConfiguration) error {
 		return errors.Errorf("cluster configuration directory %q already exists", initConfiguration.ClusterName)
 	}
 
-	scaffoldFilesToWrite := scaffoldFiles
+	scaffoldFilesToWrite := criScaffoldFiles["criconfig"]
+	kubernetesVersion := initConfiguration.KubernetesVersion
+	if kubernetesVersion.Minor() < 18 {
+		scaffoldFilesToWrite = criScaffoldFiles["sysconfig"]
+	}
+
 	if len(initConfiguration.CloudProvider) > 0 {
 		if cloudScaffoldFiles, found := cloudScaffoldFiles[initConfiguration.CloudProvider]; found {
 			scaffoldFilesToWrite = append(scaffoldFilesToWrite, cloudScaffoldFiles...)

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -24,7 +24,28 @@ const (
 ## Default        : ""
 ## ServiceRestart : crio
 #
-### BUG [ CRIO v1.18.0rc1 ] - string parsing issue based on comma separators
-CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities CHOWN --default-capabilities DAC_OVERRIDE --default-capabilities FSETID --default-capabilities FOWNER --default-capabilities NET_RAW --default-capabilities SETGID --default-capabilities SETUID --default-capabilities SETPCAP --default-capabilities NET_BIND_SERVICE --default-capabilities SYS_CHROOT --default-capabilities KILL --default-capabilities MKNOD --default-capabilities AUDIT_WRITE --default-capabilities SETFCAP{{end}}
+CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"{{end}}`
+	criDefaultsConf = `{{if not .StrictCapDefaults}}[crio.runtime]
+
+default_capabilities = [
+	"CHOWN",
+	"DAC_OVERRIDE",
+	"FSETID",
+	"FOWNER",
+	"NET_RAW",
+	"SETGID",
+	"SETUID",
+	"SETPCAP",
+	"NET_BIND_SERVICE",
+	"SYS_CHROOT",
+	"KILL",
+	"MKNOD",
+	"AUDIT_WRITE",
+	"SETFCAP",
+]{{end}}
+
+[crio.image]
+
+pause_image = "{{.PauseImage}}"
 `
 )

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -118,9 +118,11 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		return errors.Wrap(err, "error writing init configuration")
 	}
 
-	var criConfigure string
-	if _, err := os.Stat(skuba.CriDockerDefaultsConfFile()); err == nil {
-		criConfigure = "cri.configure"
+	var criSetup string
+	if _, err := os.Stat(skuba.CriDefaultsConfFile()); err == nil {
+		criSetup = "cri.configure"
+	} else if _, err := os.Stat(skuba.CriDockerDefaultsConfFile()); err == nil {
+		criSetup = "cri.sysconfig"
 	}
 
 	// bsc#1155810: generate cluster-wide kubelet root certificate
@@ -138,7 +140,7 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		"kernel.configure-parameters",
 		"firewalld.disable",
 		"apparmor.start",
-		criConfigure,
+		criSetup,
 		"cri.start",
 		"kubelet.rootcert.upload",
 		"kubelet.servercert.create-and-upload",

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -58,9 +58,11 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		return err
 	}
 
-	var criConfigure string
-	if _, err := os.Stat(skuba.CriDockerDefaultsConfFile()); err == nil {
-		criConfigure = "cri.configure"
+	var criSetup string
+	if _, err := os.Stat(skuba.CriDefaultsConfFile()); err == nil {
+		criSetup = "cri.configure"
+	} else if _, err := os.Stat(skuba.CriDockerDefaultsConfFile()); err == nil {
+		criSetup = "cri.sysconfig"
 	}
 
 	_, err = client.CoreV1().Nodes().Get(target.Nodename, metav1.GetOptions{})
@@ -82,7 +84,7 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		"kernel.configure-parameters",
 		"firewalld.disable",
 		"apparmor.start",
-		criConfigure,
+		criSetup,
 		"cri.start",
 		"kubelet.rootcert.upload",
 		"kubelet.servercert.create-and-upload",

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -80,6 +80,14 @@ func CriDockerDefaultsConfFile() string {
 	return filepath.Join(CriDir(), "default_flags")
 }
 
+func CriConfDir() string {
+	return filepath.Join(AddonsDir(), "cri/conf.d")
+}
+
+func CriDefaultsConfFile() string {
+	return filepath.Join(CriConfDir(), "01-caasp.conf")
+}
+
 func KubeConfigAdminFile() string {
 	return "admin.conf"
 }


### PR DESCRIPTION
## Why is this PR needed?

For cri-o `v1.18.0` we would like stop using sysconfig crio configuration and use more appropriate way `/etc/crio/crio.conf.d/`

## What does this PR do?

It is installing cri-o CaaSP configuration in `/etc/crio/crio.conf.d/01-caasp.conf`
For previous cri-o versions we have to keep backwards compatibility.

## Anything else a reviewer needs to know?

To upgrade cluster from previous versions 

```
skuba cluster init --control-plane <PUBLIC_IP> /tmp/test-cluster
mv /tmp/test-cluster/addons/cri/conf.d <CURRENT-CLUSTER-NAME>/addons/cri/
rm <CURRENT-CLUSTER-NAME>/addons/cri/default_flags
```


## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
