### PR TITLE
[terraform] fix mtu from 1400 to standard 1500

### DIFF
--- a/ci/infra/aws/cloud-init/cloud-init.yaml.tpl
+++ b/ci/infra/aws/cloud-init/cloud-init.yaml.tpl
@@ -10,7 +10,7 @@ ssh_authorized_keys:
 ${authorized_keys}
 
 bootcmd:
-  - ip link set dev eth0 mtu 1400
+  - ip link set dev eth0 mtu 1500
 
 runcmd:
 ${register_scc}

--- a/ci/infra/libvirt/cloud-init/common.tpl
+++ b/ci/infra/libvirt/cloud-init/common.tpl
@@ -41,9 +41,6 @@ ${repositories}
 # set hostname
 hostname: ${hostname}
 
-bootcmd:
-  - ip link set dev eth0 mtu 1400
-
 runcmd:
   # Set node's hostname from DHCP server
   - sed -i -e '/^DHCLIENT_SET_HOSTNAME/s/^.*$/DHCLIENT_SET_HOSTNAME=\"${hostname_from_dhcp}\"/' /etc/sysconfig/network/dhcp

--- a/ci/infra/openstack/cloud-init/common.tpl
+++ b/ci/infra/openstack/cloud-init/common.tpl
@@ -38,9 +38,6 @@ ${repositories}
 # set hostname
 hostname: ${hostname}
 
-bootcmd:
-  - ip link set dev eth0 mtu 1400
-
 runcmd:
   # workaround for bsc#1119397 . If this is not called, /etc/resolv.conf is empty
   - netconfig -f update


### PR DESCRIPTION
## Why is this PR needed?

This is probably a leftover form developement, there is no need to set the MTU to 1400.

On AWS, it is required otherwise we get 9001 MTU.

Signed-off-by: lcavajani <lcavajani@suse.com>

## What does this PR do?

set MTU to 1500 on AWS and use the default with libvirt and openstack

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

`ip link show eth0` should show `1500` for all platforms unless there is a specific configuration.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
