### PR TITLE
Set suitable values for maxUnavailable in addons

### DIFF
--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -146,9 +146,7 @@ spec:
     type: "RollingUpdate"
     rollingUpdate:
       # Specifies the maximum number of Pods that can be unavailable during the update process.
-      # The current default value is 1 or 100% for daemonsets; Adding an explicit value here
-      # to avoid confusion, as the default value is specific to the type (daemonset/deployment).
-      maxUnavailable: "100%"
+      maxUnavailable: 1
   selector:
     matchLabels:
       k8s-app: cilium
@@ -1017,7 +1015,7 @@ spec:
         name: cilium-config-path
   updateStrategy:
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
     type: RollingUpdate
 ---
 # Source: cilium/charts/operator/templates/deployment.yaml

--- a/internal/pkg/skuba/addons/kured.go
+++ b/internal/pkg/skuba/addons/kured.go
@@ -134,6 +134,8 @@ spec:
       name: kured
   revisionHistoryLimit: 3
   updateStrategy:
+    rollingUpdate:
+      maxUnavailable: "5%"
     type: RollingUpdate
   template:
     metadata:

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -101,8 +101,8 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.5.3", 2},
-				Kured:         &AddonVersion{"1.3.0", 4},
+				Cilium:        &AddonVersion{"1.5.3", 3},
+				Kured:         &AddonVersion{"1.3.0", 5},
 				Dex:           &AddonVersion{"2.23.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
 				MetricsServer: &AddonVersion{"0.3.6", 0},


### PR DESCRIPTION
## Why is this PR needed?

For Cilium 1.5, the value was set to 100% so this means all the pods are restarted at the same time. We should be using 1.6 soon but this fix it backwards. This commit set it to the default and safer value 1.

For Cilium 1.6, the value was set to 2 so this commit also set it to 1.

For Kured, it was not set so using the default value 1, using 5% seems appropriate to speed up a bit the update on clusters above 100 nodes without loading too much the apiserver.


### Status **BEFORE** applying the patch

all `cilium` were recreated at the same time during an addon upgrade.


### Status **AFTER** applying the patch

`cilium` pods are recreated one after an other.


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
