### PR TITLE
Update to Kubernetes v1.18.2

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -85,16 +85,16 @@ type ClusterAddonsKnownVersions = func(clusterVersion *version.Version) AddonsVe
 
 var (
 	supportedVersions = KubernetesVersions{
-		"1.18.0": KubernetesVersion{
+		"1.18.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
-				KubeletVersion:          "1.18.0",
+				KubeletVersion:          "1.18.2",
 				ContainerRuntimeVersion: "1.18.0",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
-				APIServer:         &ContainerImageTag{Name: "api-server", Tag: "v1.18.0"},
-				ControllerManager: &ContainerImageTag{Name: "controller-manager", Tag: "v1.18.0"},
-				Scheduler:         &ContainerImageTag{Name: "scheduler", Tag: "v1.18.0"},
-				Proxy:             &ContainerImageTag{Name: "proxy", Tag: "v1.18.0"},
+				APIServer:         &ContainerImageTag{Name: "api-server", Tag: "v1.18.2"},
+				ControllerManager: &ContainerImageTag{Name: "controller-manager", Tag: "v1.18.2"},
+				Scheduler:         &ContainerImageTag{Name: "scheduler", Tag: "v1.18.2"},
+				Proxy:             &ContainerImageTag{Name: "proxy", Tag: "v1.18.2"},
 				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
 				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
 				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.2"},

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -374,7 +374,7 @@ func TestMajorMinorVersion(t *testing.T) {
 func TestEnsureHyperKubeIsRemovedForSupportedVersions(t *testing.T) {
 	for kubernetesVersionStr := range supportedVersions {
 		kubernetesVersion := version.MustParseSemantic(kubernetesVersionStr)
-		versionComparedTo118, err := kubernetesVersion.Compare("1.18.0")
+		versionComparedTo118, err := kubernetesVersion.Compare("1.18.2")
 		if err != nil {
 			t.Fatalf("our versions should always be valid semver and something bad happened: %+v", err)
 		}


### PR DESCRIPTION
## Why is this PR needed?

Update to Kubernetes v1.18.2

## What does this PR do?

Upgrading  Kubernetes to v1.18.2

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

