### PR TITLE
Clarify dev environment

### DIFF
--- a/skuba-update/Makefile
+++ b/skuba-update/Makefile
@@ -1,17 +1,5 @@
 .PHONY: all
-all: install
-
-.PHONY: install
-install:
-	./setup.py install
-
-.PHONY: suse-package
-suse-package:
-	ci/packaging/suse/rpmfiles_maker.sh
-
-.PHONY: suse-changelog
-suse-changelog:
-	ci/packaging/suse/changelog_maker.sh "$(CHANGES)"
+all: test
 
 .PHONY: test
 test:

--- a/skuba-update/README.md
+++ b/skuba-update/README.md
@@ -18,20 +18,14 @@ To set the development environment consider the following commands:
 # Get into the repository folder
 $ cd skuba-update
 
-# Initiate the python3 virtualenv
-$ python3 -m venv .env3
+# Ensure you have Shellcheck (haskell) and tox (python)
+$ sudo zypper install ShellCheck python-tox
 
-# Activate the virutalenv
-$ source .env3/bin/activate
+# Alternatively: You can also install tox in user space (shellcheck still
+# needs installing through your package manager)
+$ pip install --user tox
 
-# Install development dependencies
-$ pip install -r dev-requirements.txt
-
-# We need the shellcheck utility. You can install it from the package manager
-# you might be using.
-$ sudo zypper install ShellCheck
-
-# Run tests and code style checks
+# Run tests and code style checks without containers
 $ make test
 
 # Run tests and code style checks inside of a Docker container


### PR DESCRIPTION

The Makefile is only used for testing purposes, and
is not used in packaging. It most likely won't change
anytime soon.

The `make install` instruction can go away:
For test purposes, we have tox (and make test).
We should probably not install things on the host
without a venv anyway with `make install` (at best
we should use `pip install -e .`).

The `make test` uses tox to install the software, and
should stay.

The other two make instructions are currently broken,
and exposed through skuba itself, so I don't expect
this to be required.

Next to this, the README file had to be updated.