### PR TITLE
Support Patternless kubernetes and crio packages

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/zypper.go
+++ b/internal/pkg/skuba/deployments/ssh/zypper.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 SUSE LLC.
+ * Copyright (c) 2020 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  *
  */
 
-package deployments
+package ssh
 
-func (t *Target) InstallNodePattern(kubernetesBaseOSConfiguration KubernetesBaseOSConfiguration) (bool, error) {
-	err := t.Apply(kubernetesBaseOSConfiguration, "kubernetes.install-node-pattern")
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+func (t *Target) zypperInstall(packages ...string) (stdout string, stderr string, error error) {
+	// Runs a zypper install command wrapped with the right userdata and parameters
+	var cliArgs []string
+	cliArgs = append(cliArgs, "--userdata", "skuba")
+	cliArgs = append(cliArgs, "--non-interactive", "install", "--")
+	cliArgs = append(cliArgs, packages...)
+	return t.ssh("zypper", cliArgs...)
 }

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -91,9 +91,9 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 func coreBootstrap(initConfiguration *kubeadmapi.InitConfiguration, bootstrapConfiguration deployments.BootstrapConfiguration, target *deployments.Target) error {
 	versionToDeploy := version.MustParseSemantic(initConfiguration.KubernetesVersion)
 
-	if _, err := target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
+	if err := target.Apply(deployments.KubernetesBaseOSConfiguration{
 		CurrentVersion: versionToDeploy.String(),
-	}); err != nil {
+	}, "kubernetes.install-fresh-pkgs"); err != nil {
 		return err
 	}
 

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -52,10 +52,9 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		return err
 	}
 
-	_, err = target.InstallNodePattern(deployments.KubernetesBaseOSConfiguration{
+	if err := target.Apply(deployments.KubernetesBaseOSConfiguration{
 		CurrentVersion: currentClusterVersion.String(),
-	})
-	if err != nil {
+	}, "kubernetes.install-fresh-pkgs"); err != nil {
 		return err
 	}
 

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -148,7 +148,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		err = target.Apply(deployments.KubernetesBaseOSConfiguration{
 			UpdatedVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
 			CurrentVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
-		}, "kubernetes.install-node-pattern")
+		}, "kubernetes.upgrade-stage-one")
 		if err != nil {
 			return err
 		}
@@ -164,8 +164,9 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		return err
 	}
 	err = target.Apply(deployments.KubernetesBaseOSConfiguration{
-		CurrentVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
-	}, "kubernetes.install-node-pattern")
+		UpdatedVersion: nodeVersionInfoUpdate.Update.KubeletVersion.String(),
+		CurrentVersion: nodeVersionInfoUpdate.Current.KubeletVersion.String(),
+	}, "kubernetes.upgrade-stage-two")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Without this patch, skuba is not able to install the new
kind of packages (patternless).

This is a problem, as it's necessary to install caasp5.

This also tackles the upgrade case, where we remove
the previous packages, and install the new kind of pkgs.

Partial-Fixes: https://github.com/SUSE/avant-garde/issues/1663