### PR TITLE
Refactor node reboot test

### DIFF
--- a/ci/infra/testrunner/kubectl/kubectl.py
+++ b/ci/infra/testrunner/kubectl/kubectl.py
@@ -16,6 +16,14 @@ class Kubectl:
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(shell_cmd)) from ex
 
+    def get_num_nodes_by_role(self, role):
+        """ Returns the number of nodes by role (master/worker)"""
+        if role not in ("master", "worker"):
+            raise ValueError("Invalid role {}".format(role))
+
+        nodes = self.get_node_names_by_role(role)
+        return len(nodes)
+
     def get_node_names_by_role(self, role):
         """Returns a list of node names for a given role
         Uses selectors to get the nodes. Master nodes have the node-role.kubernetes.io/master="" label, while other

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -48,9 +48,10 @@ def bootstrap(request, provision, skuba):
 
 @pytest.fixture
 def deployment(request, bootstrap, skuba, kubectl):
-    if request.config.getoption("skip_setup") != 'deployed':
-        skuba.join_nodes()
+    if request.config.getoption("skip_setup") == 'deployed':
+        return
 
+    skuba.join_nodes()
     wait(check_pods_ready,
          kubectl,
          namespace="kube-system",

--- a/ci/infra/testrunner/tests/test_node_reboot.py
+++ b/ci/infra/testrunner/tests/test_node_reboot.py
@@ -17,12 +17,12 @@ def check_node_is_ready(platform, kubectl, role, nr):
 
 @pytest.mark.pr
 @pytest.mark.parametrize('role,node', [('master', 1), ('worker', 0)])
-def test_hard_reboot(deployment, platform, skuba, kubectl, role, node):
+def test_hard_reboot(deployment, platform, kubectl, role, node):
     """ Reboots master and worker nodes and checks they are back ready.
     For masters, reboot master 1, as master 0 is expected to be the
     cluster leader and rebooting it may introduce transient etcd errors.
     """
-    assert skuba.num_of_nodes(role) > node
+    assert kubectl.get_num_nodes_by_role(role) > node
 
     platform.ssh_run(role, node, 'sudo reboot &')
 

--- a/ci/infra/testrunner/tests/test_node_reboot.py
+++ b/ci/infra/testrunner/tests/test_node_reboot.py
@@ -4,58 +4,45 @@ import time
 
 import pytest
 
-from tests.utils import wait
+from tests.utils import (check_pods_ready, node_is_ready, wait)
 
 from timeout_decorator import timeout
 
 logger = logging.getLogger("testrunner")
 
 
-def check_pods_ready(kubectl):
-    pods = json.loads(kubectl.run_kubectl('get pods --all-namespaces -o json'))['items']
-    for pod in pods:
-        pod_status = pod['status']['phase']
-        pod_name   = pod['metadata']['name']
-        assert pod_status in ['Running', 'Completed'], f'Pod {pod_name} status {pod_status} != Running or Completed'
+def check_node_is_ready(platform, kubectl, role, nr):
+    assert node_is_ready(platform, kubectl, role, nr)
 
 
 @pytest.mark.pr
-@pytest.mark.parametrize('node_type,node_number', [('master', 1), ('worker', 0)])
-def test_hard_reboot(deployment, platform, skuba, kubectl, node_type, node_number):
-    assert skuba.num_of_nodes(node_type) > node_number
+@pytest.mark.parametrize('role,node', [('master', 1), ('worker', 0)])
+def test_hard_reboot(deployment, platform, skuba, kubectl, role, node):
+    """ Reboots master and worker nodes and checks they are back ready.
+    For masters, reboot master 1, as master 0 is expected to be the
+    cluster leader and rebooting it may introduce transient etcd errors.
+    """
+    assert skuba.num_of_nodes(role) > node
 
-    logger.info('Wait for all the nodes to be ready')
-    wait(kubectl.run_kubectl, 
-         'wait --for=condition=Ready node --all --timeout=0',
-         wait_timeout=10,
-         wait_backoff=30,
-         wait_elapsed=300,
-         wait_allow=(RuntimeError))
+    platform.ssh_run(role, node, 'sudo reboot &')
 
-    logger.info(f'Rebooting {node_type} {node_number}')
-
-    platform.ssh_run(node_type, node_number, 'sudo reboot &')
-
-    # wait the node to reboot
-    wait(platform.ssh_run,
-         node_type,
-         node_number,
-         'echo hello',
-         wait_backoff=30,
-         wait_timeout=30,
-         wait_elapsed=300,
-         wait_allow=(RuntimeError))
+    # Allow time for kubernetes to check node readiness and detect it is not
+    # ready
+    time.sleep(60)
 
     # wait the node to become ready
-    wait(kubectl.run_kubectl,
-         'wait --for=condition=Ready node --all --timeout=0',
+    wait(check_node_is_ready,
+         platform,
+         kubectl,
+         role,
+         node,
          wait_delay=30,
          wait_timeout=10,
          wait_backoff=30,
          wait_elapsed=180,
-         wait_allow=(RuntimeError))
+         wait_allow=(AssertionError))
 
-    # wait pods to get become ready
+    # wait pods to become ready
     wait(check_pods_ready,
          kubectl,
          wait_timeout=10,


### PR DESCRIPTION
## Why is this PR needed?

Improve robustness of node reboot test and make failures to generate output easier to debug.

Fixes https://github.com/SUSE/avant-garde/issues/1529

## What does this PR do?

Use node_is_ready wrapped in a wait function instead of blocking in a kubectl wait --condition.

Give a prudential time for the node to become non-ready (after the readiness probe's grace period) before waiting for it to get ready.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
