### PR TITLE
Improve upgrading crio.conf.d file

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -52,7 +52,10 @@ func criConfigure(t *Target, data interface{}) error {
 		}
 	}
 
-	_, _, err = t.ssh("mv -f /tmp/crio.conf.d/01-caasp.conf /etc/crio/crio.conf.d/01-caasp.conf")
+	if _, _, err = t.ssh("mkdir -p /etc/crio/crio.conf.d"); err != nil {
+		return err
+	}
+	_, _, err = t.ssh("cp -r /tmp/crio.conf.d/*.conf /etc/crio/crio.conf.d")
 	return err
 }
 

--- a/pkg/skuba/actions/cluster/init/constants.go
+++ b/pkg/skuba/actions/cluster/init/constants.go
@@ -40,6 +40,10 @@ var (
 				Location: skuba.CriDefaultsConfFile(),
 				Content:  criDefaultsConf,
 			},
+			{
+				Location: skuba.CriConfFolderReadmeFile(),
+				Content:  CriConfFolderReadme,
+			},
 		},
 	}
 

--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -18,6 +18,8 @@
 package cluster
 
 const (
+	CriConfFolderReadme = `This directory contains CRI-O configuration files that are uploaded to CaaSP nodes. All the files (except this README) will be uploaded to the /etc/crio/conf.d/ folder. If it is required user custom files name as 99-custom.conf
+	`
 	criDockerDefaultsConf = `## Path           : System/Management
 ## Description    : Extra cli switches for crio daemon
 ## Type           : string
@@ -25,7 +27,9 @@ const (
 ## ServiceRestart : crio
 #
 CRIO_OPTIONS=--pause-image={{.PauseImage}}{{if not .StrictCapDefaults}} --default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"{{end}}`
-	criDefaultsConf = `{{if not .StrictCapDefaults}}[crio.runtime]
+	criDefaultsConf = `# PLEASE DON'T EDIT THIS FILE!
+# This file is managed by CaaSP skuba.
+{{if not .StrictCapDefaults}}[crio.runtime]
 
 default_capabilities = [
 	"CHOWN",

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -88,6 +88,10 @@ func CriDefaultsConfFile() string {
 	return filepath.Join(CriConfDir(), "01-caasp.conf")
 }
 
+func CriConfFolderReadmeFile() string {
+	return filepath.Join(CriConfDir(), "README")
+}
+
 func KubeConfigAdminFile() string {
 	return "admin.conf"
 }


### PR DESCRIPTION
## Why is this PR needed?

It is improving crio configuration 

## What does this PR do?

Instead `mv` it is `cp` whole directory with with caasp and users configuration files

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

