### PR TITLE
vsphere: support set hostname from dhcp server

### DIFF
--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -57,5 +57,6 @@ ${commands}
 bootcmd:
   # Hostnames from DHCP - otherwise `localhost` will be used
   - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"no\"#DHCLIENT_SET_HOSTNAME=\"yes\"#" /etc/sysconfig/network/dhcp
+  - /usr/bin/hostnamectl set-hostname ${hostname}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -53,7 +53,7 @@ runcmd:
   - sed -i -e '/^#PasswordAuthentication/s/^.*$/PasswordAuthentication no/' /etc/ssh/sshd_config
   - sshd -t || echo "ssh syntax failure"
   - systemctl restart sshd
-  # Disable hostname from DHCP
+  # Enable/Disable hostname from DHCP
   - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"#" /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 ${register_scc}

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -53,7 +53,7 @@ runcmd:
   - sed -i -e '/^#PasswordAuthentication/s/^.*$/PasswordAuthentication no/' /etc/ssh/sshd_config
   - sshd -t || echo "ssh syntax failure"
   - systemctl restart sshd
-  # Set node's hostname from DHCP
+  # Set node's hostname from DHCP server
   - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 ${register_scc}

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -54,7 +54,7 @@ runcmd:
   - sshd -t || echo "ssh syntax failure"
   - systemctl restart sshd
   # Disable hostname from DHCP
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
+  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"#" /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 ${register_scc}
 ${register_rmt}

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -34,6 +34,9 @@ ${repositories}
 # with SUSEConnect command after packages module is ran
 #packages:
 
+# set hostname
+hostname: ${hostname}
+
 runcmd:
   # Since we are currently inside of the cloud-init systemd unit, trying to
   # start another service by either `enable --now` or `start` will create a
@@ -50,13 +53,11 @@ runcmd:
   - sed -i -e '/^#PasswordAuthentication/s/^.*$/PasswordAuthentication no/' /etc/ssh/sshd_config
   - sshd -t || echo "ssh syntax failure"
   - systemctl restart sshd
+  # Disable hostname from DHCP
+  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
+  - systemctl restart wicked
 ${register_scc}
 ${register_rmt}
 ${commands}
-
-bootcmd:
-  # Hostnames from DHCP - otherwise `localhost` will be used
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
-  - /usr/bin/hostnamectl set-hostname ${hostname}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -56,7 +56,7 @@ ${commands}
 
 bootcmd:
   # Hostnames from DHCP - otherwise `localhost` will be used
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"no\"#DHCLIENT_SET_HOSTNAME=\"yes\"#" /etc/sysconfig/network/dhcp
+  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
   - /usr/bin/hostnamectl set-hostname ${hostname}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -54,7 +54,7 @@ runcmd:
   - sshd -t || echo "ssh syntax failure"
   - systemctl restart sshd
   # Enable/Disable hostname from DHCP
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"#" /etc/sysconfig/network/dhcp
+  - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 ${register_scc}
 ${register_rmt}

--- a/ci/infra/vmware/cloud-init/common.tpl
+++ b/ci/infra/vmware/cloud-init/common.tpl
@@ -53,7 +53,7 @@ runcmd:
   - sed -i -e '/^#PasswordAuthentication/s/^.*$/PasswordAuthentication no/' /etc/ssh/sshd_config
   - sshd -t || echo "ssh syntax failure"
   - systemctl restart sshd
-  # Enable/Disable hostname from DHCP
+  # Set node's hostname from DHCP
   - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 ${register_scc}

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -47,7 +47,7 @@ runcmd:
   - [ systemctl, restart, systemd-journald ]
   # LB firewall is not disabled via skuba, so we need to manually disable it
   - [ systemctl, disable, firewalld, --now ]
-  # Set node's hostname from DHCP
+  # Set node's hostname from DHCP server
   - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -48,7 +48,7 @@ runcmd:
 
 bootcmd:
   # Hostnames from DHCP - otherwise localhost will be used
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"no\"#DHCLIENT_SET_HOSTNAME=\"yes\"#" /etc/sysconfig/network/dhcp
+  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
   - /usr/bin/hostnamectl set-hostname ${hostname}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -49,5 +49,6 @@ runcmd:
 bootcmd:
   # Hostnames from DHCP - otherwise localhost will be used
   - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"no\"#DHCLIENT_SET_HOSTNAME=\"yes\"#" /etc/sysconfig/network/dhcp
