### PR TITLE
Update sonobuoy version

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -20,6 +20,7 @@
           - vmware
       version:
           - v4:
+              sonobuoy_version: 'v0.17'
               schedule: '1-3'
               branch: maintenance-caasp-v4 
           - v5

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -25,20 +25,6 @@ pipeline {
 
     stages {
 
-        stage('Git Clone') { steps {
-            deleteDir()
-            checkout([$class: 'GitSCM',
-                      branches: [[name: "*/${BRANCH}"]],
-                      doGenerateSubmoduleConfigurations: false,
-                      extensions: [[$class: 'LocalBranch'],
-                                   [$class: 'WipeWorkspace'],
-                                   [$class: 'RelativeTargetDirectory', relativeTargetDir: 'skuba'],
-                                   [$class: 'ChangelogToBranch', options: [compareRemote: "origin", compareTarget: "master"]]],
-                      submoduleCfg: [],
-                      userRemoteConfigs: [[refspec: '+refs/pull/*/head:refs/remotes/origin/PR-*',
-                                           credentialsId: 'github-token',
-                                           url: 'https://github.com/SUSE/skuba']]])
-        }}
         stage('Getting Ready For Cluster Deployment') { steps {
             sh(script: 'make -f skuba/ci/Makefile pre_deployment', label: 'Pre Deployment')
             sh(script: 'cd skuba; make install; cd ../', label: 'Install skuba')

--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
         TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
         GITHUB_TOKEN = credentials('github-token')
         VMWARE_ENV_FILE = credentials('vmware-env')
-        SONOBUOY_VERSION = "v0.17"
+        SONOBUOY_VERSION = "${SONOBUOY_VERSION}" 
     }
 
     stages {

--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -5,6 +5,7 @@
     days-to-keep: 30
     branch: master
     schedule: '3-5'
+    sonobuoy_version: 'v0.18.2'
     wrappers:
       - timeout:
           timeout: 180
@@ -20,6 +21,10 @@
               name: PLATFORM
               default: '{platform}'
               description: The platform to perform the tests on
+        - string:
+              name: SONOBUOY_VERSION 
+              default: '{sonobuoy_version}'
+              description: Version of sonobouy image to use
     pipeline-scm:
         scm:
             - git:


### PR DESCRIPTION
## Why is this PR needed?

Conformance tests are failing with error: `The maximum supported Kubernetes version is 1.17.99, but the server version is v1.18.2. Sonobuoy will continue but unexpected results may occur.`

Fixes https://github.com/SUSE/avant-garde/issues/1708

## What does this PR do?

Pass sonobuoy versio as a paramter to conformace tests.

Update sonobuoy version for master branch to one that supports k8s 1.18

Removes unnecessary checkout logic in the pipeline that prevents testing against the job agains a pr branch. 

# Note to reviewers

The PR was tested [running the conformance test job against the pr branch](https://ci.suse.de/job/caasp-jobs/job/conformance/job/v5/job/vmware/22/)

![Screenshot from 2020-06-16 11-41-49](https://user-images.githubusercontent.com/720259/84762440-1abc6e80-afcb-11ea-8e4b-995506925e06.png)

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
