### PR TITLE
Use branch from parameters in daily jobs

### DIFF
--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -25,7 +25,7 @@
                 url: 'https://github.com/{repo-owner}/{repo-name}.git'
                 credentials-id: '{repo-credentials}'
                 branches:
-                    - '{branch}'
+                    - '{BRANCH}'
                 browser: auto
                 suppress-automatic-scm-triggering: true
                 basedir: skuba

--- a/ci/jenkins/templates/e2e-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-daily-template.yaml
@@ -29,7 +29,7 @@
                 url: 'https://github.com/{repo-owner}/{repo-name}.git'
                 credentials-id: '{repo-credentials}'
                 branches:
-                    - '{branch}'
+                    - '{BRANCH}'
                 browser: auto
                 suppress-automatic-scm-triggering: true
                 basedir: skuba

--- a/ci/jenkins/templates/e2e-update-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-update-daily-template.yaml
@@ -25,7 +25,7 @@
                 url: 'https://github.com/{repo-owner}/{repo-name}.git'
                 credentials-id: '{repo-credentials}'
                 branches:
-                    - '{branch}'
+                    - '{BRANCH}'
                 browser: auto
                 suppress-automatic-scm-triggering: true
                 basedir: skuba


### PR DESCRIPTION
## Why is this PR needed?

Job templates for daily jobs define a BRANCH parameter but their
scm specification ignores it.

Using the BRANCH parameter allows testing daily jobs using a branch.

## What does this PR do?

configures the scm in daily jobs for using the BRANCH parameter 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
