### PR TITLE
Update base kubernetes version to upgrade from


### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -2,8 +2,8 @@ import signal
 import time
 import yaml
 
-PREVIOUS_VERSION = "1.16.2"
-CURRENT_VERSION = "1.17.4"
+PREVIOUS_VERSION = "1.17.4"
+CURRENT_VERSION = "1.18.2"
 
 
 def check_nodes_ready(kubectl):

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -42,13 +42,13 @@
         - test_upgrade_plan_all_fine
         - test_upgrade_apply_all_fine
         - test_upgrade_apply_from_previous:
-           kubernetes_version: 1.16.2
+           kubernetes_version: 1.17.4
         - test_upgrade_apply_user_lock:
-           kubernetes_version: 1.16.2
+           kubernetes_version: 1.17.4
         - test_upgrade_plan_from_previous:
-           kubernetes_version: 1.16.2
+           kubernetes_version: 1.17.4
         - test_upgrade_plan_from_previous_with_upgraded_control_plane:
-           kubernetes_version: 1.16.2
+           kubernetes_version: 1.17.4
     jobs:
         - '{name}/{platform}/{test}-daily'
         - '{name}/{platform}/update-daily'


### PR DESCRIPTION
With now k8s 1.18.2 available in Devel, we should be dealing
with the upgrade of 1.17.4 to it in CI.

This should take care of it.

Needed-By: ``<Patch to implement script running at arbitrary times>``
Closes: https://github.com/SUSE/avant-garde/issues/1585, https://github.com/SUSE/avant-garde/issues/1586

