### PR TITLE
Add kucero addon to auto rotates control plane certificates

### DIFF
--- a/internal/pkg/skuba/addons/kucero.go
+++ b/internal/pkg/skuba/addons/kucero.go
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
+	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
+)
+
+func init() {
+	registerAddon(kubernetes.Kucero, renderKuceroTemplate, nil, kuceroCallbacks{}, normalPriority, []getImageCallback{GetKuceroImage})
+}
+
+func GetKuceroImage(imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository, "kucero", imageTag)
+}
+
+func (renderContext renderContext) KuceroImage() string {
+	return GetKuceroImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Kucero, renderContext.config.ClusterVersion).Version)
+}
+
+func renderKuceroTemplate(addonConfiguration AddonConfiguration) string {
+	return kuceroManifest
+}
+
+type kuceroCallbacks struct{}
+
+func (kuceroCallbacks) beforeApply(addonConfiguration AddonConfiguration, skubaConfiguration *skuba.SkubaConfiguration) error {
+	return nil
+}
+
+func (kuceroCallbacks) afterApply(addonConfiguration AddonConfiguration, skubaConfiguration *skuba.SkubaConfiguration) error {
+	return nil
+}
+
+const (
+	kuceroManifest = `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kucero
+spec:
+  allowedHostPaths:
+  - pathPrefix: /etc/kubernetes/pki
+    readOnly: true
+  - pathPrefix: /var/lib/kubelet/pki
+    readOnly: true
+  fsGroup:
+    rule: RunAsAny
+  hostPID: true
+  privileged: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kucero
+  namespace: kube-system
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - kucero
+  resources:
+  - daemonsets
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kucero
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - extensions
+  resourceNames:
+  - kucero
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/kubelet-serving
+  resources:
+  - signers
+  verbs:
+  - approve
+  - sign
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/status
+  verbs:
+  - patch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kucero
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kucero
+subjects:
+- kind: ServiceAccount
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kucero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kucero
+subjects:
+- kind: ServiceAccount
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kucero
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: kucero
+  revisionHistoryLimit: 3
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: kucero
+      annotations:
+        {{.AnnotatedVersion}}
+    spec:
+      serviceAccountName: kucero
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostPID: true
+      restartPolicy: Always
+      containers:
+        - name: kucero
+          image: {{.KuceroImage}}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true # Give permission to nsenter /proc/1/ns/mnt
+          env:
+            # Pass in the name of the node on which this pod is scheduled
+            # for use with drain/uncordon operations and lock acquisition
+            - name: KUCERO_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command:
+            - /usr/bin/kucero
+            - --ca-cert-path=/var/lib/kubelet/pki/kubelet-ca.crt
+            - --ca-key-path=/var/lib/kubelet/pki/kubelet-ca.key
+          volumeMounts:
+            - mountPath: /var/lib/kubelet/pki/kubelet-ca.crt
+              name: ca-crt
+              readOnly: true
+            - mountPath: /var/lib/kubelet/pki/kubelet-ca.key
+              name: ca-key
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            # The initial delay for the liveness probe is intentionally large to
+            # avoid an endless kill & restart cycle if in the event that the initial
+            # bootstrapping takes longer than expected.
+            initialDelaySeconds: 120
+            failureThreshold: 10
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 60
+      volumes:
+        - name: ca-crt
+          hostPath:
+            path: /var/lib/kubelet/pki/kubelet-ca.crt
+            type: File
+        - name: ca-key
+          hostPath:
+            path: /var/lib/kubelet/pki/kubelet-ca.key
+            type: File
+`
+)

