### PR TITLE
Select worker type based on target branch for PR

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -23,7 +23,8 @@ def worker_type = 'integration'
 // because agent labels are evaluated before environment is set
 def labels = ''
 node('caasp-team-private-integration') {
-    stage('set-labels') {
+    stage('select worker') {
+
         try {
            def response = httpRequest(
                url: "https://api.github.com/repos/SUSE/skuba/pulls/${CHANGE_ID}",
@@ -31,12 +32,29 @@ node('caasp-team-private-integration') {
                validResponseCodes: "200")
 
            def pr = readJSON text: response.content
+
+           // check if PR needs experimental or maintenance workers
+           // ci-worker label will override this selection
+           if (env.CHANGE_TARGET.startsWith('experimental-') || env.CHANGE_TARGET.startsWith('maintenance-')) {
+               worker_type = env.CHANGE_TARGET
+           }
+
+           //check if the PR requires an specific worker type
+           def pr_worker_label = pr.labels.find {
+               it.name.startsWith("ci-worker:")
+           }
+           if (pr_worker_label != null) {
+               worker_type = pr_worker_label.name.split(":")[1]
+           }
+
+          // check additional worker labels
            pr.labels.findAll {
              it.name.startsWith("ci-label:")
            }.each{
              def label = it.name.split(":")[1]
              labels = labels + " && " + label 
            }
+
            // check if the PR request an specific test platform
            def pr_platform_label = pr.labels.find {
                it.name.startsWith("ci-platform")


### PR DESCRIPTION
# Why is this PR needed?

Developers need to open PR against different target branches: master of maintenance. Each branch requires different workers to process the PR.

Fixes https://github.com/SUSE/avant-garde/issues/1611


## What does this PR do?

Following the convention that master and feature branches will use the default integration worker type, while the experimental-feature and maintenance-version branches will use
the corresponding worker types.


## Anything else a reviewer needs to know?


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
