### PR TITLE
Set image alternate mirror from ci-repo label

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -21,6 +21,10 @@ endif
 ifdef KUBERNETES_VERSION
 K8S_VERSION_OPT=--kubernetes-version ${KUBERNETES_VERSION}
 endif
+ifdef BRANCH_REGISTRY
+REGISTRY_OPT=--registry-mirror ${ORIGINAL_REGISTRY} ${BRANCH_REGISTRY}
+endif
+BOOTSTRAP_OPT=${REGISTRY_OPT} ${K8S_VERSION_OPT}
 
 .PHONY: all
 all: provision deploy
@@ -33,7 +37,7 @@ provision:
 
 .PHONY: bootstrap
 bootstrap:
-	${TEST_RUNNER} --platform ${PLATFORM} bootstrap ${K8S_VERSION_OPT}
+	${TEST_RUNNER} --platform ${PLATFORM} bootstrap ${BOOTSTRAP_OPT}
 
 .PHONY: join_nodes 
 join_nodes:
@@ -41,7 +45,7 @@ join_nodes:
 
 .PHONY: deploy 
 deploy:
-	${TEST_RUNNER} --platform ${PLATFORM} deploy ${K8S_VERSION_OPT}
+	${TEST_RUNNER} --platform ${PLATFORM} deploy ${BOOTSTRAP_OPT}
 
 .PHONY: check_cluster
 check_cluster:

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -10,10 +10,14 @@ def pr_context = ''
 // Platform for pr tests.
 def platform = 'vmware'
 
-// Repo branch
+// Repo and registry branch
 def branch_repo = ""
+def branch_registry = ""
 
-// CaaSP Version for repo branch
+// original (non-branched) registry, only needed when branch_registry is in use
+def original_registry = ""
+
+// CaaSP Version for repo and registry branch
 def repo_version = "5"
 
 // type of worker required by the PR
@@ -86,7 +90,8 @@ node('caasp-team-private-integration') {
            if (pr_repo_label != null) {
                def branch_name = pr_repo_label.name.split(":")[1]
                branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP2"
-
+               branch_registry = "registry.suse.de/Devel/CaaSP/${repo_version}/Branches/${branch_name}/containers/cr/containers/caasp/v${repo_version}"
+               original_registry = "registry.suse.de/devel/caasp/5/containers/cr/containers/caasp/v5"
            }
 
         } catch (Exception e) {
@@ -216,6 +221,8 @@ pipeline {
         stage('Provision cluster') {
             environment {
                 BRANCH_REPO = "${branch_repo}"
+                BRANCH_REGISTRY = "${branch_registry}"
+                ORIGINAL_REGISTRY = "${original_registry}"
             }
             steps {
                 sh(script: 'make -f skuba/ci/Makefile provision', label: 'Provision')


### PR DESCRIPTION
## Why is this PR needed?

To have a way to test PRs with an image repository branch.

Fixes: https://github.com/SUSE/avant-garde/issues/1728

## What does this PR do?

Set image alternate mirror from ci-repo label

The IBS download url derived from the ci-repo label is passed in the
environment variable BRANCH_REGISTRY. The registry that can be set as an
alternate image mirror can be drived from that.

## Anything else a reviewer needs to know?

## Info for QA

### Related info

Depends-On: https://github.com/SUSE/skuba/pull/1127

TODO test with a branch

### Status **BEFORE** applying the patch

The ci-repo label on a PR doesn't affect the image repository config.

### Status **AFTER** applying the patch

When the ci-repo label is on a PR any images in the matching repository will be used instead of the one in the normal repository.

## Docs

https://confluence.suse.com/display/CaaSP/Jenkins+CI#JenkinsCI-Testbranchedimagesorpackagesthatgetincludedinimages

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
