### PR TITLE
Maintain /etc/sysconfig/crio for CRI-O v1.18 upgrade

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -29,6 +29,7 @@ import (
 func init() {
 	stateMap["cri.configure"] = criConfigure
 	stateMap["cri.sysconfig"] = criSysconfig
+	stateMap["cri.update"] = criUpdate
 	stateMap["cri.start"] = criStart
 }
 
@@ -80,6 +81,11 @@ func criSysconfig(t *Target, data interface{}) error {
 		return err
 	}
 	_, _, err = t.ssh("mv -f /tmp/cri.d/default_flags /etc/sysconfig/crio")
+	return err
+}
+
+func criUpdate(t *Target, data interface{}) error {
+	_, _, err := t.ssh("sed -i 's/CRIO_OPTIONS=.*/CRIO_OPTIONS=/' /etc/sysconfig/crio")
 	return err
 }
 


### PR DESCRIPTION
## Why is this PR needed?

Cri-o v1.18.0 has a nasty bug which can't parse 
```
--default-capabilities="CHOWN,DAC_OVERRIDE,FSETID,FOWNER,NET_RAW,SETGID,SETUID,SETPCAP,NET_BIND_SERVICE,SYS_CHROOT,KILL,MKNOD,AUDIT_WRITE,SETFCAP"
```
from /etc/sysconfig/crio. Probably it will be fixed in cri-o v1.18.1 but we can't block upgrade. Besides this cri-o v1.18.0 introducing users custom configuration files which can be installed in /etc/crio/crio.conf.d and this is the way which we are going to use for CaaSP.

## What does this PR do?

It is cleaning up `/etc/sysconfig/crio` and removing `--default-capabilities=" ... ` during CaaSP upgrade to Kubernetes and cri-o v1.18

## Anything else a reviewer needs to know?

Before CaaSP upgrade we have to generate new crio.conf.d configuration by 

```
skuba cluster init --control-plane <IP> /tmp/<TEST_CLUSTER_NAME>
cp -r /tmp/<TEST_CLUSTER_NAME>/addons/crio/conf.d <CURRENT_CLUSTER_NAME>/addons/crio
```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

