### PR TITLE
Set platform from pr label

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -57,6 +57,9 @@ pipeline {
         PR_CONTEXT = 'jenkins/skuba-test'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
+        LIBVIRT_URI = 'qemu+ssh://jenkins@kvm-ci.nue.caasp.suse.net/system'
+        LIBVIRT_KEYFILE = credentials('libvirt-keyfile')
+        LIBVIRT_IMAGE_URI = 'http://download.suse.de/install/SLE-15-SP1-JeOS-QU2/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU2.qcow2'
     }
 
     stages {


### PR DESCRIPTION
## Why is this PR needed?

Some PR are specific to a platform. For example, CPI related PRs must be tested in the corresponding platform. 

Fixes #

## What does this PR do?

Sets the platform to the one specified in the  `ci-platform` label, if specified.

## Anything else a reviewer needs to know?

As only the workers labeled as `kvm` can run tests in the `libvirt` platform, the PR must also be labeled with `ci-label:libvirt`.

The execution shows the pipeline starts with the regular `caasp-team-private-integration` label and then the `kvm` label was added:

![Screenshot from 2020-05-25 17-28-44](https://user-images.githubusercontent.com/720259/82826654-d519f380-9ead-11ea-9808-f00b4b4f8258.png)


Also, the provisioning step shows a `libvirt` platform was selected instead of the default `vmware` platform used for regular PR. 

```
+ make -f skuba/ci/Makefile provision
/home/jenkins/workspace/caasp-jobs_v4_pr_test_PR-1117/skuba/ci/infra/testrunner/testrunner --platform libvirt -c provision```
 ```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
