### PR TITLE
Schedule daily jobs by version

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -21,6 +21,7 @@
           - vmware
       version:
           - v4:
+              schedule: '1-3'
               branch: maintenance-caasp-v4 
           - v5
       jobs:
@@ -32,6 +33,7 @@
     repo-owner: SUSE
     repo-credentials: github-token
     branch: maintenance-caasp-v4
+    schedule: '1-3'
     platform:
         - vmware
     test:
@@ -61,6 +63,7 @@
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
+    schedule: '3-5'
     platform:
         - vmware
     test:

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -12,7 +12,7 @@ node('caasp-team-private-integration') {
 }
 
 pipeline {
-   agent { node { label "caasp-team-private-${worker_type}" } }
+   agent { node { label "caasp-team-private-${worker_type} && e2e" } }
 
     environment {
         SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"

--- a/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-daily.Jenkinsfile
@@ -16,7 +16,7 @@ node('caasp-team-private-integration') {
 }
 
 pipeline {
-   agent { node { label "caasp-team-private-${worker_type}" } }
+   agent { node { label "caasp-team-private-${worker_type} && e2e" } }
 
    parameters {
         string(name: 'E2E_MAKE_TARGET_NAME', defaultValue: 'all', description: 'The make target to run (only e2e related)')

--- a/ci/jenkins/pipelines/skuba-update-daily.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-update-daily.Jenkinsfile
@@ -16,7 +16,7 @@ node('caasp-team-private-integration') {
 }
 
 pipeline {
-   agent { node { label "caasp-team-private-${worker_type}" } }
+   agent { node { label "caasp-team-private-${worker_type} && e2e" } }
 
    environment {
         OPENRC = credentials('ecp-openrc')

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -4,12 +4,13 @@
     number-to-keep: 30
     days-to-keep: 30
     branch: master
+    schedule: '3-5'
     wrappers:
       - timeout:
           timeout: 180
           fail: true
     triggers:
-        - timed: 'H H(3-5) * * *'
+        - timed: 'H H({schedule}) * * *'
     parameters:
         - string:
             name: BRANCH

--- a/ci/jenkins/templates/e2e-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-daily-template.yaml
@@ -5,12 +5,13 @@
     days-to-keep: 30
     branch: master
     kubernetes_version: ''
+    schedule: '3-5'
     wrappers:
       - timeout:
           timeout: 120
           fail: true
     triggers:
-        - timed: 'H H(3-5) * * *'
+        - timed: 'H H({schedule}) * * *'
     parameters:
         - string:
             name: BRANCH

--- a/ci/jenkins/templates/e2e-update-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-update-daily-template.yaml
@@ -9,7 +9,7 @@
           timeout: 120
           fail: true
     triggers:
-        - timed: 'H H(3-5) * * *'
+        - timed: 'H H({schedule}) * * *'
     parameters:
         - string:
             name: BRANCH


### PR DESCRIPTION
## Why is this PR needed?

The introduction of the `maintenance-caas-v4` branch duplicates the number of daily jobs executed. This may cause resource contention if the jobs of both versions are scheduled concurrently.

This change extends the daily job execution window. As the development team is spread across multiple time zones, it is desirable to prevent the daily jobs delay PR jobs. 

Fixes https://github.com/SUSE/avant-garde/issues/1689

## What does this PR do? 

Schedule the jobs of each version in a different time range.

Use labels to ensure jobs are executed in dedicated workers, to avoid daily jobs to delay pr jobs.
 
# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
