### PR TITLE
Test PR using a branched repository

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -179,7 +179,10 @@ class Terraform(Platform):
         repos = tfvars.get("repositories", {})
         if self.conf.packages.additional_repos:
            for name, url in self.conf.packages.additional_repos.items():
-               repos[name] = url
+                if not url:
+                    logger.warning(f'skipping repository {name} with empty url')
+                    continue
+                repos[name] = url
 
         # Update mirror urls
         if self.conf.packages.mirror and repos:

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -6,6 +6,13 @@ import yaml
 
 from utils.format import Format
 
+class dict_with_default(dict):
+    def __init__(self, values, default):
+        self.default = default
+        super().__init__(values)
+
+    def __missing__(self, key):
+        return self.default
 
 class Constant:
     TERRAFORM_EXAMPLE = "terraform.tfvars.json.ci.example"
@@ -193,7 +200,7 @@ class BaseConfig:
         """
         if value is not None:
             if type(value) == str:
-                value = string.Template(value).safe_substitute(os.environ)
+                value = string.Template(value).safe_substitute(dict_with_default(os.environ, ''))
             elif type(value) == list:
                 value = [BaseConfig.substitute(e) for e in value]
             elif type(value) == dict:

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -34,6 +34,8 @@ packages:
 # mirror: "ibs-mirror.prv.suse.net" # mirror url for downloading packages
   additional_pkgs:
   - "ca-certificates-suse"
+  additional_repos:
+    branch_repo: $BRANCH_REPO
 
 utils:
   ssh_key: "$WORKSPACE/skuba/ci/infra/id_shared" 

--- a/ci/jenkins/pipelines/prs/helpers/pr-manager
+++ b/ci/jenkins/pipelines/prs/helpers/pr-manager
@@ -2,8 +2,6 @@
 
 set -eo pipefail
 
-echo "Starting $0 script"
-
 SDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 VENVDIR=${WORKSPACE:-~}/py3venv
 export VENVDIR=${VENVDIR}


### PR DESCRIPTION
## Why is this PR needed?

Allow selecting a specific branch in a repository for testing. This is required to test PR against updates of packages. 

The name of the repository branch must match the name of the PR branch.
 
The Repo is added to the testrunner configuration if it exists. 

Fixes: https://github.com/SUSE/avant-garde/issues/1524