### PR TITLE
versions: Fix Cilium version for k8s v1.18.2

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -101,7 +101,7 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.5.3", 3},
+				Cilium:        &AddonVersion{"1.6.6", 3},
 				Kured:         &AddonVersion{"1.3.0", 5},
 				Dex:           &AddonVersion{"2.23.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 4},


### PR DESCRIPTION
Fixes: f3d2d0bf6d42 ("Update to Kubernetes v1.18.2")

Signed-off-by: Michal Rostecki <mrostecki@suse.de>