### PR TITLE
Streamline testrunner configuration

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -29,7 +29,7 @@ all: provision deploy
 
 .PHONY: provision 
 provision:
-	${TEST_RUNNER} --platform ${PLATFORM} provision
+	${TEST_RUNNER} --platform ${PLATFORM} -c provision
 
 .PHONY: bootstrap
 bootstrap:

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -138,16 +138,17 @@ log_dir: "/path/to/log/dir/
 General setting for terraform-based platforms such as [Openstack](#openstack) and [VMware](#vmware). 
 
 * internal_net: name of the network used when provisioning the platform. Defaults to `stack_name`
+* lb: specifications for the load balancer(s)
+* nodeuser: the user name used to login into the platform nodes. Optional.
+* master: specifications for the master(s)
 * plugin_dir: directory used for retrieving terraform plugins. If not set, plugins are installed using terraform [discovery mechanism](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery)
 * retries: maximum number of attempts to recover from failures during terraform provisioning 
+* ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
 * stack name: the unique name of the platform stack on the shared infrastructure, used as prefix by many resources such as networks, nodes, among others. Default is "$USER" 
 * tfdir: path to the terraform files. Testrunner must have writing permissions to this directory. Defaults to `$WORKSPACE/skuba/ci/infra`.
 * tfvars: name of the terraform variables file to be used. Defaults to "terraform.tfvars.json.ci.example"
-- nodeuser: the user name used to login into the platform nodes. Optional.
-- ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
-- lb: specifications for the load balancer(s)
-- master: specifications for the master(s)
-- worker: specifications for the worker(s)
+* workdir: working directory on which tfout file will be generated
+* worker: specifications for the worker(s)
 
 Example
 ```

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -98,13 +98,12 @@ The following sections document the configuration options. The CLI arguments are
 
 This section configures the working environment and is generally specific of each user of CI job-
 
-- workspace: path to the testrunner's working directory 
-- username: user name for the user. It's optional. If `platform.stack_name` is not set, `username` is used.
-- log_dir: path to the directory where platform logs are collected. Defaults to `<workspace>/platform_logs`
+- workspace: path to the testrunner's working directory. Defaults to `$HOME/workspace`
+- log_dir: path to the directory where platform logs are collected. Defaults to `$WORKSPACE/platform_logs`
 
 ```
 workspace: "/path/to/your/workspace" 
-username: "username"
+log_dir: "/path/to/log/dir/
 ```
 
 #### Packages
@@ -133,8 +132,8 @@ General setting for terraform-based platforms such as [Openstack](#openstack) an
 * internal_net: name of the network used when provisioning the platform. Defaults to `stack_name`
 * plugin_dir: directory used for retrieving terraform plugins. If not set, plugins are installed using terraform [discovery mechanism](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery)
 * retries: maximum number of attempts to recover from failures during terraform provisioning 
-* stack name: the unique name of the platform stack on the shared infrastructure, used as prefix by many resources such as networks, nodes, among others. If not specified, the `username` is used.
-* tfdir: path to the terraform files. Testrunner must have writing permissions to this directory. Defaults to `skuba.srcpath/ci/infra`.
+* stack name: the unique name of the platform stack on the shared infrastructure, used as prefix by many resources such as networks, nodes, among others. Default is "$USER" 
+* tfdir: path to the terraform files. Testrunner must have writing permissions to this directory. Defaults to `$WORKSPACE/skuba/ci/infra`.
 * tfvars: name of the terraform variables file to be used. Defaults to "terraform.tfvars.json.ci.example"
 - nodeuser: the user name used to login into the platform nodes. Optional.
 - ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
@@ -170,16 +169,14 @@ vmware:
 
 ### Skuba
 
-The Skuba section defines the location and execution options for the `skuba` command. As `testrunner` can be used either from a local development or testing environment or a CI pipeline, the configuration allows to define the location of both the source and the binary. Please notice that the source location is used as default location for other configuration elements, such as terraform files, even if the `skuba` binary is specified. 
+The Skuba section defines the location and execution options for the `skuba` command. As `testrunner` can be used either from a local development or testing environment or a CI pipeline, the configuration allows to define the location of the binary.
 
 * binpath: path to skuba binary
-* srcpath: path to skuba source. Used to locate other resources, like terraform configuration.
 * verbosity: verbosity level for skuba command execution
 
 ```
 skuba:
   binpath: "/usr/bin/"
-  srcpath: "/go/src/github.com/SUSE/skuba"
   verbosity: 5
 ```
 
@@ -227,7 +224,6 @@ Copy `vars.yaml` to `/path/to/myvars.yaml`, set the variables according to your 
 
 ```
 workspace: "/path/to/workspace"
-username:  "my-user-test"
 ```
 
 
@@ -237,27 +233,35 @@ Set the `skuba` and `terraform parameters depending on how you are testing `skub
 * If testing from local source:
 ```
   skuba:
-    srcpath: "/path/to/local/skuba/repo"
     binpath: "path/to/go/bin/directory"
 ```
 
-Be sure you don't specify the `terraform.tfdir` directory, so terraform configuration from the local `skuba` repo are used.
+Be sure you `terraform.tfdir` directory to point to the `ci/infra` directory in the local `skuba` repo:
+```
+  terraform:
+    tfdir: "/path/to/local/skuba/repo/ci/infra"
+```
 
 
 * If testing from installed package
 
+Use skuba binary installed from the package
 ```
   skuba:
     binpath: "/usr/bin/"
+```
 
+You must copy the terraform files installed from the package to a work directory and set the `tfdir` directory accordingly:
+```
   terraform:
     tfdir: "/path/to/terraform/files"
 ```
 
-You use your `id_rsa` keys to connect to the cluster nodes, as the `shared_id` is not available.
+You must provide the ssh key to connect to the cluster nodes, as the `shared_id` key used in development is not available. By default, your `id_rsa` key will be used, but you can provide any key:
 
 ```
-ssh_key: "path/to/id_rsa"
+  terraform:
+    ssh_key: "path/to/id_rsa"
 ```
 
 #### Open Stack
@@ -334,7 +338,6 @@ Jenkins checks out the `skuba` repository under the `workspace` directory and ge
 
 ```
 skuba:
-  srcpath: ""
   binpath: ""
 ``` 
  

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -399,15 +399,16 @@ usage:
     This script supposed to run on python virtualenv from testrunner. Requires root privileges.
     Warning: it removes docker containers, VMs, images, and network configuration.
 
-       [-h] [-v YAML_PATH] [-p {openstack,vmware,bare-metal,libvirt}]
+       [-h] [-v YAML_PATH] [-p {openstack,vmware,bare-metal,libvirt}] [-c]
        [-l {DEBUG,INFO,WARNING,ERROR}]
-       {info,get_logs,cleanup,provision,bootstrap,deploy,status,cluster-upgrade-plan,join-node,remove-node,node-upgrade,join-nodes,ssh,test,inhibit_kured}
+       {info,config,get_logs,cleanup,provision,bootstrap,deploy,status,cluster-upgrade-plan,join-node,remove-node,node-upgrade,join-nodes,ssh,test,inhibit_kured}
        ...
 
 positional arguments:
   {info,get_logs,cleanup,provision,bootstrap,deploy,status,cluster-upgrade-plan,join-node,remove-node,node-upgrade,join-nodes,ssh,test,inhibit_kured}
                         command
     info                ip info
+    config              print configuration 
     get_logs            gather logs from nodes
     cleanup             cleanup created skuba environment
     provision           provision nodes for cluster in your configured
@@ -425,6 +426,18 @@ positional arguments:
     ssh                 Execute command in node via ssh.
     test                execute tests
     inhibit_kured       Prevent kured to reboot nodes
+
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v YAML_PATH, --vars YAML_PATH
+                        path for platform yaml file. Default is vars.yaml. eg:
+                        -v myconfig.yaml
+  -p {openstack,vmware,bare-metal,libvirt}, --platform {openstack,vmware,bare-metal,libvirt}
+                        The platform you're targeting. Default is openstack
+  -l {DEBUG,INFO,WARNING,ERROR}, --log-level {DEBUG,INFO,WARNING,ERROR}
+                        log level
+  -c, --print-conf      prints the configuration
 
 ```
 

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -179,13 +179,16 @@ vmware:
 
 The Skuba section defines the location and execution options for the `skuba` command. As `testrunner` can be used either from a local development or testing environment or a CI pipeline, the configuration allows to define the location of the binary.
 
-* binpath: path to skuba binary
+* binpath: path to skuba binary. Default is "$WORKSPACE/go/bin/skuba"
+* cluster: name of the cluster. Default is "test-cluster"
 * verbosity: verbosity level for skuba command execution
+* workdir: working directory on which cluster is initialized. Default is "$WORKSPACE"
 
+Example:
 ```
 skuba:
-  binpath: "/usr/bin/"
-  verbosity: 5
+  binpath: "/usr/bin/skuba"
+  verbosity: 10
 ```
 
 ### Kubectl

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -7,6 +7,7 @@
 - [Configuration](#configuration-parameters)
   - [Work Environment](#work-environment)
   - [Packages](#packages)
+  - [Utils](#utils)
   - [Platform](#platform)
     - [Terraform](#terraform)
     - [Openstack](#openstack)
@@ -123,6 +124,18 @@ packages:
 * mirror: URL for the repository mirrors to be used when setting up the skuba nodes, replacing the URL of the repositories defined in terraform. Used, for instance, to switch to development repositories or internal repositories when running in the CI pipeline.
 * registry_code: code use for registering CaaSP product. If specified, the registries from the tfvars are ignored. Additional repositories can still be defined using the `maintenance` configuration parameter.
 
+
+### Utils
+
+This section configures the utils module used for executing commands.
+
+* ssh_sock: name of the socket used to communicate with the ssh-agent. Default is /tmp/testrunner_ssh_sock'
+
+Example:
+```
+utils:
+  ssh_sock: "/path/to/ssh-agent/socket"
+```
 ### Platform
 
 This section configures general platform-independent parameters. Platform dependent parameters are defined in the corresponding sections (Terraform, Openstack, VMware)

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -215,7 +215,7 @@ The kubectl section defines the configuration of the kubectl tool.
 
 Testrunner sends output to both a console and file logger handlers, configured using the following `log` variables:
 
-* file: name of the file used to send a copy of the log with verbosity `DEBUG`. This file is located under the `workspace` directory.
+* file: path to the file used to send a copy of the log with verbosity `DEBUG`. Default is "$WORKSPACE/testrunner.log"
 * level: debug verbosity level to console. Can be any of `DEBUG`, `INFO`, `WARNING`, `ERROR`. Defaults to `INFO`.
 * overwrite: boolean that indicates if the content of the log file must be overwritten (`True`) or log entries must be appended at the end of the file if it exists. Defaults to `False` (do not overwrite) 
 * quiet: boolean that indicates if `testrunner` will send any output to console (`False`) or not will execute silently (`True`). Quiet mode is useful when `testrunner` is used as a library. Defaults to `False`.

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -118,6 +118,7 @@ packages:
 
 This section configures the utils module used for executing commands.
 
+* ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`.
 * ssh_sock: name of the socket used to communicate with the ssh-agent. Default is /tmp/testrunner_ssh_sock'
 
 Example:
@@ -145,7 +146,6 @@ General setting for terraform-based platforms such as [Openstack](#openstack) an
 * master: specifications for the master(s)
 * plugin_dir: directory used for retrieving terraform plugins. If not set, plugins are installed using terraform [discovery mechanism](https://www.terraform.io/docs/extend/how-terraform-works.html#discovery)
 * retries: maximum number of attempts to recover from failures during terraform provisioning 
-* ssh_key: specifies the location of the key used to access nodes. The default is to use the user's key located at `$HOME/.ssh/id_rsa`
 * stack name: the unique name of the platform stack on the shared infrastructure, used as prefix by many resources such as networks, nodes, among others. Default is "$USER" 
 * tfdir: path to the terraform files. Testrunner must have writing permissions to this directory. Defaults to `$WORKSPACE/skuba/ci/infra`.
 * tfvars: name of the terraform variables file to be used. Defaults to "terraform.tfvars.json.ci.example"
@@ -273,7 +273,7 @@ You must copy the terraform files installed from the package to a work directory
 You must provide the ssh key to connect to the cluster nodes, as the `shared_id` key used in development is not available. By default, your `id_rsa` key will be used, but you can provide any key:
 
 ```
-  terraform:
+  utils:
     ssh_key: "path/to/id_rsa"
 ```
 

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -5,7 +5,6 @@
 - [Summary](#summary)
 - [Design](#design)
 - [Configuration](#configuration-parameters)
-  - [Work Environment](#work-environment)
   - [Packages](#packages)
   - [Utils](#utils)
   - [Platform](#platform)
@@ -90,20 +89,10 @@ It is worth noticing that tests can be executed directly using pytest, but it is
 Testrunner provides configuration by means of:
  
 - A yaml configuration file (defaults to `vars.yaml` in current directory)
-- Environment variables that override the configuration. Every configuration option of the form `<section>.<variable>' can be subtituted by an environment variable `SECTION_VARIABLE. Notice that some variables are defined in the "root" section (e.g `workspace`). For example `skuba.binpath` is overriden by `SKUBA_BINPATH` and `workspace` by `WORKSPACE`
+- Environment variables that override the configuration. Every configuration option of the form `<section>.<variable>' can be subtituted by an environment variable `SECTION_VARIABLE. For example `skuba.binpath` is overriden by `SKUBA_BINPATH`.
 - CLI options which override configuration parameters such as the logging level (see [Usage](#usage))
 
 The following sections document the configuration options. The CLI arguments are described in the [Usage section](#usage).
-
-### Work Environment
-
-This section configures the working environment and is generally specific of each user of CI job-
-
-- workspace: path to the testrunner's working directory. Defaults to `$HOME/workspace`
-
-```
-workspace: "/path/to/your/workspace" 
-```
 
 #### Packages
 The `packages` section configures the source of the packages to be installed in the nodes:
@@ -160,7 +149,7 @@ General setting for terraform-based platforms such as [Openstack](#openstack) an
 * stack name: the unique name of the platform stack on the shared infrastructure, used as prefix by many resources such as networks, nodes, among others. Default is "$USER" 
 * tfdir: path to the terraform files. Testrunner must have writing permissions to this directory. Defaults to `$WORKSPACE/skuba/ci/infra`.
 * tfvars: name of the terraform variables file to be used. Defaults to "terraform.tfvars.json.ci.example"
-* workdir: working directory on which tfout file will be generated
+* workdir: working directory on which tfout file will be generated. Default is `$WORKSPACE`
 * worker: specifications for the worker(s)
 
 Example
@@ -244,11 +233,10 @@ Copy `vars.yaml` to `/path/to/myvars.yaml`, set the variables according to your 
 
 #### Work Environment
 
-`testrunner` requires a working directory, which is specified in the `workspace` configuration parameter. The content of this directory can be erased or overwritten by `testrunner`. Be sure you create a directory to be used as workspace which is not located under your local working copy of the `skuba` project.
-
+Different components of `testrunner` requires a working directory. In particular, skuba for maintaining the test cluster configuration. The content of this directory can be erased or overwritten by `testrunner`. Be sure you create a directory to be used as workspace which is NOT located under your local working copy of the `skuba` project. By default, the working directory is taken from environment variable `WORKSPACE`:
 
 ```
-workspace: "/path/to/workspace"
+export WORKSPACE="/path/to/workspace"
 ```
 
 
@@ -258,7 +246,7 @@ Set the `skuba` and `terraform parameters depending on how you are testing `skub
 * If testing from local source:
 ```
   skuba:
-    binpath: "path/to/go/bin/directory"
+    binpath: "/path/to/go/bin/directory"
 ```
 
 Be sure you `terraform.tfdir` directory to point to the `ci/infra` directory in the local `skuba` repo:

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -99,11 +99,9 @@ The following sections document the configuration options. The CLI arguments are
 This section configures the working environment and is generally specific of each user of CI job-
 
 - workspace: path to the testrunner's working directory. Defaults to `$HOME/workspace`
-- log_dir: path to the directory where platform logs are collected. Defaults to `$WORKSPACE/platform_logs`
 
 ```
 workspace: "/path/to/your/workspace" 
-log_dir: "/path/to/log/dir/
 ```
 
 #### Packages
@@ -124,6 +122,16 @@ packages:
 ```
 * mirror: URL for the repository mirrors to be used when setting up the skuba nodes, replacing the URL of the repositories defined in terraform. Used, for instance, to switch to development repositories or internal repositories when running in the CI pipeline.
 * registry_code: code use for registering CaaSP product. If specified, the registries from the tfvars are ignored. Additional repositories can still be defined using the `maintenance` configuration parameter.
+
+### Platform
+
+This section configures general platform-independent parameters. Platform dependent parameters are defined in the corresponding sections (Terraform, Openstack, VMware)
+
+- log_dir: path to the directory where platform logs are collected. Defaults to `$WORKSPACE/platform_logs`
+
+```
+log_dir: "/path/to/log/dir/
+```
 
 #### Terraform
 

--- a/ci/infra/testrunner/platforms/openstack.py
+++ b/ci/infra/testrunner/platforms/openstack.py
@@ -16,6 +16,7 @@ class Openstack(Terraform):
         if not self.conf.terraform.internal_net:
             self.conf.terraform.internal_net = self.conf.terraform.stack_name
 
+
     def _env_setup_cmd(self):
         return f"source {self.conf.openstack.openrc}"
 

--- a/ci/infra/testrunner/platforms/openstack.py
+++ b/ci/infra/testrunner/platforms/openstack.py
@@ -27,9 +27,9 @@ class Openstack(Terraform):
 
         self.destroy(variables)
 
-    def setup_cloud_provider(self):
+    def setup_cloud_provider(self,config_dir):
         openstack_conf_template = ""
-        for root, dirs, files in os.walk(self.conf.workspace):
+        for root, dirs, files in os.walk(config_dir):
             for f in files:
                 if f == "openstack.conf.template":
                     openstack_conf_template = os.path.join(root, f)

--- a/ci/infra/testrunner/platforms/openstack.py
+++ b/ci/infra/testrunner/platforms/openstack.py
@@ -13,7 +13,8 @@ class Openstack(Terraform):
             raise ValueError(Format.alert(f"Your openrc file path \"{conf.openstack.openrc}\" does not exist.\n\t    "
                                           "Check your openrc file path in a configured yaml file"))
         self.platform_new_vars = {}
-
+        if not self.conf.terraform.internal_net:
+            self.conf.terraform.internal_net = self.conf.terraform.stack_name
 
     def _env_setup_cmd(self):
         return f"source {self.conf.openstack.openrc}"

--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -103,14 +103,12 @@ class Platform:
         if num_master > -1 or num_worker > -1:
             logger.warning("Overriding number of nodes")
             if num_master > -1:
-                self.conf.terraform.master.count = num_master
                 logger.warning("   Masters:{} ".format(num_master))
 
             if num_worker > -1:
-                self.conf.terraform.worker.count = num_worker
                 logger.warning("   Workers:{} ".format(num_worker))
 
-        self._provision_platform()
+        self._provision_platform(num_master, num_worker)
 
     def ssh_run(self, role, nr, cmd):
         ip_addrs = self.get_nodes_ipaddrs(role)

--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -47,13 +47,13 @@ class Platform:
             "worker": self.get_nodes_ipaddrs("worker")
         }
 
-        if not os.path.isdir(self.conf.log_dir):
-            os.mkdir(self.conf.log_dir)
-            logger.info(f"Created log dir {self.conf.log_dir}")
+        if not os.path.isdir(self.conf.platform.log_dir):
+            os.mkdir(self.conf.platform.log_dir)
+            logger.info(f"Created log dir {self.conf.platform.log_dir}")
 
         for node_type in node_ips:
             for ip_address in node_ips[node_type]:
-                node_log_dir = self._create_node_log_dir(ip_address, node_type, self.conf.log_dir)
+                node_log_dir = self._create_node_log_dir(ip_address, node_type, self.conf.platform.log_dir)
                 logging_error = self.utils.collect_remote_logs(ip_address, self.logs, node_log_dir)
 
                 if logging_error:
@@ -109,7 +109,6 @@ class Platform:
             if num_worker > -1:
                 self.conf.terraform.worker.count = num_worker
                 logger.warning("   Workers:{} ".format(num_worker))
-
 
         self._provision_platform()
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -14,6 +14,9 @@ logger = logging.getLogger('testrunner')
 class Terraform(Platform):
     def __init__(self, conf, platform):
         super().__init__(conf)
+        if not conf.terraform.stack_name:
+            raise ValueError("a terraform stack name must be specified")
+
         self.tfdir = os.path.join(self.conf.terraform.tfdir, platform)
         self.tfjson_path = os.path.join(conf.workspace, "tfout.json")
         self.tfout_path = os.path.join(self.conf.workspace, "tfout")
@@ -86,7 +89,7 @@ class Terraform(Platform):
 
     def get_nodes_names(self, role):
         stack_name = self.stack_name()
-        return [f'caasp-{role}-{stack_name}-{i}' for i in range(self.get_num_nodes(role))] 
+        return [f'caasp-{role}-{stack_name}-{i}' for i in range(self.get_num_nodes(role))]
 
     def get_nodes_ipaddrs(self, role):
         self._load_tfstate()
@@ -131,7 +134,7 @@ class Terraform(Platform):
          stack_name = stack_name.replace("_","-").replace("/","-")
          stack_name = stack_name.strip("-.")
          stack_name = stack_name.lower()
-   
+
          return stack_name
 
     def _update_tfvars(self, tfvars):
@@ -178,7 +181,7 @@ class Terraform(Platform):
                 url_parsed = urlparse(url)
                 url_updated = url_parsed._replace(netloc=self.conf.packages.mirror)
                 tfvars["repositories"][name] = url_updated.geturl()
-	
+
         if self.conf.packages.additional_pkgs:
             tfvars["packages"].extend(self.conf.packages.additional_pkgs)
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -193,12 +193,6 @@ class Terraform(Platform):
     def _run_terraform_command(self, cmd, env={}):
         """Running terraform command in {terraform.tfdir}/{platform}"""
         cmd = f'{self._env_setup_cmd()}; terraform {cmd}'
-
-        # Terraform needs PATH and SSH_AUTH_SOCK
-        sock_fn = self.utils.ssh_sock_fn()
-        env["SSH_AUTH_SOCK"] = sock_fn
-        env["PATH"] = os.environ['PATH']
-
         self.utils.runshellcommand(cmd, cwd=self.tfdir, env=env)
 
     def _check_tf_deployed(self):

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -18,8 +18,8 @@ class Terraform(Platform):
             raise ValueError("a terraform stack name must be specified")
 
         self.tfdir = os.path.join(self.conf.terraform.tfdir, platform)
-        self.tfjson_path = os.path.join(conf.workspace, "tfout.json")
-        self.tfout_path = os.path.join(self.conf.workspace, "tfout")
+        self.tfjson_path = os.path.join(self.conf.terraform.workdir, "tfout.json")
+        self.tfout_path = os.path.join(self.conf.terraform.workdir, "tfout")
         self.state = None
 
         self.logs["files"] += ["/var/run/cloud-init/status.json",

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -37,8 +37,13 @@ class Terraform(Platform):
 
         self._run_terraform_command(cmd)
 
-    def _provision_platform(self):
-        """ Create and apply terraform plan"""
+    def _provision_platform(self, masters=-1, workers=-1):
+
+        if masters > -1:
+            self.conf.terraform.master.count = masters
+        if workers > -1:
+            self.conf.terraform.worker.count = workers
+
         exception = None
         self._check_tf_deployed()
 

--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import hcl
 
 from platforms.platform import Platform
-from utils import (Format, step)
+from utils import (Format, step, Utils)
 
 logger = logging.getLogger('testrunner')
 
@@ -20,6 +20,7 @@ class Terraform(Platform):
         self.tfdir = os.path.join(self.conf.terraform.tfdir, platform)
         self.tfjson_path = os.path.join(self.conf.terraform.workdir, "tfout.json")
         self.tfout_path = os.path.join(self.conf.terraform.workdir, "tfout")
+        self.utils = Utils(conf)
         self.state = None
 
         self.logs["files"] += ["/var/run/cloud-init/status.json",
@@ -146,7 +147,7 @@ class Terraform(Platform):
         new_vars = {
             "internal_net": self.conf.terraform.internal_net,
             "stack_name": self.stack_name(),
-            "username": self.conf.terraform.nodeuser,
+            "username": self.utils.ssh_user(),
             "masters": self.conf.terraform.master.count,
             "master_memory": self.conf.terraform.master.memory,
             "master_vcpu": self.conf.terraform.master.cpu,

--- a/ci/infra/testrunner/platforms/vmware.py
+++ b/ci/infra/testrunner/platforms/vmware.py
@@ -35,7 +35,7 @@ class VMware(Terraform):
             "services": ["haproxy"]
         }
 
-        node_log_dir = self._create_node_log_dir(node_ip, "load_balancer", self.conf.log_dir)
+        node_log_dir = self._create_node_log_dir(node_ip, "load_balancer", self.conf.platform.log_dir)
         logging_error = self.utils.collect_remote_logs(node_ip, logs, node_log_dir)
 
         return logging_error

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -218,14 +218,8 @@ class Skuba:
             raise ValueError(f"verbosity '{verbosity}' is not an int")
         verbosity = v
 
-        env = {
-            "SSH_AUTH_SOCK": self.utils.ssh_sock_fn(),
-            "PATH": os.environ['PATH']
-        }
-
         return self.utils.runshellcommand(
             f"{self.binpath} -v {verbosity} {cmd}",
             cwd=cwd,
-            env=env,
             ignore_errors=ignore_errors,
         )

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -83,7 +83,7 @@ class Skuba:
 
         master0_ip = self.platform.get_nodes_ipaddrs("master")[0]
         master0_name = self.platform.get_nodes_names("master")[0]
-        cmd = (f'node bootstrap --user {self.conf.terraform.nodeuser} --sudo --target '
+        cmd = (f'node bootstrap --user {self.utils.ssh_user()} --sudo --target '
                f'{master0_ip} {master0_name}')
         self._run_skuba(cmd)
 
@@ -104,7 +104,7 @@ class Skuba:
             raise Exception(f'Node {role}-{nr} is not deployed in '
                             'infrastructure')
 
-        cmd = (f'node join --role {role} --user {self.conf.terraform.nodeuser} '
+        cmd = (f'node join --role {role} --user {self.utils.ssh_user()} '
                f' --sudo --target {ip_addrs[nr]} {node_names[nr]}')
         try:
             self._run_skuba(cmd)
@@ -166,7 +166,7 @@ class Skuba:
             cmd = f'node upgrade plan {node_names[nr]}'
         elif action == "apply":
             ip_addrs = self.platform.get_nodes_ipaddrs(role)
-            cmd = (f'node upgrade apply --user {self.conf.terraform.nodeuser} --sudo'
+            cmd = (f'node upgrade apply --user {self.utils.ssh_user()} --sudo'
                    f' --target {ip_addrs[nr]}')
         else:
             raise ValueError("Invalid action '{}'".format(action))

--- a/ci/infra/testrunner/utils/__init__.py
+++ b/ci/infra/testrunner/utils/__init__.py
@@ -1,4 +1,4 @@
-from utils.constants import (BaseConfig, Constant)
+from utils.config import (BaseConfig, Constant)
 from utils.format import Format
 from utils.logger import Logger
 from utils.utils import (Utils, step)

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -51,6 +51,8 @@ class BaseConfig:
     class Utils:
         def __init__(self):
             self.ssh_sock =  "/tmp/testrunner_ssh_sock"
+            self.ssh_key = "$HOME/.ssh/id_rsa"
+            self.ssh_user = "sles"
 
     class Platform:
         def __init__(self):
@@ -71,8 +73,6 @@ class BaseConfig:
             self.tfdir = "$WORKSPACE/skuba/ci/infra"
             self.tfvars = Constant.TERRAFORM_EXAMPLE
             self.plugin_dir = None
-            self.ssh_key = "$HOME/.ssh/id_rsa"
-            self.nodeuser = None
             self.lb = BaseConfig.NodeConfig()
             self.master = BaseConfig.NodeConfig()
             self.worker = BaseConfig.NodeConfig()
@@ -144,7 +144,7 @@ class BaseConfig:
         """ Set values for configuration attributes
         The order of precedence is:
         - An environment variable exists with the fully qualified name of the
-          attribute
+          attribute (e.g SKUBA_BINPATH)
         - The attribute from vars
         - default value for configuration
 

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -77,6 +77,7 @@ class BaseConfig:
             self.retries = 5
             self.internal_net = None
             self.stack_name = "$USER"
+            self.workdir = "$WORKSPACE"
             self.tfdir = "$WORKSPACE/skuba/ci/infra"
             self.tfvars = Constant.TERRAFORM_EXAMPLE
             self.plugin_dir = None

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -1,5 +1,6 @@
 import os
 import string
+import sys
 
 import yaml
 
@@ -124,6 +125,18 @@ class BaseConfig:
             self.registry_code = None
             self.additional_repos = None
             self.additional_pkgs = None
+
+    @staticmethod
+    def print(config, level=0, out=sys.stdout):
+        """ Prints the configuration
+        """
+        print(f'{"  "*level}{config.__class__.__name__}:', file=out)
+        for key, value in config.__dict__.items():
+            if isinstance(value, BaseConfig.config_classes):
+                BaseConfig.print(value, level=level+1, out=out)
+                continue
+
+            print(f'{"  "*(level+1)}{key}: {value}', file=out)
 
     @staticmethod
     def get_yaml_path(yaml_path):

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -178,7 +178,7 @@ class BaseConfig:
     @staticmethod
     def finalize(conf):
         """ Finalize configuration.
-            Deprecated. Will be removed
+        Deprecated. Will be removed
         """
         return conf
 

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -95,6 +95,8 @@ class BaseConfig:
     class Kubectl:
         def __init__(self):
             super().__init__()
+            self.workdir = "$WORKSPACE"
+            self.cluster = "test-cluster"
             self.binpath = "/usr/bin/kubectl"
             self.kubeconfig = "$WORKSPACE/test-cluster/admin.conf"
 

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -19,8 +19,7 @@ class BaseConfig:
         obj = super().__new__(cls, *args, **kwargs)
         obj.yaml_path = yaml_path
         obj.workspace = "$HOME/workspace"
-        obj.log_dir = "$WORKSPACE/platform_logs"
-
+        obj.platform  = BaseConfig.Platform()
         obj.terraform = BaseConfig.Terraform()
         obj.openstack = BaseConfig.Openstack()
         obj.vmware = BaseConfig.VMware()
@@ -32,6 +31,7 @@ class BaseConfig:
         obj.kubectl = BaseConfig.Kubectl()
 
         config_classes = (
+            BaseConfig.Platform,
             BaseConfig.Packages,
             BaseConfig.NodeConfig,
             BaseConfig.Test,
@@ -61,6 +61,10 @@ class BaseConfig:
             self.cpu = cpu
             self.ips = []
             self.external_ips = []
+
+    class Platform:
+        def __init__(self):
+            self.log_dir = "$WORKSPACE/platform_logs"
 
     class Openstack:
         def __init__(self):

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -29,6 +29,7 @@ class BaseConfig:
         obj.log = BaseConfig.Log()
         obj.packages = BaseConfig.Packages()
         obj.kubectl = BaseConfig.Kubectl()
+        obj.utils = BaseConfig.Utils()
 
         config_classes = (
             BaseConfig.Platform,
@@ -41,7 +42,8 @@ class BaseConfig:
             BaseConfig.Skuba,
             BaseConfig.Kubectl,
             BaseConfig.VMware,
-            BaseConfig.Libvirt
+            BaseConfig.Libvirt,
+            BaseConfig.Utils
         )
 
         # vars get the values from yaml file
@@ -61,6 +63,10 @@ class BaseConfig:
             self.cpu = cpu
             self.ips = []
             self.external_ips = []
+
+    class Utils:
+        def __init__(self):
+            self.ssh_sock =  "/tmp/testrunner_ssh_sock"
 
     class Platform:
         def __init__(self):

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -117,7 +117,7 @@ class BaseConfig:
             super().__init__()
             self.level = "INFO"
             self.quiet = False
-            self.file = "testrunner.log"
+            self.file = "$WORKSPACE/testrunner.log"
             self.overwrite = False
 
     class VMware:

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -18,7 +18,6 @@ class BaseConfig:
     def __new__(cls, yaml_path, *args, **kwargs):
         obj = super().__new__(cls, *args, **kwargs)
         obj.yaml_path = yaml_path
-        obj.workspace = "$HOME/workspace"
         obj.platform  = BaseConfig.Platform()
         obj.terraform = BaseConfig.Terraform()
         obj.openstack = BaseConfig.Openstack()
@@ -96,6 +95,8 @@ class BaseConfig:
     class Skuba:
         def __init__(self):
             super().__init__()
+            self.workdir = "$WORKSPACE"
+            self.cluster = "test-cluster"
             self.binpath = "$WORKSPACE/go/bin/skuba"
             self.verbosity = 5
 
@@ -165,6 +166,10 @@ class BaseConfig:
         After the attribute's value is set, a environement variables in the
         value are expanded.
         """
+
+        if not vars:
+            return obj
+
         for key, value in obj.__dict__.items():
             if isinstance(value, config_classes):
                 config_class = obj.__dict__[key]
@@ -197,13 +202,9 @@ class BaseConfig:
 
     @staticmethod
     def verify(conf):
-        if not conf.workspace and conf.workspace == "":
-            raise ValueError(Format.alert("You should set the workspace value in a configured yaml file e.g. vars.yaml"
-                                          " or set env var WORKSPACE before using testrunner)"))
-
-        if os.path.normpath(conf.workspace) == os.path.normpath((os.getenv("HOME"))):
-            raise ValueError(Format.alert("workspace should not be your home directory"))
-
+        """ Validates configuration.
+        Deprecated. Will be removed
+        """
         return conf
 
     @staticmethod

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -18,9 +18,8 @@ class BaseConfig:
     def __new__(cls, yaml_path, *args, **kwargs):
         obj = super().__new__(cls, *args, **kwargs)
         obj.yaml_path = yaml_path
-        obj.workspace = None
-        obj.username = None
-        obj.log_dir = None
+        obj.workspace = "$HOME/workspace"
+        obj.log_dir = "$WORKSPACE/platform_logs"
 
         obj.terraform = BaseConfig.Terraform()
         obj.openstack = BaseConfig.Openstack()
@@ -73,11 +72,11 @@ class BaseConfig:
             super().__init__()
             self.retries = 5
             self.internal_net = None
-            self.stack_name = None
-            self.tfdir = None
+            self.stack_name = "$USER"
+            self.tfdir = "$WORKSPACE/skuba/ci/infra"
             self.tfvars = Constant.TERRAFORM_EXAMPLE
             self.plugin_dir = None
-            self.ssh_key = None
+            self.ssh_key = "$HOME/.ssh/id_rsa"
             self.nodeuser = None
             self.lb = BaseConfig.NodeConfig()
             self.master = BaseConfig.NodeConfig()
@@ -86,15 +85,14 @@ class BaseConfig:
     class Skuba:
         def __init__(self):
             super().__init__()
-            self.binpath = None
-            self.srcpath = None
+            self.binpath = "$WORKSPACE/go/bin/skuba"
             self.verbosity = 5
 
     class Kubectl:
         def __init__(self):
             super().__init__()
             self.binpath = "/usr/bin/kubectl"
-            self.kubeconfig = None
+            self.kubeconfig = "$WORKSPACE/test-cluster/admin.conf"
 
     class Test:
         def __init__(self):
@@ -151,8 +149,8 @@ class BaseConfig:
         - The attribute from vars
         - default value for configuration
 
-        After the value is set, a environement variables in the value of the
-        attribute are subtituted.
+        After the attribute's value is set, a environement variables in the
+        value are expanded.
         """
         for key, value in obj.__dict__.items():
             if isinstance(value, config_classes):
@@ -179,38 +177,9 @@ class BaseConfig:
 
     @staticmethod
     def finalize(conf):
-        conf.workspace = os.path.expanduser(conf.workspace)
-
-        if not conf.log_dir:
-            conf.log_dir = os.path.join(conf.workspace, 'platform_logs')
-        elif not os.path.isabs(conf.log_dir):
-            conf.log_dir = os.path.join(conf.workspace, conf.log_dir)
-
-        if not conf.skuba.binpath:
-            conf.skuba.binpath = os.path.join(conf.workspace, 'go/bin/skuba')
-
-        if not conf.skuba.srcpath:
-            conf.skuba.srcpath = os.path.realpath(os.path.join(conf.workspace, "skuba"))
-
-        if not conf.kubectl.kubeconfig:
-            conf.kubectl.kubeconfig =  os.path.realpath(os.path.join(conf.workspace, "test-cluster", "admin.conf"))
-
-        if not conf.terraform.tfdir:
-            conf.terraform.tfdir = os.path.join(conf.skuba.srcpath, "ci/infra/")
-
-        if not conf.terraform.stack_name:
-            conf.terraform.stack_name = conf.username
-
-        # TODO: This variable should be in openstack configuration but due to
-        # the way variables are processed in Terraform class, must be here for know.
-        if not conf.terraform.internal_net:
-            conf.terraform.internal_net = conf.terraform.stack_name
-
-        if not conf.terraform.ssh_key:
-            conf.terraform.ssh_key = os.path.join(os.path.expanduser("~"), ".ssh/id_rsa")
-        else:
-            conf.terraform.ssh_key = os.path.expandvars(conf.terraform.ssh_key)
-
+        """ Finalize configuration.
+            Deprecated. Will be removed
+        """
         return conf
 
     @staticmethod

--- a/ci/infra/testrunner/utils/constants.py
+++ b/ci/infra/testrunner/utils/constants.py
@@ -187,8 +187,6 @@ class BaseConfig:
         if not conf.workspace and conf.workspace == "":
             raise ValueError(Format.alert("You should set the workspace value in a configured yaml file e.g. vars.yaml"
                                           " or set env var WORKSPACE before using testrunner)"))
-        if not conf.terraform.stack_name:
-            raise ValueError(Format.alert("Either a terraform stack name or an user name must be specified"))
 
         if os.path.normpath(conf.workspace) == os.path.normpath((os.getenv("HOME"))):
             raise ValueError(Format.alert("workspace should not be your home directory"))

--- a/ci/infra/testrunner/utils/logger.py
+++ b/ci/infra/testrunner/utils/logger.py
@@ -20,8 +20,7 @@ class Logger:
             mode = 'a'
             if conf.log.overwrite:
                 mode = 'w'
-            log_file = os.path.join(conf.workspace, conf.log.file)
-            file_handler = logging.FileHandler(log_file)
+            file_handler = logging.FileHandler(conf.log.file)
             logger.addHandler(file_handler)
 
         if not conf.log.quiet:

--- a/ci/infra/testrunner/utils/test_config.py
+++ b/ci/infra/testrunner/utils/test_config.py
@@ -1,0 +1,37 @@
+import os
+from unittest import mock
+from utils.config import BaseConfig
+
+user = "USERID"
+home = "/path/to/home"
+workspace = "/path/to/workspace"
+env_workspace = "/path/to/workspace/from/env"
+skuba_binpath = "go/bin/skuba"
+terraform_tfdir = "skuba/ci/infra"
+ssh_key = ".ssh/id_rsa"
+tfvars = "terraform.tfvars.json.ci.example"
+
+empty_yaml = """
+""".format(workspace=workspace)
+
+def test_defaults():
+    """Test defaults according to the [documentation](../README.md)
+    """
+    with mock.patch("builtins.open", mock.mock_open(read_data=empty_yaml)), \
+         mock.patch.dict("os.environ", clear=True,
+                         values={"WORKSPACE": workspace,
+                                 "HOME": home,
+                                 "USER": user
+                         }):
+        config = BaseConfig("vars.yaml")
+        assert config.skuba.workdir == workspace
+        assert config.skuba.binpath == os.path.join(workspace,skuba_binpath)
+        assert config.skuba.cluster == "test-cluster"
+        assert config.terraform.tfdir == os.path.join(workspace,terraform_tfdir)
+        assert config.terraform.ssh_key == os.path.join(home, ssh_key)
+        assert config.terraform.stack_name == user
+        assert config.terraform.workdir ==  workspace
+        assert config.terraform.tfvars ==  tfvars
+        assert config.terraform.plugin_dir == None
+
+

--- a/ci/infra/testrunner/utils/test_config.py
+++ b/ci/infra/testrunner/utils/test_config.py
@@ -28,10 +28,10 @@ def test_defaults():
         assert config.skuba.binpath == os.path.join(workspace,skuba_binpath)
         assert config.skuba.cluster == "test-cluster"
         assert config.terraform.tfdir == os.path.join(workspace,terraform_tfdir)
-        assert config.terraform.ssh_key == os.path.join(home, ssh_key)
         assert config.terraform.stack_name == user
         assert config.terraform.workdir ==  workspace
         assert config.terraform.tfvars ==  tfvars
         assert config.terraform.plugin_dir == None
+        assert config.utils.ssh_key == os.path.join(home, ssh_key)
 
 

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -125,18 +125,21 @@ class Utils:
 
         return logging_errors
 
+    def ssh_user(self):
+        return self.conf.utils.ssh_user
+
     def authorized_keys(self):
-        public_key_path = self.conf.terraform.ssh_key + ".pub"
-        os.chmod(self.conf.terraform.ssh_key, 0o400)
+        public_key_path = self.conf.utils.ssh_key + ".pub"
+        os.chmod(self.conf.utils.ssh_key, 0o400)
 
         with open(public_key_path) as f:
             pubkey = f.read().strip()
         return pubkey
 
     def ssh_run(self, ipaddr, cmd):
-        key_fn = self.conf.terraform.ssh_key
+        key_fn = self.conf.utils.ssh_key
         cmd = "ssh " + Constant.SSH_OPTS + " -i {key_fn} {username}@{ip} -- '{cmd}'".format(
-            key_fn=key_fn, ip=ipaddr, cmd=cmd, username=self.conf.terraform.nodeuser)
+            key_fn=key_fn, ip=ipaddr, cmd=cmd, username=self.ssh_user())
         return self.runshellcommand(cmd)
 
     def scp_file(self, ip_address, remote_file_path, local_file_path):
@@ -147,8 +150,8 @@ class Utils:
         :param local_file_path: (str) Path where to store the log
         :return:
         """
-        cmd = (f"scp {Constant.SSH_OPTS} -i {self.conf.terraform.ssh_key}"
-               f" {self.conf.terraform.nodeuser}@{ip_address}:{remote_file_path} {local_file_path}")
+        cmd = (f"scp {Constant.SSH_OPTS} -i {self.conf.utils.ssh_key}"
+               f" {self.ssh_user()}@{ip_address}:{remote_file_path} {local_file_path}")
         self.runshellcommand(cmd)
 
     def rsync(self, ip_address, remote_dir_path, local_dir_path):
@@ -159,8 +162,8 @@ class Utils:
         :param local_dir_path: (str) Path where to store the dir
         :return:
         """
-        cmd = (f'rsync -avz --no-owner --no-perms -e "ssh {Constant.SSH_OPTS} -i {self.conf.terraform.ssh_key}"  '
-               f'--rsync-path="sudo rsync" --ignore-missing-args {self.conf.terraform.nodeuser}@{ip_address}:{remote_dir_path} '
+        cmd = (f'rsync -avz --no-owner --no-perms -e "ssh {Constant.SSH_OPTS} -i {self.conf.utils.ssh_key}"  '
+               f'--rsync-path="sudo rsync" --ignore-missing-args {self.ssh_user()}@{ip_address}:{remote_dir_path} '
                f'{local_dir_path}')
         self.runshellcommand(cmd)
 
@@ -233,7 +236,7 @@ class Utils:
     @timeout(60)
     @step
     def setup_ssh(self):
-        os.chmod(self.conf.terraform.ssh_key, 0o400)
+        os.chmod(self.conf.utils.ssh_key, 0o400)
 
         # use a dedicated agent to minimize stateful components
         sock_fn = self.conf.utils.ssh_sock
@@ -261,7 +264,7 @@ class Utils:
             pass
         self.runshellcommand("ssh-agent -a {}".format(sock_fn))
         self.runshellcommand(
-            "ssh-add " + self.conf.terraform.ssh_key, env={"SSH_AUTH_SOCK": sock_fn})
+            "ssh-add " + self.conf.utils.ssh_key, env={"SSH_AUTH_SOCK": sock_fn})
 
     @timeout(30)
     @step

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -1,11 +1,9 @@
 import glob
-import hashlib
 import logging
 import os
 import shutil
 import subprocess
 from functools import wraps
-from tempfile import gettempdir
 from threading import Thread
 
 import requests
@@ -75,7 +73,7 @@ class Utils:
     def ssh_cleanup(self):
         """Remove ssh sock files"""
         # TODO: also kill ssh agent here? maybe move pkill to kill_ssh_agent()?
-        sock_file = self.ssh_sock_fn()
+        sock_file = self.conf.utils.ssh_sock
         sock_dir = os.path.dirname(sock_file)
         try:
             Utils.cleanup_file(sock_file)
@@ -167,10 +165,7 @@ class Utils:
         self.runshellcommand(cmd)
 
     def runshellcommand(self, cmd, cwd=None, env={}, ignore_errors=False, stdin=None):
-        """Running shell command in {workspace} if cwd == None
-           Eg) cwd is "skuba", cmd will run shell in {workspace}/skuba/
-               cwd is None, cmd will run in {workspace}
-               cwd is abs path, cmd will run in cwd
+        """Running shell command
         Keyword arguments:
         cmd -- command to run
         cwd -- dir to run the cmd
@@ -178,27 +173,28 @@ class Utils:
         ignore_errors -- don't raise exception if command fails
         stdin -- standard input for the command in bytes
         """
-        if not cwd:
-            cwd = self.conf.workspace
 
-        if not os.path.isabs(cwd):
-            cwd = os.path.join(self.conf.workspace, cwd)
+        cmd_env = {
+            "SSH_AUTH_SOCK": self.conf.utils.ssh_sock,
+            "PATH": os.environ['PATH'],
+            **env
+        }
 
-        if not os.path.exists(cwd):
+        if cwd and not os.path.exists(cwd):
             raise FileNotFoundError(Format.alert("Directory {} does not exists".format(cwd)))
 
         if logging.DEBUG >= logger.level:
             logger.debug("Executing command\n"
                          "    cwd: {} \n"
                          "    env: {}\n"
-                         "    cmd: {}".format(cwd, str(env) if env else "{}", cmd))
+                         "    cmd: {}".format(cwd, str(cmd_env) if cmd_env else "{}", cmd))
         else:
             logger.info("Executing command {}".format(cmd))
 
         stdout, stderr = [], []
         p = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd,
-            stdin=subprocess.PIPE if stdin else None, shell=True, env=env
+            stdin=subprocess.PIPE if stdin else None, shell=True, env=cmd_env
         )
         if stdin:
             p.stdin.write(stdin)
@@ -221,23 +217,6 @@ class Utils:
                 return stderr
         return stdout
 
-    def ssh_sock_fn(self):
-        """generate path to ssh socket
-
-        A socket path can't be over 107 chars on Linux, so generate a short
-        hash of the workspace and use that in $TMPDIR (usually /tmp) so we have
-        a predictable, test-unique, fixed-length path.
-        """
-        path = os.path.join(
-            gettempdir(),
-            hashlib.md5(self.conf.workspace.encode()).hexdigest(),
-            "ssh-agent-sock"
-        )
-        maxl = 107
-        if len(path) > maxl:
-            raise Exception(f"Socket path '{path}' len {len(path)} > {maxl}")
-        return path
-
     def read_fd(self, proc, fd, logger_func, output):
         """Read from fd, logging using logger_func
 
@@ -257,7 +236,7 @@ class Utils:
         os.chmod(self.conf.terraform.ssh_key, 0o400)
 
         # use a dedicated agent to minimize stateful components
-        sock_fn = self.ssh_sock_fn()
+        sock_fn = self.conf.utils.ssh_sock
         # be sure directory containing socket exists and socket doesn't exist
         if os.path.exists(sock_fn):
             try:

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -11,7 +11,7 @@ from threading import Thread
 import requests
 from timeout_decorator import timeout
 
-from utils.constants import Constant
+from utils.config import Constant
 from utils.format import Format
 
 logger = logging.getLogger('testrunner')

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -1,55 +1,55 @@
-# Infra deployment engine
-workspace: "" # Working directory for testrunner
-username: ""  # Fill your username
-
 # Skuba setup
-skuba:
-  binpath: "" # path to skuba binary
-  srcpath: "" # path to skuba source
-  verbosity: 10  # default value passed to skuba with -v
-
-#Kubectl setup
+#skuba:
+#  binpath: "" # path to skuba binary
+#  srcpath: "" # path to skuba source
+#  verbosity: 10  # default value passed to skuba with -v
+#
+#
+# Kubectl setup
 #kubectl:
 #  path: #path to kubectl binary (defaults to /usr/bin/kubectl)
-
-# platform settings
-terraform:
-  internal_net: "" # name of the internal network
-  plugin_dir: "" # path to the terraform plugin dir
-  stack_name: "" # name of the stack
-  tfdir: ""  # path to terraform templates
-  tfvars: "" # terraform vars
-  ssh_key: "$WORKSPACE/skuba/ci/infra/id_shared" # path to ssh keys
-  nodeuser: "sles"  # Default node username
-  lb:
-    count: 1
-    memory: 8192
-    cpu: 4
-  master:
-    count: 3
-    memory: 4096
-    cpu: 4
-  worker:
-    count: 3
-    memory: 4096
-    cpu: 2
+#
+#
+#terraform:
+#  internal_net: "" # name of the internal network
+#  plugin_dir: "" # path to the terraform plugin dir
+#  stack_name: "" # name of the stack
+#  tfdir: ""  # path to terraform templates
+#  tfvars: "" # terraform vars
+#  nodeuser: "sles"  # Default node username
+#  lb:
+#    count: 1
+#    memory: 8192
+#    cpu: 4
+#  master:
+#    count: 3
+#    memory: 4096
+#    cpu: 4
+#  worker:
+#    count: 3
+#    memory: 4096
+#    cpu: 2
 
 packages:
 # mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
   additional_pkgs:
   - "ca-certificates-suse"
 
-openstack:
-  openrc: "" #os.getenv("OPENSTACK_OPENRC")
+utils:
+  ssh_key: "$WORKSPACE/skuba/ci/infra/id_shared" 
+  ssh_sock: "/tmp/
 
-vmware:
-  env_file: "" #os.getenv("VMWARE_ENV_FILE")
-  template_name: "SLES15-SP1-GM-guestinfo" #os.getenv("VMWARE_TEMPLATE_NAME")
+#openstack:
+#  openrc: "" #os.getenv("OPENSTACK_OPENRC")
 
-libvirt:
-  uri: "qemu:///system" #os.getenv("LIBVIRT_URI")
-  keyfile: "" #os.getenv("LIBVIRT_KEYFILE")
-  image_uri: "" #os.getenv("LIBVIRT_IMAGE_URI") 
+#vmware:
+#  env_file: "" #os.getenv("VMWARE_ENV_FILE")
+#  template_name: "SLES15-SP1-GM-guestinfo" #os.getenv("VMWARE_TEMPLATE_NAME")
 
-log:
-  level: DEBUG
+#libvirt:
+#  uri: "qemu:///system" #os.getenv("LIBVIRT_URI")
+#  keyfile: "" #os.getenv("LIBVIRT_KEYFILE")
+#  image_uri: "" #os.getenv("LIBVIRT_IMAGE_URI") 
+#
+#log:
+#  level: DEBUG

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -10,23 +10,23 @@
 #  path: #path to kubectl binary (defaults to /usr/bin/kubectl)
 #
 #
-#terraform:
+terraform:
 #  internal_net: "" # name of the internal network
 #  plugin_dir: "" # path to the terraform plugin dir
 #  stack_name: "" # name of the stack
 #  tfdir: ""  # path to terraform templates
 #  tfvars: "" # terraform vars
 #  nodeuser: "sles"  # Default node username
-#  lb:
-#    count: 1
+  lb:
+    count: 1
 #    memory: 8192
 #    cpu: 4
-#  master:
-#    count: 3
+  master:
+    count: 3
 #    memory: 4096
 #    cpu: 4
-#  worker:
-#    count: 3
+  worker:
+    count: 3
 #    memory: 4096
 #    cpu: 2
 
@@ -37,7 +37,8 @@ packages:
 
 utils:
   ssh_key: "$WORKSPACE/skuba/ci/infra/id_shared" 
-  ssh_sock: "/tmp/
+  ssh_user: "sles"
+  ssh_sock: "$WORKSPACE/agent.sock"
 
 #openstack:
 #  openrc: "" #os.getenv("OPENSTACK_OPENRC")


### PR DESCRIPTION
## Why is this PR needed?

Testrunner's configuration is complex, including some implicit dependencies that make hard to deduce the default values for some configuration parameters. 

## What does this PR do?

- Removes the `workspace` configuration parameter which was used as a basis for other configurations such as terraform's `tfdir`
- Make every component to have its own parameter for defining the working directory
- Allows environment variables in the value of configuration parameters, which are expanded when the configuration is loaded
- Simplifies the configuration logic. Eliminates some redundant logic when loading configuration from yaml 
- Reorganized some configuration parameters to locate then closer to the logic that uses it. Noticeably, ssh related parameters were moved to the new `utils` configuration section.
- Provides sensible defaults
- Introduce unit test for the configuration (WIP)
- Updates the documentation accordingly

## Anything else a reviewer needs to know?

The structure of the `vars.yaml` file changes. Testing locally with old config files will likely fail.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
