### PR TITLE
Do not render empty client secret (bsc#1173055)

### DIFF
--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -40,11 +40,11 @@ func (renderContext renderContext) GangwayImage() string {
 }
 
 func (renderContext renderContext) GangwayClientSecret() string {
+	// ignore error for `skuba cluster init` case
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
-		return ""
+		return gangway.GetClientSecret(nil)
 	}
-
 	return gangway.GetClientSecret(client)
 }
 

--- a/internal/pkg/skuba/addons/gangway_test.go
+++ b/internal/pkg/skuba/addons/gangway_test.go
@@ -21,8 +21,6 @@ import (
 	"regexp"
 	"testing"
 
-	"k8s.io/client-go/kubernetes/fake"
-
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
 	img "github.com/SUSE/skuba/pkg/skuba"
@@ -91,11 +89,9 @@ func Test_renderContext_GangwayImage(t *testing.T) {
 func Test_renderContext_GangwayClientSecret(t *testing.T) {
 	for _, ver := range kubernetes.AvailableVersions() {
 		t.Run("get gangway client secret when cluster version is "+ver.String(), func(t *testing.T) {
-			fake.NewSimpleClientset()
-
 			got := renderContext{}.GangwayClientSecret()
-			if got != "" {
-				t.Errorf("expect got client secret empty")
+			if got == "" {
+				t.Errorf("expect got client secret")
 				return
 			}
 		})

--- a/internal/pkg/skuba/gangway/gangway.go
+++ b/internal/pkg/skuba/gangway/gangway.go
@@ -91,6 +91,12 @@ func GetClientSecret(client clientset.Interface) string {
 		return gClientSecret
 	}
 
+	// generate a new client secret when `skuba cluster init`
+	if client == nil {
+		gClientSecret = dex.GenerateClientSecret()
+		return gClientSecret
+	}
+
 	// global client secret not exist, read from ConfigMap
 	clientSecret, err := getClientSecretFromConfigMap(client)
 	if err != nil || clientSecret == "" {

--- a/internal/pkg/skuba/gangway/gangway_test.go
+++ b/internal/pkg/skuba/gangway/gangway_test.go
@@ -151,6 +151,10 @@ customHTMLTemplatesDir: /usr/share/caasp-gangway/web/templates/caasp
 				},
 			}),
 		},
+		{
+			name:   "nil clientset",
+			client: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Why is this PR needed?

`skuba cluster init` would render an empty client secret to dex&gangway.
It might cause an issue when the admin wants to re-install the dex&gangway from generated manifested directly with `kubectl apply -f addons/dex/base/dex.yaml` & `kubectl apply -f addons/gangway/base/gangway.yaml`.

Furthermore, the admin would use kustomize the oidc dex connector by copy `addons/dex/base/dex.yaml` to `addon/dex/patches/dex-patch.yaml`, and modifies connector in `dex-patch.yaml`, this would cause the client secret is empty in the dex server (unmatched with gangway).

Fixes #1173055

## What does this PR do?

* render the client secret when `skuba cluster init` by checking the _client_ is nil or not.
* add retry function when get existed oidc-gangway-config Configmap, this prevents the client secret might regenerate when installing addon due to network issue.

## Anything else a reviewer needs to know?

This PR does not address using the single source of the client secret since dex supports it until `v2.23.0`, we'll address it in another PR. Therefore, there might be a case that the admin change either oidc-dex _or_ oidc-gangway client secret in each Configmap, makes the client secret out of sync.

NOTE: this PR is for CaaSP v4 only, for CaaSP v5 we'd have another better approach for this.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

xref https://github.com/SUSE/avant-garde/issues/1721

### Status **BEFORE** applying the patch

run `skuba cluster init`, the client secret is empty in `addons/dex/base/dex.yaml` & `addons/gangway/base/gangway.yaml`.

### Status **AFTER** applying the patch

run `skuba cluster init`, the client secret is _not_ empty in `addons/dex/base/dex.yaml` & `addons/gangway/base/gangway.yaml`.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