--- a/internal/pkg/skuba/addons/kucero_test.go
+++ b/internal/pkg/skuba/addons/kucero_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"testing"
+
+	img "github.com/SUSE/skuba/pkg/skuba"
+)
+
+func TestGetKuceroImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageTag string
+		want     string
+	}{
+		{
+			name:     "get kucero image without revision",
+			imageTag: "1.1.1",
+			want:     img.ImageRepository + "/kucero:1.1.1",
+		},
+		{
+			name:     "get kucero image with revision",
+			imageTag: "1.1.1-rev1",
+			want:     img.ImageRepository + "/kucero:1.1.1-rev1",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetKuceroImage(tt.imageTag); got != tt.want {
+				t.Errorf("GetKuceroImage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/skuba/addons/kucero_test.go
+++ b/internal/pkg/skuba/addons/kucero_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -18,17 +18,11 @@
 package ssh
 
 import (
-	"crypto/x509"
 	"io/ioutil"
-	"net"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/pkg/errors"
-	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/util/pkiutil"
 	"sigs.k8s.io/yaml"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
@@ -39,7 +33,6 @@ import (
 
 func init() {
 	stateMap["kubelet.rootcert.upload"] = kubeletUploadRootCert
-	stateMap["kubelet.servercert.create-and-upload"] = kubeletCreateAndUploadServerCert
 	stateMap["kubelet.configure"] = kubeletConfigure
 	stateMap["kubelet.enable"] = kubeletEnable
 }
@@ -57,84 +50,6 @@ func kubeletUploadRootCert(t *Target, data interface{}) error {
 		if _, _, err := t.silentSsh("chmod", "0400", filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletCAKeyName)); err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-func kubeletCreateAndUploadServerCert(t *Target, data interface{}) error {
-	// Read kubelet root ca certificate and key
-	caCert, caKey, err := pkiutil.TryLoadCertAndKeyFromDisk(skuba.PkiDir(), kubernetes.KubeletCACertAndKeyBaseName)
-	if err != nil {
-		return errors.Wrap(err, "failure loading kubelet CA certificate authority")
-	}
-
-	host := t.target.Nodename
-	altNames := certutil.AltNames{}
-	if ip := net.ParseIP(host); ip != nil {
-		altNames.IPs = append(altNames.IPs, ip)
-	} else {
-		altNames.DNSNames = append(altNames.DNSNames, host)
-	}
-
-	// Create AltNames with defaults DNSNames/IPs
-	stdout, _, err := t.silentSsh("hostname", "-I")
-	if err != nil {
-		return err
-	}
-	for _, addr := range strings.Split(stdout, " ") {
-		if ip := net.ParseIP(addr); ip != nil {
-			altNames.IPs = append(altNames.IPs, ip)
-		}
-	}
-
-	alternateIPs := []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback}
-	alternateDNS := []string{"localhost"}
-	if ip := net.ParseIP(t.target.Target); ip != nil {
-		alternateIPs = append(alternateIPs, ip)
-	} else {
-		alternateDNS = append(alternateDNS, t.target.Target)
-	}
-
-	altNames.IPs = append(altNames.IPs, alternateIPs...)
-	altNames.DNSNames = append(altNames.DNSNames, alternateDNS...)
-
-	certCfg := certutil.Config{
-		CommonName: host,
-		AltNames:   altNames,
-		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-	}
-	cfg := &pkiutil.CertConfig{
-		Config: certCfg,
-	}
-	cert, key, err := pkiutil.NewCertAndKey(caCert, caKey, cfg)
-	if err != nil {
-		return errors.Wrap(err, "couldn't generate kubelet server certificate")
-	}
-
-	// Save kubelet server certificate and key to local temporarily
-	if err := pkiutil.WriteCertAndKey(skuba.PkiDir(), host, cert, key); err != nil {
-		return errors.Wrapf(err, "failure while saving kubelet server %s certificate and key", host)
-	}
-
-	// Upload server certificate and key
-	certPath, keyPath := pkiutil.PathsForCertAndKey(skuba.PkiDir(), host)
-	if err := t.target.UploadFile(certPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerCertName)); err != nil {
-		return err
-	}
-	if err := t.target.UploadFile(keyPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerKeyName)); err != nil {
-		return err
-	}
-	if _, _, err := t.silentSsh("chmod", "0400", filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerKeyName)); err != nil {
-		return err
-	}
-
-	// Remove local temporarily kubelet server certificate and key
-	if err := os.Remove(certPath); err != nil {
-		return err
-	}
-	if err := os.Remove(keyPath); err != nil {
-		return err
 	}
 
 	return nil

--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -25,12 +25,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
+	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	skubautil "github.com/SUSE/skuba/internal/pkg/skuba/util"
 )
@@ -130,10 +132,28 @@ func RemoveAPIEndpointFromConfigMap(client clientset.Interface, node *corev1.Nod
 
 // UpdateClusterConfigurationWithClusterVersion allows us to set certain configurations during init, but also during upgrades.
 // The configuration that we put here will be consistently set to newly created configurations, and when we upgrade a cluster.
-func UpdateClusterConfigurationWithClusterVersion(initCfg *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
+func UpdateClusterConfigurationWithClusterVersion(initCfg *kubeadmapi.InitConfiguration, clusterVersion *version.Version) ([]byte, error) {
+	// apiserver
 	setApiserverAdmissionPlugins(initCfg, clusterVersion)
 	setContainerImagesWithClusterVersion(initCfg, clusterVersion)
 	setApiserverArgs(initCfg)
+
+	initCfgContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(initCfg, schema.GroupVersion{
+		Group:   "kubeadm.k8s.io",
+		Version: GetKubeadmApisVersion(clusterVersion),
+	})
+	if err != nil {
+		return []byte{}, err
+	}
+
+	// kubelet
+	kubeletManifest := []byte(`---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+serverTLSBootstrap: true
+`)
+
+	return append(initCfgContents, kubeletManifest...), nil
 }
 
 func setApiserverAdmissionPlugins(initCfg *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {

--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -367,7 +367,10 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 				}
 				initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = currentAdmissionPlugins
 			}
-			UpdateClusterConfigurationWithClusterVersion(&initCfg, tt.clusterVersion)
+			_, err := UpdateClusterConfigurationWithClusterVersion(&initCfg, tt.clusterVersion)
+			if err != nil {
+				t.Errorf("expected no error but an error returned: %v", err)
+			}
 			// Check admission plugins
 			gotAdmissionPlugins := initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"]
 			if gotAdmissionPlugins != expectedAdmissionPlugins {

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -45,13 +45,6 @@ const (
 	KubeletCACertName = "kubelet-ca.crt"
 	// KubeletCAKeyName defines kubelet's CA key name
 	KubeletCAKeyName = "kubelet-ca.key"
-
-	// KubeletServerCertAndKeyBaseName defines kubelet server certificate and key base name
-	KubeletServerCertAndKeyBaseName = "kubelet"
-	// KubeletServerCertName defines kubelet server certificate name
-	KubeletServerCertName = "kubelet.crt"
-	// KubeletServerKeyName defines kubelet server key name
-	KubeletServerKeyName = "kubelet.key"
 )
 
 // GenerateKubeletRootCert generates kubelet root CA certificate and key

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -132,6 +132,7 @@ var (
 				Dex:           &AddonVersion{"2.16.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 1},
+				Kucero:        &AddonVersion{"1.1.1", 0},
 				PSP:           &AddonVersion{"", 4},
 			},
 		},

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -37,6 +37,7 @@ const (
 	Dex           Addon = "dex"
 	Gangway       Addon = "gangway"
 	MetricsServer Addon = "metrics-server"
+	Kucero        Addon = "kucero"
 	PSP           Addon = "psp"
 
 	Kubelet          Component = "kubelet"
@@ -106,6 +107,7 @@ var (
 				Dex:           &AddonVersion{"2.23.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 4},
 				MetricsServer: &AddonVersion{"0.3.6", 0},
+				Kucero:        &AddonVersion{"1.1.1", 0},
 				PSP:           &AddonVersion{"", 2},
 			},
 		},

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -33,7 +33,6 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
-	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
@@ -259,14 +258,12 @@ func writeKubeadmInitConf(initConfiguration InitConfiguration) error {
 	if len(initConfiguration.CloudProvider) > 0 {
 		updateInitConfigurationWithCloudIntegration(&initCfg, initConfiguration)
 	}
-	kubeadm.UpdateClusterConfigurationWithClusterVersion(&initCfg, initConfiguration.KubernetesVersion)
-	initCfgContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(&initCfg, schema.GroupVersion{
-		Group:   "kubeadm.k8s.io",
-		Version: kubeadm.GetKubeadmApisVersion(initConfiguration.KubernetesVersion),
-	})
+
+	initCfgContents, err := kubeadm.UpdateClusterConfigurationWithClusterVersion(&initCfg, initConfiguration.KubernetesVersion)
 	if err != nil {
 		return err
 	}
+
 	if err := ioutil.WriteFile(skuba.KubeadmInitConfFile(), initCfgContents, 0600); err != nil {
 		return errors.Wrap(err, "error writing init configuration")
 	}

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -143,7 +143,6 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		criSetup,
 		"cri.start",
 		"kubelet.rootcert.upload",
-		"kubelet.servercert.create-and-upload",
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.init",

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -24,10 +24,8 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/version"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
@@ -104,11 +102,7 @@ func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapCon
 		return errors.Wrap(err, "unable to add target information to init configuration")
 	}
 
-	finalInitConfigurationContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(initConfiguration, schema.GroupVersion{
-		Group:   "kubeadm.k8s.io",
-		Version: kubeadm.GetKubeadmApisVersion(versionToDeploy),
-	})
-
+	finalInitConfigurationContents, err := kubeadm.UpdateClusterConfigurationWithClusterVersion(initConfiguration, versionToDeploy)
 	if err != nil {
 		return errors.Wrap(err, "could not marshal configuration")
 	}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -88,7 +88,6 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		criSetup,
 		"cri.start",
 		"kubelet.rootcert.upload",
-		"kubelet.servercert.create-and-upload",
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.join",

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -22,11 +22,8 @@ import (
 	"os"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	clientset "k8s.io/client-go/kubernetes"
-	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
-
 	"github.com/pkg/errors"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
@@ -107,11 +104,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 			initCfg.UseHyperKubeImage = false
 		}
 
-		kubeadm.UpdateClusterConfigurationWithClusterVersion(initCfg, nodeVersionInfoUpdate.Update.APIServerVersion)
-		initCfgContents, err = kubeadmconfigutil.MarshalInitConfigurationToBytes(initCfg, schema.GroupVersion{
-			Group:   "kubeadm.k8s.io",
-			Version: kubeadm.GetKubeadmApisVersion(nodeVersionInfoUpdate.Update.APIServerVersion),
-		})
+		initCfgContents, err = kubeadm.UpdateClusterConfigurationWithClusterVersion(initCfg, nodeVersionInfoUpdate.Update.APIServerVersion)
 		if err != nil {
 			return err
 		}

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -183,7 +183,6 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 	}
 	err = target.Apply(nil,
 		"kubelet.rootcert.upload",
-		"kubelet.servercert.create-and-upload",
 		"kubernetes.restart-services",
 	)
 	if err != nil {

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2019,2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Why is this PR needed?

Add kucero as an addon to auto rotates control plane certificates.

kucero includes two components:
- A Daemonset to pulling and rotates the kubeadm-managed certificates.
- A Controller to sign the kubelet server CSR.

refs: https://github.com/SUSE/avant-garde/issues/1632

## What does this PR do?

Add kucero as an addon.

## Anything else a reviewer needs to know?

We add kucero on both `1.17.4` and `1.18.2` because we want kucero deployed before node upgrade. Add kucero into the previous version make the user have to install kucero addon first.
Otherwise, the kubelet server CSR will in pending state since no signer signs the kubelet server certificate.

## Info for QA

Previously, the kubelet server certificate is self-signed by skuba with kubelet CA cert/key pair.
With this PR, the kubelet sends server CSR in K8s cluster, and kucero signed the server certificate to kubelet with kubelet CA cert/key pair, then kubelet save the server certificate in `/var/lib/kubelet/pki/kubelet-server-current.pem`.

Note that, the metrics-server trusted kubelet server certificate by kubelet CA cert.
If the kubelet server certificate signed by other CA, the metrics-server will in CrashLoopBack.

### Related info

Packages to be released:
* https://build.suse.de/package/show/Devel:CaaSP:5/kucero
* https://build.suse.de/package/show/Devel:CaaSP:5:Containers:CR/caasp-kucero-image

### Status **BEFORE** applying the patch

1. The kubeadm-managed server/client certificates will expire after 1 year.
2. The kubelet server certificate is self-signed by skuba with kubelet CA cert/key pair.

### Status **AFTER** applying the patch

1. The kucero will periodically checks the kubeadm-managed server/client certificates residual time, and rotates the certificates if necessary automatically, and restart kubelet after rotates certificates finished.
2. The kubelet will set `serverTLSBootstrap: true`, and kubelet will send server CSR. Then kucero will sign the kubelet server certificate by kubelet CA cert/key pair and kubelet saves the server certificate in `/var/lib/kubelet/pki/kubelet-server-current.pem`. The time kubelet send server CSR is handled by kubelet daemon.

## Docs

https://github.com/SUSE/doc-caasp/pull/879

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
