### PR TITLE
Tumbleweed container has no diff cmd

### DIFF
--- a/skuba-update/test/os/suse/suse.sh
+++ b/skuba-update/test/os/suse/suse.sh
@@ -116,6 +116,7 @@ check_kubectl_calls() {
         for i in "$@"; do
             echo "$i" >> /commands.txt
         done
+        type -p diff || zypper -n in diffutils
         diff -w /commands.txt /tmp/kubectl-commands &> /dev/null
     fi
 }


### PR DESCRIPTION
The new tumbleweed images don't have the diff command by default.
This quick hack makes sures to install diffutils if necessary
when the diff command is used.

Partial-Fix: https://github.com/SUSE/avant-garde/issues/1660