### PR TITLE
Substitute env variables in lists and maps inside testrunner's configuration

### DIFF
--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -184,13 +184,21 @@ class BaseConfig:
             elif vars and key in vars:
                 value = vars[key]
 
-            # subtitute environment variables in the value of the attribute
-            if value is not None and type(value) == str:
-                config.__dict__[key] = string.Template(value).safe_substitute(os.environ)
-            else:
-                config.__dict__[key] = value
+            config.__dict__[key] = BaseConfig.substitute(value)
 
-        return
+    @staticmethod
+    def substitute(value):
+        """subtitute environment variables in the value of the attribute
+           recursively substitute values in list or maps
+        """
+        if value is not None:
+            if type(value) == str:
+                value = string.Template(value).safe_substitute(os.environ)
+            elif type(value) == list:
+                value = [BaseConfig.substitute(e) for e in value]
+            elif type(value) == dict:
+                value = { k: BaseConfig.substitute(v) for k,v in value.items()}
+        return value
 
     @staticmethod
     def finalize(conf):

--- a/ci/infra/testrunner/utils/test_config.py
+++ b/ci/infra/testrunner/utils/test_config.py
@@ -34,4 +34,25 @@ def test_defaults():
         assert config.terraform.plugin_dir == None
         assert config.utils.ssh_key == os.path.join(home, ssh_key)
 
+subs_yaml ="""
+packages:
+  additional_pkgs:
+  - $MYPACKAGE
+  additional_repos:
+    my_repo: $MYREPO
+"""
+my_package = "my-repo"
+my_repo = "http://url/to/my/repo"
 
+def test_substitutions():
+    """Test substitution of environment variables in lists and  maps
+    """
+    with mock.patch("builtins.open", mock.mock_open(read_data=subs_yaml)), \
+         mock.patch.dict("os.environ", clear=True,
+                         values={"MYPACKAGE": my_package,
+                                 "MYREPO": my_repo,
+                         }):
+        config = BaseConfig("vars.yaml")
+        assert len(config.packages.additional_pkgs) == 1
+        assert config.packages.additional_pkgs[0] == my_package
+        assert config.packages.additional_repos["my_repo"] == my_repo


### PR DESCRIPTION
## Why is this PR needed?

Allow environment variable substitution in the values of lists and maps, like the additional packages to install or additional repositories to add to nodes.

This is required for https://github.com/SUSE/avant-garde/issues/1524 as described [in this comment](https://github.com/SUSE/avant-garde/issues/1524#issuecomment-627261978)

## What does this PR do?

Add a logic for recursively substitute environment variables in the elements of lists and maps in the configuration.

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
