### PR TITLE
Fix log collection in pr pipeline

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -241,7 +241,8 @@ pipeline {
     post {
         always { script {
             // collect artifacts only if pr-test stage was executed.
-            if (pr_context == 'jenkins/pr-test'){
+            // FIXME: this will break if we add an stage after skuba-test
+            if (pr_context == 'jenkins/skuba-test'){
                 archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
                 archiveArtifacts(artifacts: "skuba/ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
                 archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)


### PR DESCRIPTION
## Why is this PR needed?

The log collection is conditioned to the execution of the skuba-test stage, but the logic is asking for 'pr-test' instead.

## What does this PR do?

Use proper stage name for conditional

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