+  - /usr/bin/hostnamectl set-hostname ${hostname}
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -48,7 +48,7 @@ runcmd:
   # LB firewall is not disabled via skuba, so we need to manually disable it
   - [ systemctl, disable, firewalld, --now ]
   # Enable/Disable hostname from DHCP
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"#" /etc/sysconfig/network/dhcp
+  - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -47,7 +47,7 @@ runcmd:
   - [ systemctl, restart, systemd-journald ]
   # LB firewall is not disabled via skuba, so we need to manually disable it
   - [ systemctl, disable, firewalld, --now ]
-  # Enable/Disable hostname from DHCP
+  # Set node's hostname from DHCP
   - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -32,6 +32,9 @@ ${repositories}
 packages:
   - haproxy
 
+# set hostname
+hostname: ${hostname}
+
 runcmd:
   # Since we are currently inside of the cloud-init systemd unit, trying to
   # start another service by either `enable --now` or `start` will create a
@@ -44,11 +47,8 @@ runcmd:
   - [ systemctl, restart, systemd-journald ]
   # LB firewall is not disabled via skuba, so we need to manually disable it
   - [ systemctl, disable, firewalld, --now ]
-
-
-bootcmd:
-  # Hostnames from DHCP - otherwise localhost will be used
+  # Disable hostname from DHCP
   - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
-  - /usr/bin/hostnamectl set-hostname ${hostname}
+  - systemctl restart wicked
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -48,7 +48,7 @@ runcmd:
   # LB firewall is not disabled via skuba, so we need to manually disable it
   - [ systemctl, disable, firewalld, --now ]
   # Disable hostname from DHCP
-  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"no\"#" /etc/sysconfig/network/dhcp
+  - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"#" /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 
 final_message: "The system is finally up, after $UPTIME seconds"

--- a/ci/infra/vmware/cloud-init/lb.tpl
+++ b/ci/infra/vmware/cloud-init/lb.tpl
@@ -47,7 +47,7 @@ runcmd:
   - [ systemctl, restart, systemd-journald ]
   # LB firewall is not disabled via skuba, so we need to manually disable it
   - [ systemctl, disable, firewalld, --now ]
-  # Disable hostname from DHCP
+  # Enable/Disable hostname from DHCP
   - /usr/bin/sed -ie "s#DHCLIENT_SET_HOSTNAME=\"yes\"#DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"#" /etc/sysconfig/network/dhcp
   - systemctl restart wicked
 

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -119,11 +119,12 @@ data "template_file" "lb_cloud_init_userdata" {
   count    = var.lbs
 
   vars = {
-    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
-    repositories    = join("\n", data.template_file.lb_repositories_template.*.rendered)
-    packages        = join("\n", formatlist("  - %s", var.packages))
-    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
-    hostname        = "${var.stack_name}-lb-${count.index}"
+    authorized_keys    = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories       = join("\n", data.template_file.lb_repositories_template.*.rendered)
+    packages           = join("\n", formatlist("  - %s", var.packages))
+    ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
+    hostname           = "${var.stack_name}-lb-${count.index}"
+    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
   }
 }
 

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -128,17 +128,17 @@ data "template_file" "lb_cloud_init_userdata" {
 }
 
 resource "vsphere_virtual_machine" "lb" {
-  count            = var.lbs
-  name             = "${var.stack_name}-lb-${count.index}"
-  num_cpus         = var.lb_cpus
-  memory           = var.lb_memory
-  guest_id         = var.guest_id
-  firmware         = var.firmware
-  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
-  resource_pool_id = data.vsphere_resource_pool.pool.id
-  datastore_id     = (var.vsphere_datastore == null ? null: data.vsphere_datastore.datastore[0].id)
+  count                = var.lbs
+  name                 = "${var.stack_name}-lb-${count.index}"
+  num_cpus             = var.lb_cpus
+  memory               = var.lb_memory
+  guest_id             = var.guest_id
+  firmware             = var.firmware
+  scsi_type            = data.vsphere_virtual_machine.template.scsi_type
+  resource_pool_id     = data.vsphere_resource_pool.pool.id
+  datastore_id         = (var.vsphere_datastore == null ? null : data.vsphere_datastore.datastore[0].id)
   datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
-  folder           = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
+  folder               = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
 
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id
@@ -219,4 +219,3 @@ resource "null_resource" "lb_push_haproxy_cfg" {
     ]
   }
 }
