### PR TITLE
Better looking comment


### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -131,16 +131,14 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		}
 	}
 
-	/*
-		Always upload crio files, regardless of the version (allows to
-		enforce user behavior during patch updates).
-		During the upgrade from 1.16 to 1.18 crio, the cri-o package will
-		handle overriding the old crio sysconfig to an "empty" sysconfig,
-		and the cri.configure action will be enough.
-		We can remove the conditionals and only
-		keep the cri.configure action when caasp 4.2.0 is not supported
-		anymore (everyone has updated crio to 1.18)
-	*/
+	// Always upload crio files, regardless of the version (allows to
+	// enforce user behavior during patch updates).
+	// During the upgrade from 1.16 to 1.18 crio, the cri-o package will
+	// handle overriding the old crio sysconfig to an "empty" sysconfig,
+	// and the cri.configure action will be enough.
+	// We can remove the conditionals and only
+	// keep the cri.configure action when caasp 4.2.0 is not supported
+	// anymore (everyone has updated crio to 1.18)
 	if _, err := os.Stat(skuba.CriDefaultsConfFile()); err == nil {
 		err = target.Apply(nil, "cri.configure")
 		if err != nil {


### PR DESCRIPTION


Some IDEs are using // to automatically comment, compared to
/* */, for multiline comments. This makes it more convenient
for those using IDEs like that.

