### PR TITLE
Use Leap 15.1 for builder image


### DIFF
--- a/skuba-update/test/os/suse/Dockerfile.builder
+++ b/skuba-update/test/os/suse/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/opensuse/tumbleweed
+FROM registry.opensuse.org/opensuse/leap:15.1
 
 RUN zypper ref && zypper -n in rpm-build rpmdevtools createrepo libcreaterepo_c-devel
 RUN rm /var/run/reboot-needed


### PR DESCRIPTION

The integration tests are using a builder image
running tumbleweed, which could be breaking at any
time. I suspect that the real tests are merely
using the builder data artifacts, and apply those
in the proper images.

In other words, it means that the builder does
not need to be a moving target (as it is just
a tooling). For stability purposes, I am moving
the image to a more stable image, based on Leap.
