### PR TITLE
Fix log message when service restart fail

### DIFF
--- a/skuba-update/skuba_update/skuba_update.py
+++ b/skuba-update/skuba_update/skuba_update.py
@@ -68,9 +68,8 @@ def main():
 
     # Check that we have the proper zypper version.
     if not check_version('zypper', REQUIRED_ZYPPER_VERSION):
-        raise Exception('zypper version {0} or higher is required'.format(
-            '.'.join([str(x) for x in REQUIRED_ZYPPER_VERSION])
-        ))
+        version = '.'.join([str(x) for x in REQUIRED_ZYPPER_VERSION])
+        raise Exception(f"zypper version {version} or higher is required")
 
     if os.geteuid() != 0:
         raise Exception('root privileges are required to run this tool')
@@ -92,7 +91,7 @@ def parse_args():
 
     annotate_only_msg = \
         'Do not install any update, just annotate there are available updates'
-    version_msg = '%(prog)s {0}'.format(version())
+    version_msg = f"%(prog)s {version()}"
 
     parser = argparse.ArgumentParser(description='Updates a CaaSP node')
     parser.add_argument(
@@ -244,7 +243,8 @@ def restart_services():
     for service in result.output.splitlines():
         cmd = run_command(['systemctl', 'restart', service], needsOutput=False)
         if cmd.returncode != 0:
-            log('Warning! Service \'{0}\' restart returned non zero exit code')
+            log((f"Warning! Service '{service}' restart returned non zero "
+                 "exit code"))
 
 
 def is_zypper_error(code):
@@ -300,10 +300,8 @@ def log(message):
     program.
     """
 
-    print('{0} [skuba-update] {1}'.format(
-        datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-        message)
-    )
+    datestr = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    print(f"{datestr} [skuba-update] {message}")
 
 
 def run_zypper_command(command, needsOutput=False):
@@ -315,7 +313,8 @@ def run_zypper_command(command, needsOutput=False):
 
     process = run_command(zypperCommand, needsOutput)
     if is_zypper_error(process.returncode):
-        raise Exception('"{0}" failed'.format(' '.join(zypperCommand)))
+        zypper_cmd_str = ' '.join(zypperCommand)
+        raise Exception(f'"{zypper_cmd_str}" failed')
     if needsOutput:
         return process
     return process.returncode
@@ -346,7 +345,8 @@ def run_command(command, needsOutput=True, added_env={}):
     command_type = namedtuple(
         'command', ['output', 'error', 'returncode']
     )
-    log('running \'{0}\''.format(' '.join(command)))
+    cmd_str = ' '.join(command)
+    log(f'running "{cmd_str}"')
     process = subprocess.Popen(
         command,
         stdout=subprocess.PIPE if needsOutput else None,
@@ -384,7 +384,7 @@ def check_version(call, version_waterline):
         if version_info is None:
             raise Exception
     except Exception:
-        message = 'Could not parse {0} version'.format(call)
+        message = f"Could not parse {call} version"
         raise Exception(message)
     return version_info >= version_waterline
 
@@ -412,7 +412,7 @@ def node_name_from_machine_id():
             if node['status']['nodeInfo']['machineID'] == machine_id:
                 return node['metadata']['name']
     except KeyError as e:
-        raise Exception('Unexpected format for node name: {}'.format(e))
+        raise Exception(f"Unexpected format for node name: {e}")
 
     raise Exception('Node name could not be determined via machine-id')
 
@@ -424,7 +424,7 @@ def annotate(resource, resource_name, key, value):
 
     ret = run_command([
         'kubectl', 'annotate', '--overwrite', resource, resource_name,
-        '{}={}'.format(key, value)],
+        f"{key}={value}"],
         added_env={'KUBECONFIG': KUBECONFIG_PATH}
     )
 


### PR DESCRIPTION
## Why is this PR needed?

The call to the "log" method to notify the user that the service restart
failed does not format the message adding the service name. This commit
fixes that adding a call to the "format" method of the string.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
