### PR TITLE
Update the staging constants

### DIFF
--- a/pkg/skuba/staging_constants.go
+++ b/pkg/skuba/staging_constants.go
@@ -21,5 +21,5 @@ package skuba
 
 const (
 	BuildType       = "staging"
-	ImageRepository = "registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4"
+	ImageRepository = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/5/containers/caasp/v5"
 )


### PR DESCRIPTION
## Why is this PR needed?
This is needed to clear the references of CaaSPv4 on our current master (which is already CaaSPv5)
## What does this PR do?

This commit changes the staging constants to point to the appropriate
CaaSP v5 registry.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
