### PR TITLE
Increase cilium's liveness/readiness probes timeout.

### DIFF
--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -267,19 +267,26 @@ spec:
             command:
             - cilium
             - status
+            - --brief
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
           initialDelaySeconds: 120
           failureThreshold: 10
-          periodSeconds: 10
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
         readinessProbe:
           exec:
             command:
             - cilium
             - status
+            - --brief
+          failureThreshold: 3
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 5
         volumeMounts:
           - name: cilium-run
             mountPath: /var/run/cilium

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -149,7 +149,7 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.5.3", 2},
+				Cilium:        &AddonVersion{"1.5.3", 3},
 				Kured:         &AddonVersion{"1.3.0", 4},
 				Dex:           &AddonVersion{"2.16.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
@@ -173,7 +173,7 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:  &AddonVersion{"1.5.3", 2},
+				Cilium:  &AddonVersion{"1.5.3", 3},
 				Kured:   &AddonVersion{"1.2.0-rev4", 2},
 				Dex:     &AddonVersion{"2.16.0", 6},
 				Gangway: &AddonVersion{"3.1.0-rev4", 5},


### PR DESCRIPTION
## Why is this PR needed?

The default liveness and readiness probes timeout used by cilium addon is
too short. It can fail sometime due the response time of the health
daemon. This commit increases the timeout to 5 seconds. To ensure the
time necessary to the daemon send the response.

Fixes bsc#1171316
