### PR TITLE
Fix quotes in label to allow variable substitution

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -12,7 +12,7 @@ node('caasp-team-private-integration') {
 }
 
 pipeline {
-   agent { node { label 'caasp-team-private-${worker_type}' } }
+   agent { node { label "caasp-team-private-${worker_type}" } }
 
     environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"

--- a/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
@@ -16,7 +16,7 @@ node('caasp-team-private-integration') {
 }
 
 pipeline {
-   agent { node { label 'caasp-team-private-${worker_type}' } }
+   agent { node { label "caasp-team-private-${worker_type}" } }
 
    parameters {
         string(name: 'E2E_MAKE_TARGET_NAME', defaultValue: 'all', description: 'The make target to run (only e2e related)')

--- a/ci/jenkins/pipelines/skuba-update-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-update-daily.Jenkinsfile
@@ -16,7 +16,7 @@ node('caasp-team-private-integration') {
 }
 
 pipeline {
-   agent { node { label 'caasp-team-private-${worker_type}' } }
+   agent { node { label "caasp-team-private-${worker_type}" } }
 
    environment {
         OPENRC = credentials('ecp-openrc')


### PR DESCRIPTION
## Why is this PR needed?

After changes introduced in https://github.com/SUSE/skuba/pull/1129 worker labels are not properly setup

## What does this PR do?

Use double quotes in worker labels to allow for variable substitution.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
