### PR TITLE
[WIP] Deregister instances when destroying

### DIFF
--- a/ci/infra/aws/iam_policies.tf
+++ b/ci/infra/aws/iam_policies.tf
@@ -7,16 +7,16 @@ locals {
 }
 
 resource "aws_iam_instance_profile" "master" {
-  name = local.aws_iam_instance_profile_master_terraform
-  role = aws_iam_role.master[count.index].name
+  name  = local.aws_iam_instance_profile_master_terraform
+  role  = aws_iam_role.master[count.index].name
   count = length(var.iam_profile_master) == 0 ? 1 : 0
 }
 
 resource "aws_iam_role" "master" {
-  name = local.aws_iam_instance_profile_master_terraform
+  name        = local.aws_iam_instance_profile_master_terraform
   description = "IAM role needed by CPI on master nodes"
-  path = "/"
-  count = length(var.iam_profile_master) == 0 ? 1 : 0
+  path        = "/"
+  count       = length(var.iam_profile_master) == 0 ? 1 : 0
 
   assume_role_policy = <<EOF
 {
@@ -36,8 +36,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "master" {
-  name = local.aws_iam_instance_profile_master_terraform
-  role = aws_iam_role.master[count.index].id
+  name  = local.aws_iam_instance_profile_master_terraform
+  role  = aws_iam_role.master[count.index].id
   count = length(var.iam_profile_master) == 0 ? 1 : 0
 
   policy = <<EOF
@@ -112,16 +112,16 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "worker" {
-  name = local.aws_iam_instance_profile_worker_terraform
-  role = aws_iam_role.worker[count.index].name
+  name  = local.aws_iam_instance_profile_worker_terraform
+  role  = aws_iam_role.worker[count.index].name
   count = length(var.iam_profile_worker) == 0 ? 1 : 0
 }
 
 resource "aws_iam_role" "worker" {
-  name = local.aws_iam_instance_profile_worker_terraform
+  name        = local.aws_iam_instance_profile_worker_terraform
   description = "IAM role needed by CPI on worker nodes"
-  path = "/"
-  count = length(var.iam_profile_worker) == 0 ? 1 : 0
+  path        = "/"
+  count       = length(var.iam_profile_worker) == 0 ? 1 : 0
 
   assume_role_policy = <<EOF
 {
@@ -142,8 +142,8 @@ EOF
 
 
 resource "aws_iam_role_policy" "worker" {
-  name = local.aws_iam_instance_profile_worker_terraform
-  role = aws_iam_role.worker[count.index].id
+  name  = local.aws_iam_instance_profile_worker_terraform
+  role  = aws_iam_role.worker[count.index].id
   count = length(var.iam_profile_worker) == 0 ? 1 : 0
 
   policy = <<EOF

--- a/ci/infra/aws/master-instance.tf
+++ b/ci/infra/aws/master-instance.tf
@@ -67,7 +67,8 @@ resource "null_resource" "control_plane" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/aws/master-instance.tf
+++ b/ci/infra/aws/master-instance.tf
@@ -68,7 +68,7 @@ resource "null_resource" "control_plane" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/aws/worker-instance.tf
+++ b/ci/infra/aws/worker-instance.tf
@@ -68,7 +68,7 @@ resource "null_resource" "nodes" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/aws/worker-instance.tf
+++ b/ci/infra/aws/worker-instance.tf
@@ -67,7 +67,8 @@ resource "null_resource" "nodes" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -127,7 +127,8 @@ resource "null_resource" "master" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -128,7 +128,7 @@ resource "null_resource" "master" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -128,7 +128,7 @@ resource "null_resource" "worker" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -127,7 +127,8 @@ resource "null_resource" "worker" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -121,7 +121,8 @@ resource "null_resource" "master" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -122,7 +122,7 @@ resource "null_resource" "master" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -135,7 +135,8 @@ resource "null_resource" "worker" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -136,7 +136,7 @@ resource "null_resource" "worker" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -126,7 +126,8 @@ resource "null_resource" "master" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -127,7 +127,7 @@ resource "null_resource" "master" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -127,7 +127,7 @@ resource "null_resource" "worker" {
 
   provisioner "remote-exec" {
     when       = destroy
-    on_failure = "continue"
+    on_failure = continue
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -126,7 +126,8 @@ resource "null_resource" "worker" {
   }
 
   provisioner "remote-exec" {
-    when = destroy
+    when       = destroy
+    on_failure = "continue"
     inline = [
       "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -81,6 +81,8 @@ resource "vsphere_virtual_machine" "worker" {
 
   hardware_version = var.vsphere_hardware_version
 
+  enable_disk_uuid = var.cpi_enable == true ? true : false
+
   disk {
     label = "disk0"
     size  = var.worker_disk_size
@@ -92,23 +94,27 @@ resource "vsphere_virtual_machine" "worker" {
     "guestinfo.userdata"          = base64gzip(data.template_file.worker_cloud_init_userdata[count.index].rendered)
     "guestinfo.userdata.encoding" = "gzip+base64"
   }
-  enable_disk_uuid = var.cpi_enable == true ? true : false
 
   network_interface {
     network_id = data.vsphere_network.network.id
   }
 }
 
-resource "null_resource" "worker_wait_cloudinit" {
+resource "null_resource" "worker" {
   depends_on = [vsphere_virtual_machine.worker]
   count      = var.workers
 
+  triggers = {
+    worker_ips = "${join(",", vsphere_virtual_machine.worker.*.guest_ip_addresses.0)}"
+    username   = var.username
+  }
+
   connection {
     host = element(
-      vsphere_virtual_machine.worker.*.guest_ip_addresses.0,
+      split(",", self.triggers.worker_ips),
       count.index,
     )
-    user  = var.username
+    user  = self.triggers.username
     type  = "ssh"
     agent = true
   }
@@ -116,6 +122,13 @@ resource "null_resource" "worker_wait_cloudinit" {
   provisioner "remote-exec" {
     inline = [
       "cloud-init status --wait > /dev/null",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when = destroy
+    inline = [
+      "if sudo SUSEConnect -s | grep -qv 'Not Registered'; then sudo SUSEConnect -d; fi"
     ]
   }
 }


### PR DESCRIPTION
This idea comes from what is done with `validator`, thanks to @kravciak and @thehejik !

## Why is this PR needed?

This commit allows to de-register instances from RMT or from SCC automatically when destroying.

One specificity is the use of trigger within the null_resources. This avoids using external references (variables, resource attributes...) with the destroy provisioners which is deprecated.

For AWS, this commit also introduces a stanza to wait for cloud-init to finish.

`terraform fmt` also rewrites some files.

## Info for QA

I have just tested with `VMware` so far.

### Status **BEFORE** applying the patch

Non-registered instances are not impacted.
Registered instances are not deregistered.


### Status **AFTER** applying the patch

Non-registered instances should not run the de-register step.
Instances are deregistered, this can be seen in the terraform outputs:

```hcl
null_resource.master[0] (remote-exec): Deregistering system from SUSE Customer Center
null_resource.master[0]: Still destroying... [id=5790196521205169156, 10s elapsed]

null_resource.master[0] (remote-exec): Deactivating caasp 4.0 x86_64 ...
null_resource.master[0] (remote-exec): -> Removing service from system ...
null_resource.master[0] (remote-exec): -> Removing release package ...

null_resource.master[0] (remote-exec): Deactivating sle-module-containers 15.1 x86_64 ...
null_resource.master[0] (remote-exec): -> Removing service from system ...
null_resource.master[0] (remote-exec): -> Removing release package ...
null_resource.master[0]: Still destroying... [id=5790196521205169156, 20s elapsed]

null_resource.master[0] (remote-exec): Deactivating sle-module-server-applications 15.1 x86_64 ...
null_resource.master[0] (remote-exec): -> Removing service from system ...
null_resource.master[0] (remote-exec): -> Removing release package ...

null_resource.master[0] (remote-exec): Deactivating sle-module-basesystem 15.1 x86_64 ...
null_resource.master[0] (remote-exec): -> Removing service from system ...
null_resource.master[0] (remote-exec): -> Removing release package ...
null_resource.master[0]: Still destroying... [id=5790196521205169156, 30s elapsed]

null_resource.master[0] (remote-exec): Cleaning up ...
null_resource.master[0] (remote-exec): Successfully deregistered system
```

## Docs

in progress....

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
