### PR TITLE
Missing cloud-config file should fail bootstrap

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -19,6 +19,7 @@ package ssh
 
 import (
 	"crypto/x509"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -26,7 +27,9 @@ import (
 
 	"github.com/pkg/errors"
 	certutil "k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
+	"sigs.k8s.io/yaml"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments/ssh/assets"
@@ -155,18 +158,17 @@ func kubeletConfigure(t *Target, data interface{}) error {
 		}
 	}
 
-	if _, err := os.Stat(skuba.OpenstackCloudConfFile()); err == nil {
-		if err := t.target.UploadFile(skuba.OpenstackCloudConfFile(), skuba.OpenstackConfigRuntimeFile()); err != nil {
+	cloudProvider, err := getCloudProvider()
+	if err != nil {
+		return err
+	}
+	switch cloudProvider {
+	case "openstack":
+		if err := setCloudProvider(t, cloudProvider); err != nil {
 			return err
 		}
-		if _, _, err = t.ssh("chmod", "0400", skuba.OpenstackConfigRuntimeFile()); err != nil {
-			return err
-		}
-	} else if _, err := os.Stat(skuba.VSphereCloudConfFile()); err == nil {
-		if err := t.target.UploadFile(skuba.VSphereCloudConfFile(), skuba.VSphereConfigRuntimeFile()); err != nil {
-			return err
-		}
-		if _, _, err = t.ssh("chmod", "0400", skuba.VSphereConfigRuntimeFile()); err != nil {
+	case "vsphere":
+		if err := setCloudProvider(t, cloudProvider); err != nil {
 			return err
 		}
 	}
@@ -178,4 +180,39 @@ func kubeletConfigure(t *Target, data interface{}) error {
 func kubeletEnable(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "enable", "kubelet")
 	return err
+}
+
+func getCloudProvider() (string, error) {
+	data, err := ioutil.ReadFile(skuba.KubeadmInitConfFile())
+	if err != nil {
+		return "", err
+	}
+	type config struct {
+		NodeRegistration struct {
+			KubeletExtraArgs struct {
+				CloudProvider string `json:"cloud-provider"`
+			} `json:"kubeletExtraArgs"`
+		} `json:"nodeRegistration"`
+	}
+	c := config{}
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		return "", err
+	}
+	return c.NodeRegistration.KubeletExtraArgs.CloudProvider, nil
+}
+
+func setCloudProvider(t *Target, cloudProvider string) error {
+	cloudConfigFile := cloudProvider + ".conf"
+	cloudConfigFilePath := filepath.Join(skuba.CloudDir(), cloudProvider, cloudConfigFile)
+	if _, err := os.Stat(cloudConfigFilePath); os.IsNotExist(err) {
+		return err
+	}
+	cloudConfigRuntimeFilePath := filepath.Join(constants.KubernetesDir, cloudConfigFile)
+	if err := t.target.UploadFile(cloudConfigFilePath, cloudConfigRuntimeFilePath); err != nil {
+		return err
+	}
+	if _, _, err := t.ssh("chmod", "0400", cloudConfigRuntimeFilePath); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -164,11 +164,11 @@ func kubeletConfigure(t *Target, data interface{}) error {
 	}
 	switch cloudProvider {
 	case "openstack":
-		if err := setCloudProvider(t, cloudProvider); err != nil {
+		if err := uploadCloudProvider(t, cloudProvider); err != nil {
 			return err
 		}
 	case "vsphere":
-		if err := setCloudProvider(t, cloudProvider); err != nil {
+		if err := uploadCloudProvider(t, cloudProvider); err != nil {
 			return err
 		}
 	}
@@ -201,7 +201,7 @@ func getCloudProvider() (string, error) {
 	return c.NodeRegistration.KubeletExtraArgs.CloudProvider, nil
 }
 
-func setCloudProvider(t *Target, cloudProvider string) error {
+func uploadCloudProvider(t *Target, cloudProvider string) error {
 	cloudConfigFile := cloudProvider + ".conf"
 	cloudConfigFilePath := filepath.Join(skuba.CloudDir(), cloudProvider, cloudConfigFile)
 	if _, err := os.Stat(cloudConfigFilePath); os.IsNotExist(err) {

--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -163,11 +163,7 @@ func kubeletConfigure(t *Target, data interface{}) error {
 		return err
 	}
 	switch cloudProvider {
-	case "openstack":
-		if err := uploadCloudProvider(t, cloudProvider); err != nil {
-			return err
-		}
-	case "vsphere":
+	case "openstack", "vsphere":
 		if err := uploadCloudProvider(t, cloudProvider); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Why is this PR needed?

When cloud-config is not present in provider folder. It should exit out before complete bootstrap.

Fixes #

## What does this PR do?

Checks cloud-config files exist before remote upload for `openstack` and `vsphere`. Exit if not exist.

## Anything else a reviewer needs to know?

## Info for QA

https://github.com/SUSE/caasp-test-cases/pull/39

### Related info

### Status **BEFORE** applying the patch

When `--cloud-provider` is enabled `skuba node bootstrap` continue and succeed without necessary cloud-config file.

### Status **AFTER** applying the patch

```
skuba-cluster ➤ skuba node bootstrap --user sles --sudo --target ${CONTROL_PLANE} ${NAME} -v 10
...
F0425 18:18:48.001752   18971 bootstrap.go:56] error bootstrapping node: failed to apply state kubelet.configure: stat cloud/vsphere/vsphere.conf: no such file or directory
skuba-cluster ➤     
```

## Docs
n/a

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>