### PR TITLE
Allow ssh through bastion with skuba

### DIFF
--- a/docs/man/skuba-node-bootstrap.1.md
+++ b/docs/man/skuba-node-bootstrap.1.md
@@ -23,7 +23,7 @@ the first node of a cluster
   IP or host name of the node to connect to using SSH
 
 **--user, -u**
-  User identity used to connect to target
+  User identity used to connect to target (required)
 
 **--port, -p**
   Port to connect to using SSH
@@ -38,7 +38,7 @@ the first node of a cluster
   IP or FQDN of the bastion to connect to the other nodes using SSH
 
 **--bastion-user**
-  User identity used to connect to the bastion using SSH (default to target user)
+  User identity used to connect to the bastion using SSH (defaults to target user)
 
 **--bastion-port**
   Port to connect to the bastion using SSH (default 22)

--- a/docs/man/skuba-node-bootstrap.1.md
+++ b/docs/man/skuba-node-bootstrap.1.md
@@ -6,6 +6,7 @@ bootstrap - Bootstraps the first master node of the cluster
 # SYNOPSIS
 **bootstrap**
 [**--help**|**-h**] [**--target**|**-t**] [**--user**|**-u**]
+[**--bastion] [**--bastion-user**] [**--bastion-port**]
 [**--sudo**|**-s**] [**--port**|**-p**] [**--ignore-preflight-errors**]
 *bootstrap* *<node-name>* *-t <fqdn>* [-hsp] [-u user] [-p port]
 
@@ -22,13 +23,22 @@ the first node of a cluster
   IP or host name of the node to connect to using SSH
 
 **--user, -u**
-  User identity used to connect to target (default=root)
-
-**--sudo, -s**
-  Run remote command via sudo (defaults to ssh connection user identity)
+  User identity used to connect to target
 
 **--port, -p**
   Port to connect to using SSH
 
+**--sudo, -s**
+  Run remote command via sudo (defaults to ssh connection user identity)
+
 **--ignore-preflight-errors**
   A list of checks whose errors will be shown as warnings. Value 'all' ignores errors from all checks.
+
+**--bastion**
+  IP or FQDN of the bastion to connect to the other nodes using SSH
+
+**--bastion-user**
+  User identity used to connect to the bastion using SSH (default to target user)
+
+**--bastion-port**
+  Port to connect to the bastion using SSH (default 22)

--- a/docs/man/skuba-node-join.1.md
+++ b/docs/man/skuba-node-join.1.md
@@ -22,7 +22,7 @@ join - join a node to a cluster
   IP or host name of the node to connect to using SSH
 
 **--user, -u**
-  User identity used to connect to target
+  User identity used to connect to target (required)
 
 **--port, -p**
   Port to connect to using SSH
@@ -40,7 +40,7 @@ join - join a node to a cluster
   IP or FQDN of the bastion to connect to the other nodes using SSH
 
 **--bastion-user**
-  User identity used to connect to the bastion using SSH (default to target user)
+  User identity used to connect to the bastion using SSH (defaults to target user)
 
 **--bastion-port**
   Port to connect to the bastion using SSH (default 22)

--- a/docs/man/skuba-node-join.1.md
+++ b/docs/man/skuba-node-join.1.md
@@ -6,6 +6,7 @@ join - join a node to a cluster
 # SYNOPSIS
 **join**
 [**--help**|**-h**] [**--target**|**-t**] [**--user**|**-u**] [**--role**|**-r**]
+[**--bastion] [**--bastion-user**] [**--bastion-port**]
 [**--sudo**|**-s**] [**--port**|**-p**] [**--ignore-preflight-errors**]
 *join* *<node-name>* *-t <fqdn>* [-hsp] [-r master] [-u user] [-p port]
 
@@ -21,16 +22,25 @@ join - join a node to a cluster
   IP or host name of the node to connect to using SSH
 
 **--user, -u**
-  User identity used to connect to target (default=root)
-
-**--role, -r**
-  (required) Role that this node will have in the cluster (master|worker)
-
-**--sudo, -s**
-  Run remote command via sudo (defaults to ssh connection user identity)
+  User identity used to connect to target
 
 **--port, -p**
   Port to connect to using SSH
 
