### PR TITLE
Select workers for daily jobs based on version

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -23,6 +23,8 @@
           - vmware
       version:
           - v4
+          - v5:
+              branch: experimental-v5
       jobs:
           - '{name}/{version}/{platform}'
 
@@ -35,6 +37,8 @@
         - vmware
     version:
         - v4
+        - v5:
+            branch: experimental-v5
     test:
         - test_addon_upgrade
         - test_cilium

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -1,5 +1,18 @@
+// type of worker required by the job 
+def worker_type = 'integration'
+
+node('caasp-team-private-integration') {
+    stage('select worker') {
+        if (env.BRANCH != 'master') {
+            if (env.BRANCH.startsWith('experimental') || env.BRANCH.startsWith('maintenance')) {
+                worker_type = env.BRANCH
+            }
+        }
+    }
+}
+
 pipeline {
-    agent { node { label 'caasp-team-private-integration' } }
+   agent { node { label 'caasp-team-private-${worker_type}' } }
 
     environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"

--- a/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
@@ -2,8 +2,21 @@
  * This pipeline runs any e2e test parametrized
  */
 
+// type of worker required by the job 
+def worker_type = 'integration'
+
+node('caasp-team-private-integration') {
+    stage('select worker') {
+        if (env.BRANCH != 'master') {
+            if (env.BRANCH.startsWith('experimental') || env.BRANCH.startsWith('maintenance')) {
+                worker_type = env.BRANCH
+            }
+        }
+    }
+}
+
 pipeline {
-   agent { node { label 'caasp-team-private-integration' } }
+   agent { node { label 'caasp-team-private-${worker_type}' } }
 
    parameters {
         string(name: 'E2E_MAKE_TARGET_NAME', defaultValue: 'all', description: 'The make target to run (only e2e related)')

--- a/ci/jenkins/pipelines/skuba-update-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-update-daily.Jenkinsfile
@@ -1,9 +1,22 @@
-/**
+/*
  * This pipeline verifies for the basic skuba-update os tests
  */
 
+// type of worker required by the job 
+def worker_type = 'integration'
+
+node('caasp-team-private-integration') {
+    stage('select worker') {
+        if (env.BRANCH != 'master') {
+            if (env.BRANCH.startsWith('experimental') || env.BRANCH.startsWith('maintenance')) {
+                worker_type = env.BRANCH
+            }
+        }
+    }
+}
+
 pipeline {
-   agent { node { label 'caasp-team-private-integration' } }
+   agent { node { label 'caasp-team-private-${worker_type}' } }
 
    environment {
         OPENRC = credentials('ecp-openrc')


### PR DESCRIPTION
## Why is this PR needed?

Daily jobs for different versions will use different source branches and require different workers for processing. 

Fixes https://github.com/SUSE/avant-garde/issues/1611

## What does this PR do?

Run daily jobs for multiple versions, each with a different source branch. Also, select the worker type based on the branch.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
