### PR TITLE
Add a mirror to registry for testing images from branch 

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -463,7 +463,13 @@ optional arguments:
   -c, --cloud-provider  Use cloud provider integration
   -t TIMEOUT, --timeout TIMEOUT
                         timeout for waiting a node to become ready (seconds)
-
+  -m R M, --registry-mirror R M
+                        Add to the registry R a mirror M. If an image is
+			available at the mirror it will be preferred, otherwise
+                        the image in the original registry is used. This
+                        argument can be used multiple times, then mirrors will
+                        be tried in that order. Example:
+                        --registry-mirror registry.example.com/path test-registry.example.com/path
 ```
 
 ### Deploy
@@ -476,6 +482,13 @@ optional arguments:
   -c, --cloud-provider  Use cloud provider integration
   -t TIMEOUT, --timeout TIMEOUT
                         timeout for waiting a node to become ready (seconds)
+  -m R M, --registry-mirror R M
+                        Add to the registry R a mirror M. If an image is
+			available at the mirror it will be preferred, otherwise
+                        the image in the original registry is used. This
+                        argument can be used multiple times, then mirrors will
+                        be tried in that order. Example:
+                        --registry-mirror registry.example.com/path test-registry.example.com/path
 ```
 
 ### Join nodes

--- a/ci/infra/testrunner/platforms/platform.py
+++ b/ci/infra/testrunner/platforms/platform.py
@@ -18,7 +18,7 @@ class Platform:
         # Which logs will be collected from the nodes
         self.logs = {
             "files": [],
-            "dirs": ["/var/log/pods"],
+            "dirs": ["/var/log/pods", "/etc/crio", "/etc/containers"],
             "services": ["kubelet", "crio"]
         }
 

--- a/ci/infra/testrunner/requirements.txt
+++ b/ci/infra/testrunner/requirements.txt
@@ -4,3 +4,4 @@ pyhcl
 pytest==5.1.0
 pyyaml
 pytest-ordering
+toml

--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import toml
 
 import platforms
 from checks import Checker
@@ -39,11 +40,12 @@ class Skuba:
 
     @step
     def cluster_deploy(self, kubernetes_version=None, cloud_provider=None,
-                       timeout=None):
+                       timeout=None, registry_mirror=None):
         """Deploy a cluster joining all nodes"""
         self.cluster_bootstrap(kubernetes_version=kubernetes_version,
                                cloud_provider=cloud_provider,
-                               timeout=timeout)
+                               timeout=timeout,
+                               registry_mirror=registry_mirror)
         self.join_nodes(timeout=timeout)
 
     @step
@@ -64,17 +66,20 @@ class Skuba:
         self._run_skuba(cmd, cwd=self.workdir)
 
     @step
-    def cluster_bootstrap(self, kubernetes_version=None,
-                          cloud_provider=None, timeout=None):
+    def cluster_bootstrap(self, kubernetes_version=None, cloud_provider=None,
+                          timeout=None, registry_mirror=None):
         self.cluster_init(kubernetes_version, cloud_provider)
-        self.node_bootstrap(cloud_provider, timeout=timeout)
+        self.node_bootstrap(cloud_provider, timeout=timeout, registry_mirror=registry_mirror)
 
     @step
-    def node_bootstrap(self, cloud_provider=None, timeout=None):
+    def node_bootstrap(self, cloud_provider=None, timeout=None, registry_mirror=None):
         self._verify_bootstrap_dependency()
 
         if cloud_provider:
             self.platform.setup_cloud_provider(self.workdir)
+
+        if registry_mirror:
+            self._setup_container_registries(registry_mirror)
 
         master0_ip = self.platform.get_nodes_ipaddrs("master")[0]
         master0_name = self.platform.get_nodes_names("master")[0]
@@ -84,6 +89,26 @@ class Skuba:
 
         self.checker.check_node("master", 0, stage="joined", timeout=timeout)
 
+    def _setup_container_registries(self, registry_mirror):
+        mirrors = {}
+        for l in registry_mirror:
+            if l[0] not in mirrors:
+                mirrors[l[0]] = []
+            mirrors[l[0]].append(l[1])
+
+        conf = {'unqualified-search-registries': ['docker.io'], 'registry': []}
+        for location, mirror_list in mirrors.items():
+            mirror_toml = []
+            for m in mirror_list:
+                mirror_toml.append({'location': m, 'insecure': True})
+            conf['registry'].append(
+                    {'prefix': location, 'location': location,
+                        'mirror': mirror_toml})
+        conf_string = toml.dumps(conf)
+        c_dir = os.path.join(self.cluster_dir, 'addons/containers')
+        os.mkdir(c_dir)
+        with open(os.path.join(c_dir, 'registries.conf'), 'w') as f:
+            f.write(conf_string)
     @step
     def node_join(self, role="worker", nr=0, timeout=None):
         self._verify_bootstrap_dependency()

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -46,7 +46,8 @@ def deploy(options):
     skuba.cluster_deploy(
         kubernetes_version=options.kubernetes_version,
         cloud_provider=options.cloud_provider,
-        timeout=options.timeout)
+        timeout=options.timeout,
+        registry_mirror=options.registry_mirror)
 
 
 def bootstrap(options):