+**--sudo, -s**
+  Run remote command via sudo (defaults to ssh connection user identity)
+
+**--role, -r**
+  (required) Role that this node will have in the cluster (master|worker)
+
 **--ignore-preflight-errors**
   A list of checks whose errors will be shown as warnings. Value 'all' ignores errors from all checks.
+
+**--bastion**
+  IP or FQDN of the bastion to connect to the other nodes using SSH
+
+**--bastion-user**
+  User identity used to connect to the bastion using SSH (default to target user)
+
+**--bastion-port**
+  Port to connect to the bastion using SSH (default 22)

--- a/docs/man/skuba-node-upgrade-apply.1.md
+++ b/docs/man/skuba-node-upgrade-apply.1.md
@@ -23,7 +23,7 @@ apply - Applies the upgrade plan for the given node
   IP or host name of the node to connect to using SSH
 
 **--user, -u**
-  User identity used to connect to target
+  User identity used to connect to target (required)
 
 **--port, -p**
   Port to connect to using SSH
@@ -35,7 +35,7 @@ apply - Applies the upgrade plan for the given node
   IP or FQDN of the bastion to connect to the other nodes using SSH
 
 **--bastion-user**
-  User identity used to connect to the bastion using SSH (default to target user)
+  User identity used to connect to the bastion using SSH (defaults to target user)
 
 **--bastion-port**
   Port to connect to the bastion using SSH (default 22)

--- a/docs/man/skuba-node-upgrade-apply.1.md
+++ b/docs/man/skuba-node-upgrade-apply.1.md
@@ -7,6 +7,7 @@ apply - Applies the upgrade plan for the given node
 # SYNOPSIS
 **apply**
 [**--help**|**-h**] [**--port**|**-p**] [**--sudo**|**-s**] [**--target**|**-t**]
+[**--bastion] [**--bastion-user**] [**--bastion-port**]
 [**--user**|**-u**]
 *apply* *-t <fqdn>* [-hs] [-u user] [-p port]
 
@@ -18,14 +19,23 @@ apply - Applies the upgrade plan for the given node
 **--help, -h**
   Print usage statement.
 
+**--target, -t**
+  IP or host name of the node to connect to using SSH
+
+**--user, -u**
+  User identity used to connect to target
+
 **--port, -p**
   Port to connect to using SSH
 
 **--sudo, -s**
   Run remote command via sudo (defaults to ssh connection user identity)
 
-**--target, -t**
-  IP or host name of the node to connect to using SSH
+**--bastion**
+  IP or FQDN of the bastion to connect to the other nodes using SSH
 
-**--user, -u**
-  User identity used to connect to target (default=root)
+**--bastion-user**
+  User identity used to connect to the bastion using SSH (default to target user)
+
+**--bastion-port**
+  Port to connect to the bastion using SSH (default 22)

