### PR TITLE
Update release constants to v5

### DIFF
--- a/pkg/skuba/release_constants.go
+++ b/pkg/skuba/release_constants.go
@@ -21,5 +21,5 @@ package skuba
 
 const (
 	BuildType       = "release"
-	ImageRepository = "registry.suse.com/caasp/5"
+	ImageRepository = "registry.suse.com/caasp/v5"
 )

--- a/pkg/skuba/release_constants.go
+++ b/pkg/skuba/release_constants.go
@@ -21,5 +21,5 @@ package skuba
 
 const (
 	BuildType       = "release"
-	ImageRepository = "registry.suse.com/caasp/v4"
+	ImageRepository = "registry.suse.com/caasp/5"
 )


### PR DESCRIPTION
package in SCC is pointing to v4 images, instead of to v5. This fixes it.