### PR TITLE
1.17 skuba is now deployed with crio 1.16.1


### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -112,7 +112,7 @@ var (
 		"1.17.4": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.17.4",
-				ContainerRuntimeVersion: "1.17.0",
+				ContainerRuntimeVersion: "1.16.1",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
 				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},


### PR DESCRIPTION


Without this patch, the expected output of skuba upgrade plan
will mention that crio 1.16.1 is not up to date and will require
upgrading to 1.17.0.

This is a problem, as we are sending the wrong message to users.

This should fix it.

Closes: https://github.com/SUSE/avant-garde/issues/1493

