### PR TITLE
Fix typo in configuration comment

### DIFF
--- a/pkg/skuba/actions/cluster/init/manifests.go
+++ b/pkg/skuba/actions/cluster/init/manifests.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019-2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,14 @@
 package cluster
 
 const (
-	CriConfFolderReadme = `This directory contains CRI-O configuration files that are uploaded to CaaSP nodes. All the files (except this README) will be uploaded to the /etc/crio/conf.d/ folder. If it is required user custom files name as 99-custom.conf
+	CriConfFolderReadme = `This folder provides CRI-O configuration for CaaSP nodes.
+All the files (except this README) will be uploaded to the /etc/crio/crio.conf.d/ folder.
+If you need any customization, please add a custom files with the name 99-custom.conf
 	`
-	criDockerDefaultsConf = `## Path           : System/Management
+	criDockerDefaultsConf = `# PLEASE DON'T EDIT THIS FILE!
+# This file is managed by CaaSP skuba.
+
+## Path           : System/Management
 ## Description    : Extra cli switches for crio daemon
 ## Type           : string
 ## Default        : ""


### PR DESCRIPTION
The files are supposed to be in /etc/crio/crio.conf.d/ not
/etc/crio/conf.d/. Also cleanup wording a bit.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

The README generated in skuba init process step pointed to a file / directory location that does not exist. 

### Status **AFTER** applying the patch

The README generated in skuba init process step points to an existing directory.

## Docs

Docs do not need to be updated because they do not carry this typo.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