@@ -54,7 +55,8 @@ def bootstrap(options):
     skuba.cluster_bootstrap(
         kubernetes_version=options.kubernetes_version,
         cloud_provider=options.cloud_provider,
-        timeout=options.timeout)
+        timeout=options.timeout,
+        registry_mirror=options.registry_mirror)
 
 
 def cluster_status(options):
@@ -177,6 +179,16 @@ def main():
                                 help="Use cloud provider integration")
     bootstrap_args.add_argument("-t", "--timeout", type=int, default=300,
                                 help="timeout for waiting a node to become ready (seconds)")
+    bootstrap_args.add_argument("-m", "--registry-mirror", metavar=('R', 'M'),
+                                help="Add to the registry R a mirror M."
+                                     " If an image is available at the mirror"
+                                     " it will be preferred, otherwise the"
+                                     " image in the original registry is used."
+                                     " This argument can be used multiple"
+                                     " times, then mirrors will be tried in"
+                                     " that order."
+                                     " Example: --registry-mirror registry.example.com/path test-registry.example.com/path",
+                                nargs=2, action='append')
 
     cmd_bootstrap = commands.add_parser(
         "bootstrap", parents=[bootstrap_args], help="bootstrap k8s cluster")

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -72,6 +72,10 @@ func AddonsDir() string {
 	return "addons"
 }
 
+func ContainersDir() string {
+	return filepath.Join(AddonsDir(), "containers")
+}
+
 func CriDir() string {
 	return filepath.Join(AddonsDir(), "cri")
 }


### PR DESCRIPTION
## Why is this PR needed?

Add --registry-mirror for testrunner

Fixes https://github.com/SUSE/avant-garde/issues/1601

## What does this PR do?

testrunner: Add --registry-mirror
    
to add a mirror to a registy that takes priority and can be used to
branched images. Creates a configuration that skuba then deploys to
/etc/containers/registries.conf .

--

Also deploy /etc/containers/registries.conf

Needed for https://github.com/SUSE/avant-garde/issues/1601 to be able to
remap registries to test branched images.

--

testrunner: Add config files to gather_logs

## Anything else a reviewer needs to know?

## Info for QA

I tested the following:
* an invalid registry location `--registry-replace https://example.com https://test.example.com` makes crio fail to start up and report this in its log
* an [unused registry location ](https://ci.suse.de/blue/organizations/jenkins/caasp-jobs%2Fpr%2Ftest/detail/PR-1127/26/pipeline/)`--registry-mirror example.com/test test.example.com/test` still works
* [adding to caspv5 a name that will fail](https://ci.suse.de/blue/organizations/jenkins/caasp-jobs%2Fpr%2Ftest/detail/PR-1127/27/pipeline) `--registry-mirror registry.suse.de/devel/caasp/5/containers/cr/containers/caasp/v5 does-not-exist.suse.de/caasp/v5` still works
* [adding to caspv5 a registry that has one image](https://ci.suse.de/blue/organizations/jenkins/caasp-jobs%2Fpr%2Ftest/detail/PR-1127/29/pipeline/) `--registry-mirror registry.suse.de/devel/caasp/5/containers/cr/containers/caasp/v5 registry.suse.de/home/jzerebecki/branches/devel/caasp/5/containers/cr/containers/caasp/v5` still works TODO the CI logs do not show which image was used, so if the right images was picked was not verified

### Related info

### Status **BEFORE** applying the patch


### Status **AFTER** applying the patch

Test by using the features: --registry-replace for testrunner or addons/containers/registries.conf for skuba.

## Docs

https://confluence.suse.com/display/CaaSP/Jenkins+CI#JenkinsCI-Testbranchedimagesorpackagesthatgetincludedinimages

This PR adds support for a addons/containers directory. The existing skuba addons directory is currently not document: https://github.com/SUSE/doc-caasp/blob/master/adoc/deployment-bootstrap.adoc https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#bootstrap

The documentation about /etc/containers/registries.conf will still work as is, but it could mention that it is now possible to deploy it via skuba: https://github.com/SUSE/doc-caasp/blob/master/adoc/admin-crio-registries.adoc https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_configuring_container_registries_for_cri_o

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
