### PR TITLE
Enable disruptive tests for conformance job

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
         stage('Conformance Tests') {
             options { timeout(time: 200, unit: 'MINUTES', activity: false) }
             steps {
-                sh(script: "skuba/ci/tasks/sonobuoy_e2e.py run --kubeconfig ${WORKSPACE}/test-cluster/admin.conf --sonobuoy-version ${SONOBUOY_VERSION}", label: 'Run Conformance')
+                sh(script: "skuba/ci/tasks/sonobuoy_e2e.py run --kubeconfig ${WORKSPACE}/test-cluster/admin.conf --sonobuoy-version ${SONOBUOY_VERSION} --mode=certified-conformance", label: 'Run Conformance')
                 sh(script: "skuba/ci/tasks/sonobuoy_e2e.py collect --kubeconfig ${WORKSPACE}/test-cluster/admin.conf --sonobuoy-version ${SONOBUOY_VERSION}", label: 'Collect Results')
                 sh(script: "skuba/ci/tasks/sonobuoy_e2e.py cleanup --kubeconfig ${WORKSPACE}/test-cluster/admin.conf --sonobuoy-version ${SONOBUOY_VERSION}", label: 'Cleanup Cluster')
             }

--- a/ci/tasks/sonobuoy_e2e.py
+++ b/ci/tasks/sonobuoy_e2e.py
@@ -88,7 +88,7 @@ class SonobuoyE2eTests:
         return self._run_cmd(cmd)
 
     def _start_the_tests(self, sonobuoy_args):
-        self._sonobuoy('run ' + ' '.join(sonobuoy_args) + '--wait')
+        self._sonobuoy('run ' + ' '.join(sonobuoy_args) + ' --wait')
 
 
 class SonobuoyE2eTestsError(Exception):


### PR DESCRIPTION
## Why is this PR needed?

To also run tests that were disabled until now.

Fixes: https://github.com/SUSE/avant-garde/issues/1409

## What does this PR do?

Also run all tests for the `Certified Kubernetes Conformance Program` and not only the non-disruptive ones.

## Anything else a reviewer needs to know?

## Info for QA

Doesn't change product only enables additional tests.

### Related info

### Status **BEFORE** applying the patch

https://ci.suse.de/view/CaaSP/view/Dashboard%20v4%20Dashboard/job/caasp-jobs/job/v4/job/conformance/job/vmware-conformance/360/testReport/

Number of tests: Skip: 4717 Pass: 275

### Status **AFTER** applying the patch

Fewer tests skipped:

https://ci.suse.de/view/CaaSP/view/Dashboard%20v4%20Dashboard/job/caasp-jobs/job/v4/job/conformance/job/vmware-conformance/364/testReport/

Number of tests: Skip: 4715 diff -2  Pass: 277 diff +2

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
