### PR TITLE
Implement manual e2e test job

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -80,6 +80,14 @@
         - '{name}/{platform}/{test}-daily'
         - '{name}/{platform}/update-daily'
 
+- project:
+    name: caasp-jobs/dev
+    repo-name: skuba
+    repo-owner: SUSE
+    repo-credentials: github-token
+    jobs:
+        - '{name}/e2e-test'
+
 
 - job:
     name: caasp-jobs/caasp-jjb-skuba

--- a/ci/jenkins/templates/e2e-dev-template.yaml
+++ b/ci/jenkins/templates/e2e-dev-template.yaml
@@ -1,34 +1,41 @@
 - job-template:
-    name: '{name}/{platform}/{test}-daily'
+    name: '{name}/e2e-test'
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30
-    branch: master
-    kubernetes_version: ''
-    schedule: '3-5'
     wrappers:
       - timeout:
           timeout: 120
           fail: true
-    triggers:
-        - timed: 'H H({schedule}) * * *'
     parameters:
         - string:
             name: BRANCH
-            default: '{branch}'
+            default: 'master'
             description: The branch to checkout
         - string:
               name: PLATFORM
-              default: '{platform}'
+              default: 'vmware'
               description: The platform to perform the tests on
         - string:
             name: E2E_MAKE_TARGET_NAME
-            default: '{test}'
+            default: ''
             description: The make target to run (only e2e tests)
         - string:
               name: KUBERNETES_VERSION 
-              default: '{kubernetes_version}'
+              default: ''
               description: version of kubernetes to install
+        - string:
+              name: WORKER_TYPE 
+              default: ''
+              description: worker type required by the job
+        - string:
+              name: WORKER_LABELS 
+              default: ''
+              description: additional labels used for worker selection
+        - string:
+              name: REPO_BRANCH 
+              default: ''
+              description: repository branch used for skuba packages
     pipeline-scm:
         scm:
             - git:


### PR DESCRIPTION
## Why is this PR needed?

Updates in packages and images used by skuba sometimes do not require corresponding modifications in the skuba code and therefore cannot be tested ina PR. 

Fixes: https://github.com/SUSE/avant-garde/issues/1735

## What does this PR do?

Create a job that runs an e2e tests with a specific configuration
- worker type
- worker selection labels
- platform
- repository branch
- kubernetes version

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