-

--- a/ci/infra/vmware/main.tf
+++ b/ci/infra/vmware/main.tf
@@ -8,13 +8,13 @@ data "vsphere_resource_pool" "pool" {
 }
 
 data "vsphere_datastore" "datastore" {
-  count         = var.vsphere_datastore == "null" ||  var.vsphere_datastore == null ? 0 : 1
+  count         = var.vsphere_datastore == "null" || var.vsphere_datastore == null ? 0 : 1
   name          = var.vsphere_datastore
   datacenter_id = data.vsphere_datacenter.dc.id
 }
 
 data "vsphere_datastore_cluster" "datastore" {
-  count         = var.vsphere_datastore_cluster == "null" ||  var.vsphere_datastore_cluster == null ? 0 : 1
+  count         = var.vsphere_datastore_cluster == "null" || var.vsphere_datastore_cluster == null ? 0 : 1
   name          = var.vsphere_datastore_cluster
   datacenter_id = data.vsphere_datacenter.dc.id
 }

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -49,13 +49,14 @@ data "template_file" "master_cloud_init_userdata" {
   count    = var.masters
 
   vars = {
-    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
-    repositories    = join("\n", data.template_file.master_repositories.*.rendered)
-    register_scc    = join("\n", data.template_file.master_register_scc.*.rendered)
-    register_rmt    = join("\n", data.template_file.master_register_rmt.*.rendered)
-    commands        = join("\n", data.template_file.master_commands.*.rendered)
-    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
-    hostname        = "${var.stack_name}-master-${count.index}"
+    authorized_keys    = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories       = join("\n", data.template_file.master_repositories.*.rendered)
+    register_scc       = join("\n", data.template_file.master_register_scc.*.rendered)
+    register_rmt       = join("\n", data.template_file.master_register_rmt.*.rendered)
+    commands           = join("\n", data.template_file.master_commands.*.rendered)
+    ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
+    hostname           = "${var.stack_name}-master-${count.index}"
+    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
   }
 }
 

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -60,19 +60,19 @@ data "template_file" "master_cloud_init_userdata" {
 }
 
 resource "vsphere_virtual_machine" "master" {
-  depends_on       = [vsphere_folder.folder]
+  depends_on = [vsphere_folder.folder]
 
-  count            = var.masters
-  name             = "${var.stack_name}-master-${count.index}"
-  num_cpus         = var.master_cpus
-  memory           = var.master_memory
-  guest_id         = var.guest_id
-  firmware         = var.firmware
-  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
-  resource_pool_id = data.vsphere_resource_pool.pool.id
-  datastore_id     = (var.vsphere_datastore == null ? null: data.vsphere_datastore.datastore[0].id)
+  count                = var.masters
+  name                 = "${var.stack_name}-master-${count.index}"
+  num_cpus             = var.master_cpus
+  memory               = var.master_memory
+  guest_id             = var.guest_id
+  firmware             = var.firmware
+  scsi_type            = data.vsphere_virtual_machine.template.scsi_type
+  resource_pool_id     = data.vsphere_resource_pool.pool.id
+  datastore_id         = (var.vsphere_datastore == null ? null : data.vsphere_datastore.datastore[0].id)
   datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
-  folder           = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
+  folder               = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
 
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id
@@ -100,7 +100,7 @@ resource "vsphere_virtual_machine" "master" {
 
 resource "null_resource" "master_wait_cloudinit" {
   depends_on = [vsphere_virtual_machine.master]
-  count = var.masters
+  count      = var.masters
 
   connection {
     host = element(
@@ -118,4 +118,3 @@ resource "null_resource" "master_wait_cloudinit" {
     ]
   }
 }
-

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -46,6 +46,7 @@ data "template_file" "master_cloud_init_metadata" {
 
 data "template_file" "master_cloud_init_userdata" {
   template = file("cloud-init/common.tpl")
+  count    = var.masters
 
   vars = {
     authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
@@ -54,6 +55,7 @@ data "template_file" "master_cloud_init_userdata" {
     register_rmt    = join("\n", data.template_file.master_register_rmt.*.rendered)
     commands        = join("\n", data.template_file.master_commands.*.rendered)
     ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
+    hostname        = "${var.stack_name}-master-${count.index}"
   }
 }
 
@@ -86,7 +88,7 @@ resource "vsphere_virtual_machine" "master" {
   extra_config = {
     "guestinfo.metadata"          = base64gzip(data.template_file.master_cloud_init_metadata.rendered)
     "guestinfo.metadata.encoding" = "gzip+base64"
-    "guestinfo.userdata"          = base64gzip(data.template_file.master_cloud_init_userdata.rendered)
+    "guestinfo.userdata"          = base64gzip(data.template_file.master_cloud_init_userdata[count.index].rendered)
     "guestinfo.userdata.encoding" = "gzip+base64"
   }
   enable_disk_uuid = var.cpi_enable == true ? true : false

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -68,3 +68,6 @@ ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.
 
 # Enable CPI integration with vSphere
 #cpi_enable = true
+
+# Enable node's hostname from DHCP server
+#hostname_from_dhcp = true

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -69,5 +69,5 @@ ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.
 # Enable CPI integration with vSphere
 #cpi_enable = true
 
-# Enable node's hostname from DHCP server
-#hostname_from_dhcp = true
+# Set node's hostname from DHCP server
+#hostname_from_dhcp = false

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -119,3 +119,8 @@ variable "cpi_enable" {
   default     = false
   description = "Enable CPI integration with vSphere"
 }
+
+variable "hostname_from_dhcp" {
+  default     = false
+  description = "Set node's hostname from DHCP server"
+}

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -122,5 +122,5 @@ variable "cpi_enable" {
 
 variable "hostname_from_dhcp" {
   default     = false
-  description = "Set node's hostname from DHCP server"
+  description = "Enable node's hostname from DHCP server"
 }

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -121,6 +121,6 @@ variable "cpi_enable" {
 }
 
 variable "hostname_from_dhcp" {
-  default     = false
-  description = "Enable node's hostname from DHCP server"
+  default     = true
+  description = "Set node's hostname from DHCP server"
 }

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -60,19 +60,19 @@ data "template_file" "worker_cloud_init_userdata" {
 }
 
 resource "vsphere_virtual_machine" "worker" {
-  depends_on       = [vsphere_folder.folder]
+  depends_on = [vsphere_folder.folder]
 
-  count            = var.workers
-  name             = "${var.stack_name}-worker-${count.index}"
-  num_cpus         = var.worker_cpus
-  memory           = var.worker_memory
-  guest_id         = var.guest_id
-  firmware         = var.firmware
-  scsi_type        = data.vsphere_virtual_machine.template.scsi_type
-  resource_pool_id = data.vsphere_resource_pool.pool.id
-  datastore_id     = (var.vsphere_datastore == null ? null: data.vsphere_datastore.datastore[0].id)
+  count                = var.workers
+  name                 = "${var.stack_name}-worker-${count.index}"
+  num_cpus             = var.worker_cpus
+  memory               = var.worker_memory
+  guest_id             = var.guest_id
+  firmware             = var.firmware
+  scsi_type            = data.vsphere_virtual_machine.template.scsi_type
+  resource_pool_id     = data.vsphere_resource_pool.pool.id
+  datastore_id         = (var.vsphere_datastore == null ? null : data.vsphere_datastore.datastore[0].id)
   datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
-  folder           = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
+  folder               = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
 
 
   clone {
@@ -101,7 +101,7 @@ resource "vsphere_virtual_machine" "worker" {
 
 resource "null_resource" "worker_wait_cloudinit" {
   depends_on = [vsphere_virtual_machine.worker]
-  count = var.workers
+  count      = var.workers
 
   connection {
     host = element(
@@ -119,4 +119,3 @@ resource "null_resource" "worker_wait_cloudinit" {
     ]
   }
 }
-

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -49,13 +49,14 @@ data "template_file" "worker_cloud_init_userdata" {
   count    = var.workers
 
   vars = {
-    authorized_keys = join("\n", formatlist("  - %s", var.authorized_keys))
-    repositories    = join("\n", data.template_file.worker_repositories.*.rendered)
-    register_scc    = join("\n", data.template_file.worker_register_scc.*.rendered)
-    register_rmt    = join("\n", data.template_file.worker_register_rmt.*.rendered)
-    commands        = join("\n", data.template_file.worker_commands.*.rendered)
-    ntp_servers     = join("\n", formatlist("    - %s", var.ntp_servers))
-    hostname        = "${var.stack_name}-worker-${count.index}"
+    authorized_keys    = join("\n", formatlist("  - %s", var.authorized_keys))
+    repositories       = join("\n", data.template_file.worker_repositories.*.rendered)
+    register_scc       = join("\n", data.template_file.worker_register_scc.*.rendered)
+    register_rmt       = join("\n", data.template_file.worker_register_rmt.*.rendered)
+    commands           = join("\n", data.template_file.worker_commands.*.rendered)
+    ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
+    hostname           = "${var.stack_name}-worker-${count.index}"
+    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
   }
 }
 
@@ -73,7 +74,6 @@ resource "vsphere_virtual_machine" "worker" {
   datastore_id         = (var.vsphere_datastore == null ? null : data.vsphere_datastore.datastore[0].id)
   datastore_cluster_id = (var.vsphere_datastore_cluster == null ? null : data.vsphere_datastore_cluster.datastore[0].id)
   folder               = var.cpi_enable == true ? vsphere_folder.folder[0].path : null
-
 
   clone {
     template_uuid = data.vsphere_virtual_machine.template.id


### PR DESCRIPTION
## Why is this PR needed?

With vSphere `cpi_enable=true` and bootstrapping a cluster with `cloud-provider=vsphere`, the node name has to be the node hostname.

Current CaaSP vSphere environment, the deployed node's hostname is the DNS name, this makes the user have to find the current hostname via the vSphere web client, not the terraform output.

Therefore, for user experience _or_ automation tests, it better supports to set node's hostname from DHCP server.

## What does this PR do?

Setup hostname by cloud-init and reload wicked daemon to apply a new DHCP configuration.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together: #1050
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

After terraform apply, the node's hostname is a 6 octets number (comes from DHCP server).

```
$ terraform output
ip_load_balancer = {
  "jenting-vsphere-cloud-provider-lb-0" = "10.84.72.14"
}
ip_masters = {
  "jenting-vsphere-cloud-provider-master-0" = "10.84.72.212"
}
ip_workers = {
  "jenting-vsphere-cloud-provider-worker-0" = "10.84.72.57"
  "jenting-vsphere-cloud-provider-worker-1" = "10.84.73.118"
}
```

```
$ skuba cluster init --control-plane 10.84.72.14 --cloud-provider vsphere my-cluster
$ cd my-cluster
$ cp cloud/vsphere/vsphere.conf.template cloud/vsphere/vsphere.conf
$ vim cloud/vsphere/vsphere.conf
$ skuba node bootstrap -s -u sles -t 10.84.72.212 <master-0-node-6-octets-number> -v 5
$ skuba node join --role worker -s -u sles -t 10.84.72.57 <worker-0-node-6-octets-number> -v 5
$ skuba node join --role worker -s -u sles -t 10.84.73.118 <worker-1-node-6-octets-number> -v 5
```

### Status **AFTER** applying the patch

Set `hostname_from_dhcp = false` and after terraform apply, the node's hostname is the same as `terraform output` hostname.

```
$ vim terraform.tfvars
hostname_from_dhcp = false

$ terraform output
ip_load_balancer = {
  "jenting-vsphere-cloud-provider-lb-0" = "10.84.72.14"
}
ip_masters = {
  "jenting-vsphere-cloud-provider-master-0" = "10.84.72.212"
}
ip_workers = {
  "jenting-vsphere-cloud-provider-worker-0" = "10.84.72.57"
  "jenting-vsphere-cloud-provider-worker-1" = "10.84.73.118"
}
```

```
$ skuba cluster init --control-plane 10.84.72.14 --cloud-provider vsphere my-cluster
$ cd my-cluster
$ cp cloud/vsphere/vsphere.conf.template cloud/vsphere/vsphere.conf
$ vim cloud/vsphere/vsphere.conf
$ skuba node bootstrap -s -u sles -t 10.84.72.212 jenting-vsphere-cloud-provider-master-0 -v 5
$ skuba node join --role worker -s -u sles -t 10.84.72.57 jenting-vsphere-cloud-provider-worker-0 -v 5
$ skuba node join --role worker -s -u sles -t 10.84.73.118 jenting-vsphere-cloud-provider-worker-1 -v 5
```

1. Check node's hostname did not change after bootstrapping a k8s cluster
2. Check node's hostname did not change after node reboot

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
