### PR TITLE
fixes missing space on an assert in failing test

### DIFF
--- a/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
@@ -16,7 +16,7 @@ def test_upgrade_plan_from_previous(deployment, skuba, kubectl, platform):
     assert out.find("Latest Kubernetes version: {cv}".format(
         cv=CURRENT_VERSION)) != -1
     assert out.find(
-        "Upgrade path to update from {pv} to {cv}:\n - {pv} -> {cv}".format(
+        "Upgrade path to update from {pv} to {cv}:\n  - {pv} -> {cv}".format(
             pv=PREVIOUS_VERSION, cv=CURRENT_VERSION)
     ) != -1
 


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

## Why is this PR needed?

A test is failing due to a missing space on an assert.

Fixes https://github.com/SUSE/avant-garde/issues/1494

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Fixes missing space on an assert in failing test

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This test scenario from `testrunner` should pass now  `upgrade_plan_from_previous`

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
