### PR TITLE
Create separated projects for v4 and v5 daily jobs

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -27,16 +27,12 @@
           - '{name}/{version}/{platform}'
 
 - project:
-    name: caasp-jobs/e2e
+    name: caasp-jobs/e2e/v4
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
     platform:
         - vmware
-    version:
-        - v4
-        - v5:
-            branch: experimental-v5
     test:
         - test_addon_upgrade
         - test_cilium
@@ -56,8 +52,31 @@
         - test_upgrade_plan_from_previous_with_upgraded_control_plane:
            kubernetes_version: 1.17.4
     jobs:
-        - '{name}/{version}/{platform}/{test}-daily'
-        - '{name}/{version}/{platform}/update-daily'
+        - '{name}/{platform}/{test}-daily'
+        - '{name}/{platform}/update-daily'
+
+- project:
+    name: caasp-jobs/e2e/v5
+    repo-name: skuba
+    repo-owner: SUSE
+    repo-credentials: github-token
+    platform:
+        - vmware
+    branch: experimental-v5
+    test:
+        - test_addon_upgrade
+        - test_cilium
+        - test_dockercaps
+        - test_nginx_deployment
+        - test_node_reboot
+        - test_remove_master
+        - test_remove_worker
+        - test_upgrade_plan_all_fine
+        - test_upgrade_apply_all_fine
+    jobs:
+        - '{name}/{platform}/{test}-daily'
+        - '{name}/{platform}/update-daily'
+
 
 - job:
     name: caasp-jobs/caasp-jjb-skuba

--- a/ci/jenkins/templates/e2e-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-daily-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}/{version}/{platform}/{test}-daily'
+    name: '{name}/{platform}/{test}-daily'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/e2e-update-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-update-daily-template.yaml
@@ -1,5 +1,5 @@
 - job-template:
-    name: '{name}/{version}/{platform}/update-daily'
+    name: '{name}/{platform}/update-daily'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30


### PR DESCRIPTION
## Why is this PR needed?

The configuration for v4 and v5 jobs tend to diverge, requiring more independence in the configuration for each one. For example, the list of tests to be executed on each version differs. Some other parameters are also expected to change. 

Fixes https://github.com/SUSE/avant-garde/issues/1659

## What does this PR do?

Create a separate project for each version.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
