### PR TITLE
CI: Reorganize jobs per caasp version

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -1,5 +1,5 @@
 - project:
-    name: caasp-jobs/v4/pr
+    name: caasp-jobs/pr
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
@@ -14,23 +14,27 @@
         - '{name}/jjb-validation'
 
 - project:
-      name: caasp-jobs/v4/conformance
+      name: caasp-jobs/conformance
       repo-name: skuba
       repo-owner: SUSE
       repo-credentials: github-token
       platform:
-        - openstack
-        - vmware
+          - openstack
+          - vmware
+      version:
+          - v4
       jobs:
-          - '{name}/{platform}-conformance'
+          - '{name}/{version}/{platform}/conformance'
 
 - project:
-    name: caasp-jobs/v4/e2e
+    name: caasp-jobs/e2e
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
     platform:
         - vmware
+    version:
+        - v4
     test:
         - test_addon_upgrade
         - test_cilium
@@ -50,8 +54,8 @@
         - test_upgrade_plan_from_previous_with_upgraded_control_plane:
            kubernetes_version: 1.17.4
     jobs:
-        - '{name}/{platform}/{test}-daily'
-        - '{name}/{platform}/update-daily'
+        - '{name}/{version}/{platform}/{test}-daily'
+        - '{name}/{version}/{platform}/update-daily'
 
 - job:
     name: caasp-jobs/caasp-jjb-skuba

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}/{platform}-conformance'
+    name: '{name}/{version}/{platform}/conformance'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/e2e-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-daily-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}/{platform}/{test}-daily'
+    name: '{name}/{version}/{platform}/{test}-daily'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/e2e-update-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-update-daily-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}/{platform}/update-daily'
+    name: '{name}/{version}/{platform}/update-daily'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

For some time it is expected to have jobs of versions CaaSP V4 and V5 in parallel. Those jobs must be easily differentiated.

The proposed structure is:
```
caasp-jobs
    pr
    e2e
        v4
        v5
    conformance
        v4
        v5
```
Fixes https://github.com/SUSE/avant-garde/issues/1608

## What does this PR do?

Adds the version as a parameter, to facilitate creating jobs for version 5

## Anything else a reviewer needs to know?

Before merging, the existing v4 jobs must be renamed to preserve their history. For doing so, the JJB job must be disabled during the renaming and re-enable after the merge. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