--- a/internal/pkg/skuba/deployments/ssh/ssh.go
+++ b/internal/pkg/skuba/deployments/ssh/ssh.go
@@ -355,7 +355,7 @@ func hostKeyChecker() (ssh.HostKeyCallback, error) {
 					Filename    string
 				}{
 					algoStr,
-					remote.String(),
+					hostname,
 					keyFingerprintStr,
 					defKnownHosts,
 				}); err != nil {
@@ -372,7 +372,7 @@ func hostKeyChecker() (ssh.HostKeyCallback, error) {
 				klog.Warning(replaceMessage(trustHostMessage))
 				klog.Infof("accepting SSH key for %q", hostname)
 				klog.Infof("adding fingerprint for %q to %q", hostname, defKnownHosts)
-				line := knownhosts.Line([]string{remote.String()}, key)
+				line := knownhosts.Line([]string{hostname}, key)
 				if _, err := out.WriteString(line + "\n"); err != nil {
 					return err
 				}

--- a/internal/pkg/skuba/deployments/ssh/ssh.go
+++ b/internal/pkg/skuba/deployments/ssh/ssh.go
@@ -43,7 +43,7 @@ import (
 const (
 	// defKnowHosts is the default `known_hosts` file
 	defKnowHosts = "known_hosts"
-	defSSHUser   = "root"
+	defSSHUser   = "sles"
 	defSSHPort   = 22
 )
 

--- a/internal/pkg/skuba/deployments/ssh/ssh.go
+++ b/internal/pkg/skuba/deployments/ssh/ssh.go
@@ -110,6 +110,7 @@ func (t *Target) GetFlags() *flag.FlagSet {
 	flagSet.StringVarP(&t.targetName, "target", "t", "", "IP or FQDN of the node to connect to using SSH (required)")
 
 	_ = cobra.MarkFlagRequired(flagSet, "target")
+	_ = cobra.MarkFlagRequired(flagSet, "user")
 
 	return flagSet
 }
@@ -285,10 +286,6 @@ func (t *Target) initClient() error {
 }
 
 func createClientConfig(user string, agentClient agent.ExtendedAgent, hostKeyCallback ssh.HostKeyCallback) (*ssh.ClientConfig, error) {
-	if user == "" {
-		return nil, errors.Errorf("SSH user not provided")
-	}
-
 	return &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{


### PR DESCRIPTION
## What does this PR do?

This commit allows an operator to bootstrap a cluster
through a bastion over SSH, this is particularly handy
and almost a hard requirement for public cloud environments.

Before this commit, an operator must deploy a bastion and run
skuba from the bastion.

Signed-off-by: lcavajani <lcavajani@suse.com>


## Info for QA

Try deploying a cluster through a bastion, for my testings on VMware, I've used the LB.

I think deploying a cluster is pretty known now so just configure the flags `--bastion`, `--bastion-user` and `--bastion-port` if necessary:

```sh
skuba cluster init --control-plane 192.168.1.1 cluster
skuba node bootstrap --bastion-user sles --bastion 192.168.1.1 --sudo --user sles --target 10.0.0.1 master -v5
skuba node join --role worker --bastion-user sles --bastion 192.168.1.1 --sudo --user sles --target 10.0.1.1 worker -v5
```

`--bastion-user` can be omitted if it is the same as the target user, this way we just have to provide the user one time.

**To actually check on the nodes:**

Considering my ip is `192.168.1.73` and I'm tailing the logs of sshd `journalctl -flu sshd`

On the LB `192.168.1.1`, I will see my IP:

> Jun 23 20:34:47 load-balancer sshd[1878]: Accepted publickey for sles from 192.168.1.73 port 45828 ssh2: RSA

On the nodes, I will see the IP of the LBs `192.168.1.1`

> Jun 23 20:34:49 master sshd[16562]: Accepted publickey for sles from 192.168.1.1 port 57454 ssh2: RSA

### Status **BEFORE** applying the patch

There are no options in skuba.

### Status **AFTER** applying the patch

There are 3 new flags for the following commands:
* node bootstrap
* node join
* node upgrade apply

```
skuba node {bootstrap,join} --help
** This is an UNTAGGED version and NOT intended for production usage. **
Joins a new node to the cluster

Usage:
  skuba node join <node-name> [flags]

Flags:
      --bastion string                   IP or FQDN of the bastion to connect to the other nodes using SSH
      --bastion-port int                 Port to connect to the bastion using SSH (default 22)
      --bastion-user string              User identity used to connect to the bastion using SSH (default to target user)
  -h, --help                             help for join
      --ignore-preflight-errors string   Comma separated list of preflight errors to ignore
  -p, --port int                         Port to connect to using SSH (default 22)
  -r, --role string                      Role that this node will have in the cluster (master|worker) (required)
  -s, --sudo                             Run remote command via sudo
  -t, --target string                    IP or FQDN of the node to connect to using SSH (required)
  -u, --user string                      User identity used to connect to target using SSH

Global Flags:
  -v, --verbosity Level   log level [0-5]. 0 (Only Error and Warning) to 5 (Maximum detail).
```


## Docs

https://github.com/SUSE/doc-caasp/pull/913

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
