### PR TITLE
Fix the branched repo url

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -85,7 +85,7 @@ node('caasp-team-private-integration') {
            }
            if (pr_repo_label != null) {
                def branch_name = pr_repo_label.name.split(":")[1]
-               branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP1"
+               branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP2"
 
            }
 


### PR DESCRIPTION
## Why is this PR needed?

The URL for the branched repo is pointing to a wrong OBS repository,
for CaaSPv5 instead of SLE_15_SP1 we are using SLE_15_SP2.

## What does this PR do?

Update the URL to make use of `SLE_15_SP2`

