### PR TITLE
[terraform] Enable security group management in CPI config

### DIFF
--- a/ci/infra/openstack/generate-cpi-conf.sh
+++ b/ci/infra/openstack/generate-cpi-conf.sh
@@ -37,6 +37,7 @@ create-monitor=yes
 monitor-delay=1m
 monitor-timeout=30s
 monitor-max-retries=3
+manage-security-groups=true
 [BlockStorage]
 trust-device-path=false
 bs-version=v2


### PR DESCRIPTION
## Why is this PR needed?

When the OpenStack cloud provider is enabled, all cloud load
balancer instances created to reflect LoadBalancer type services
are automatically associated with the default security group in
the OpenStack project specified in the cloud provider configuration.
There is a cloud provider setting, manage-security-groups [1],
that can be enabled to allow the kubernetes OpenStack cloud provider
to manage load balancer security group rules automatically to match
the service ports.

The node-security-group setting has been deprecated [2] and is not
required anymore.

[1] https://github.com/kubernetes/kubernetes/pull/31921
[2] https://github.com/kubernetes/kubernetes/issues/58145


## What does this PR do?

Enable the `manage-security-groups` OpenStack CPI setting,
to allow the kubernetes OpenStack cloud provider to manage load
balancer security group rules automatically to match the service ports.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

Deploy a CaaSP cluster on top of OpenStack, with the OpenStack cloud provider enabled, in a project with a default security group that blocks all traffic. Creating a LoadBalancer type service should be possible, however, no services can be accessed via the external IP.

### Status **AFTER** applying the patch

The external IP associated with LoadBalancer type services can be used to access services, even when the CaaSP cluster is deployed on top of an OpenStack infra in a project with a default security group that blocks all incoming traffic. 

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
