### PR TITLE
Enable toggling of the CNI plugin used in the cluster

### DIFF
--- a/cmd/skuba/cluster/init.go
+++ b/cmd/skuba/cluster/init.go
@@ -32,6 +32,7 @@ type initOptions struct {
 	KubernetesVersion string
 	CloudProvider     string
 	StrictCapDefaults bool
+	CniPlugin         string
 }
 
 // NewInitCmd creates a new `skuba cluster init` cobra command
@@ -47,7 +48,8 @@ func NewInitCmd() *cobra.Command {
 				initOptions.CloudProvider,
 				initOptions.ControlPlane,
 				initOptions.KubernetesVersion,
-				initOptions.StrictCapDefaults)
+				initOptions.StrictCapDefaults,
+				initOptions.CniPlugin)
 			if err != nil {
 				klog.Fatalf("init failed due to error: %s", err)
 			}
@@ -74,6 +76,8 @@ func NewInitCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("control-plane")
 
 	cmd.Flags().BoolVar(&initOptions.StrictCapDefaults, "strict-capability-defaults", false, "All the containers will start with CRI-O default capabilities")
+
+	cmd.Flags().StringVar(&initOptions.CniPlugin, "cni-plugin", "cilium", "Specify the CNI plugin to be used across the cluster. Valid values: cilium")
 
 	return cmd
 }

--- a/internal/pkg/skuba/addons/README.md
+++ b/internal/pkg/skuba/addons/README.md
@@ -20,9 +20,21 @@ https://golang.org/doc/effective_go.html#init
 ## How to create a new Addon
 
 To create a new addon, check the rest of the addons source file to
-understand what is required. Again, as long as the addon is in this
-directory, it will get called.
-
-You should also express the version mapping with kubernetes in:
+understand what is required. You should express the version mapping
+with kubernetes in:
 
 https://github.com/SUSE/skuba/blob/master/internal/pkg/skuba/kubernetes/versions.go
+
+Each addon must also declare its `AddOnType`. Any number of addons of type
+`CniAddOn`can be created. However, only a single addon of type `CniAddOn`
+can be used in the cluster and as such only one addon providing a CNI
+plugin will be activated and deployed.
+
+The CNI addon that is activated defaults to cilium, but can be toggled by
+passing `--cni-plugin` to `skuba cluster init`.
+
+Example:
+
+```sh
+skuba cluster init --control-plane load-balancer.example.com --cni-plugin cilium company-cluster
+```

--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.Cilium, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumInitImage, GetCiliumOperatorImage, GetCiliumImage})
+	registerAddon(kubernetes.Cilium, CniAddOn, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumInitImage, GetCiliumOperatorImage, GetCiliumImage})
 }
 
 func GetCiliumInitImage(imageTag string) string {

--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.Dex, renderDexTemplate, nil, dexCallbacks{}, normalPriority, []getImageCallback{GetDexImage})
+	registerAddon(kubernetes.Dex, GenericAddOn, renderDexTemplate, nil, dexCallbacks{}, normalPriority, []getImageCallback{GetDexImage})
 }
 
 func GetDexImage(imageTag string) string {

--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.Gangway, renderGangwayTemplate, nil, gangwayCallbacks{}, normalPriority, []getImageCallback{GetGangwayImage})
+	registerAddon(kubernetes.Gangway, GenericAddOn, renderGangwayTemplate, nil, gangwayCallbacks{}, normalPriority, []getImageCallback{GetGangwayImage})
 }
 
 func GetGangwayImage(imageTag string) string {

--- a/internal/pkg/skuba/addons/kured.go
+++ b/internal/pkg/skuba/addons/kured.go
@@ -24,7 +24,7 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.Kured, renderKuredTemplate, nil, nil, normalPriority, []getImageCallback{GetKuredImage})
+	registerAddon(kubernetes.Kured, GenericAddOn, renderKuredTemplate, nil, nil, normalPriority, []getImageCallback{GetKuredImage})
 }
 
 func GetKuredImage(imageTag string) string {

--- a/internal/pkg/skuba/addons/metricsserver.go
+++ b/internal/pkg/skuba/addons/metricsserver.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.MetricsServer, renderMetricsServerTemplate, nil, metricsServerCallbacks{}, normalPriority, []getImageCallback{GetMetricsServerImage})
+	registerAddon(kubernetes.MetricsServer, GenericAddOn, renderMetricsServerTemplate, nil, metricsServerCallbacks{}, normalPriority, []getImageCallback{GetMetricsServerImage})
 }
 
 func GetMetricsServerImage(imageTag string) string {

--- a/internal/pkg/skuba/addons/psp.go
+++ b/internal/pkg/skuba/addons/psp.go
@@ -20,7 +20,7 @@ package addons
 import "github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 
 func init() {
-	registerAddon(kubernetes.PSP, renderPSPTemplate, nil, nil, highPriority, []getImageCallback{})
+	registerAddon(kubernetes.PSP, GenericAddOn, renderPSPTemplate, nil, nil, highPriority, []getImageCallback{})
 }
 
 func renderPSPTemplate(addonConfiguration AddonConfiguration) string {


### PR DESCRIPTION
## Why is this PR needed?

Introduce special handling of CNI addons
    
This change introduces special handling of addons that introduce CNI plugins. The change introduces the following new functionality:
    
    - Introduce '--cni-plugin' flag for use with 'skuba cluster init'
    - Addons must now declare whether they provide a CNI plugin or not
    - The user-supplied CNI plugin request is checked against addons that provide
      CNI plugins
    - If '--cni-plugin' is not specified, cilium selected as the default CNI
      addon. This maintains backward-compatible behavior for 'skuba cluster init'
    - Rather than write config files for all CNI plugin addons,
      configuration files are only written for the selected CNI addon

This enables future support of CNI plugins beyond Cilium.

## What does this PR do?

This introduces a new optional flag for `skuba cluster init` that allows for specifying the CNI plugin to configure in the cluster. This change does not add suport for any new CNI's, it simply creates the framework by which new CNI plugins can be integrated. Support for new CNI plugins will be handled with future PR's.

`--cni-plugin` is an optional flag, and at this time only allows `cilium` to be passed as an option. These changes are backward-compatible: invoking `skuba cluster init` without `--cni-plugin` will emit manifests for Cilium as has been previously done. As more CNI plugins are added, they can be specified using `skuba cluster init --cni-plugin <CNI plugin name>`.

## Anything else a reviewer needs to know?

This PR adds automated test cases. All tests we have had in place are still valid.

## Info for QA

N/A

### Related info

* https://github.com/SUSE/avant-garde/issues/1673

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
