### PR TITLE
change ssh_sock to use TERRAFORM_STACK_NAME

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -356,10 +356,12 @@ skuba:
  
 #### Terraform
 
-It is advisable to use a unique id related to the job execution as the terraform stack name:
+It is advisable to use a unique id related to the job execution as the
+terraform stack name that doesn't contain slash or dash and is at a maximum 70
+bytes long:
 
 ```
-TERRAFORM_STACK_NAME  = "${JOB_NAME}-${BUILD_NUMBER}" 
+TERRAFORM_STACK_NAME  = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
 ```
 
 #### Openstack

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -40,7 +40,7 @@ packages:
 utils:
   ssh_key: "$WORKSPACE/skuba/ci/infra/id_shared" 
   ssh_user: "sles"
-  ssh_sock: "$WORKSPACE/agent.sock"
+  ssh_sock: "/tmp/$TERRAFORM_STACK_NAME/agent.sock"
 
 #openstack:
 #  openrc: "" #os.getenv("OPENSTACK_OPENRC")

--- a/ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test-libvirt.Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         SKUBA_BINPATH = '/home/jenkins/go/bin/skuba'
         GITHUB_TOKEN = credentials('github-token')
         PLATFORM = 'libvirt'
-        TERRAFORM_STACK_NAME = "${JOB_NAME.replaceAll("/","-")}-${BUILD_NUMBER}".take(70)
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
         PR_CONTEXT = 'jenkins/skuba-test-libvirt'
         PR_MANAGER = 'ci/jenkins/pipelines/prs/helpers/pr-manager'
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'


### PR DESCRIPTION
## Why is this PR needed?

When ssh-agend -a NAME is called with a NAME that is too long it fails
with:
```
unix_listener: path "/home/jenkins/workspace/caasp-jobs/v4/e2e/vmware/test_upgrade_plan_from_previous_with_upgraded_control_plane-daily/agent.sock" too long for Unix domain socket
```

Fixes: SUSE/avant-garde#1596

## What does this PR do?

change ssh_sock to use TERRAFORM_STACK_NAME

This ensure the resulting PATH is a maximum of 1+3+1+70+1+10=86 bytes long.

---

make one different TERRAFORM_STACK_NAME the same

Otherwise it might cut the build number off, which is what ensures it
being uniqe.

Also make the README match.

## Anything else a reviewer needs to know?

## Info for QA

### Related info

### Status **BEFORE** applying the patch

Choosing a long JOBNAME that results in a long $WORKSPACE does make it fail.

### Status **AFTER** applying the patch

Choosing a long JOBNAME that results in a long $WORKSPACE does not make it fail.

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
