### PR TITLE
CI: Fix name of conformace test job

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -24,7 +24,7 @@
       version:
           - v4
       jobs:
-          - '{name}/{version}/{platform}/conformance'
+          - '{name}/{version}/{platform}'
 
 - project:
     name: caasp-jobs/e2e

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}/{version}/{platform}/conformance'
+    name: '{name}/{version}/{platform}'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30


### PR DESCRIPTION
After job reorganization introduced in https://github.com/SUSE/skuba/commit/5da73ae53bd6d09cc899b8635b2409f0b020c3a8 the  the 'conformace' postfix should had be removed from the job name.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
