### PR TITLE
Collect logs from platform after e2e tests

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
             archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
             archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
             archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
-            archiveArtifacts(artifacts: 'skuba/ci/infra/testrunner/*.xml', allowEmptyArchive: true)
+            sh(script: "make --keep-going -f skuba/ci/Makefile gather_logs", label: 'Gather Logs')
             archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
         }
         cleanup {


### PR DESCRIPTION
## Why is this PR needed?

The e2e pipeline is not collecting the logs from the cluster nodes, including cloud-init, kubelet, cri-o, and system pods.

## What does this PR do?

Adds a step to the post-execution stage for collecting the logs using testrunner's get_logs command

## Note to reviewers

This same change was merged into v5 but should be applied to master in case experimental v5 is not merged into master soon.

## Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
