### PR TITLE
Get disk format from template on VMware, fixes bsc#1171349

### DIFF
--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -148,8 +148,10 @@ resource "vsphere_virtual_machine" "lb" {
   hardware_version = var.vsphere_hardware_version
 
   disk {
-    label = "disk0"
-    size  = var.lb_disk_size
+    label            = "disk0"
+    size             = var.lb_disk_size
+    eagerly_scrub    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
+    thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
   }
 
   extra_config = {

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -82,8 +82,10 @@ resource "vsphere_virtual_machine" "master" {
   hardware_version = var.vsphere_hardware_version
 
   disk {
-    label = "disk0"
-    size  = var.master_disk_size
+    label            = "disk0"
+    size             = var.master_disk_size
+    eagerly_scrub    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
+    thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
   }
 
   extra_config = {

--- a/ci/infra/vmware/variables.tf
+++ b/ci/infra/vmware/variables.tf
@@ -75,11 +75,6 @@ variable "username" {
   description = "Default user for the cluster nodes created by cloud-init default configuration for all SUSE SLES systems"
 }
 
-variable "masters" {
-  default     = 1
-  description = "Number of master nodes"
-}
-
 variable "workers" {
   default     = 1
   description = "Number of worker nodes"
@@ -98,6 +93,11 @@ variable "worker_memory" {
 variable "worker_disk_size" {
   default     = 40
   description = "Size of the root disk in GB on worker node"
+}
+
+variable "masters" {
+  default     = 1
+  description = "Number of master nodes"
 }
 
 variable "master_cpus" {

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -82,8 +82,10 @@ resource "vsphere_virtual_machine" "worker" {
   hardware_version = var.vsphere_hardware_version
 
   disk {
-    label = "disk0"
-    size  = var.worker_disk_size
+    label            = "disk0"
+    size             = var.worker_disk_size
+    eagerly_scrub    = data.vsphere_virtual_machine.template.disks.0.eagerly_scrub
+    thin_provisioned = data.vsphere_virtual_machine.template.disks.0.thin_provisioned
   }
 
   extra_config = {


### PR DESCRIPTION
## Why is this PR needed?


Fixes https://bugzilla.suse.com/show_bug.cgi?id=1171349


## What does this PR do?

This commit makes it possible to inherit the format of a disk from the template, before this, only
"Thin provision" templates could be cloned as these are the default terraform values.

* Thick Provision Lazy Zeroed (default)
* Thick Provision Eager Zeroed
* Thin Provision

Signed-off-by: lcavajani <lcavajani@suse.com>


## Info for QA

#### To use Thick Provisoning Lazy Zeroed (default)

1. Create Template with `Thick Provisoning Lazy Zeroed` as format for the disk
2. Clone from this template

```bash
$ INSTANCE_NAME="test-disks-lcava-master-0"
$ govc device.info -json=true -vm /PROVO/vm/$INSTANCE_NAME disk-1000-0 | jq '.Devices[].Backing | {ThinProvisioned, EagerlyScrub}'
{
  "ThinProvisioned": false,
  "EagerlyScrub": null
}
````

#### To use Thick Provisoning Eager Zeroed (default)

1. Create Template with `Thick Provisoning Eager Zeroed` as format for the disk
2. Clone from this template

:warning: didn't show as eagerly scrubbed, need to investigate...

EDIT: I've found out we end up with lazy-zeroed when the size of the disk is changed, which is what we do, I've created an issue upstream: https://github.com/terraform-providers/terraform-provider-vsphere/issues/1078

If it's by design and not a bug, I will update the doc


```bash
$ INSTANCE_NAME="test-disks-lcava-master-0"
$ govc device.info -json=true -vm /PROVO/vm/$INSTANCE_NAME disk-1000-0 | jq '.Devices[].Backing | {ThinProvisioned, EagerlyScrub}'
{
  "ThinProvisioned": false,
  "EagerlyScrub": null
}
````

#### To use Thin Provisoning:

1. Create Template with `Thin Provisioning` as format for the disk
2. Clone from this template

```bash
$ INSTANCE_NAME="test-disks-lcava-master-0"
$ govc device.info -json=true -vm /PROVO/vm/$INSTANCE_NAME disk-1000-0 | jq '.Devices[].Backing | {ThinProvisioned, EagerlyScrub}'
{
  "ThinProvisioned": true,
  "EagerlyScrub": null
}
````


### Status **BEFORE** applying the patch

It's not possible to use something else as the default Thin provisioning.

### Status **AFTER** applying the patch

It's now possible to use the three formats above.

## Docs

https://github.com/SUSE/doc-caasp/pull/796

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
