### PR TITLE
Revert "Do not render empty client secret (bsc#1173055)"

### DIFF
--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -40,11 +40,11 @@ func (renderContext renderContext) GangwayImage() string {
 }
 
 func (renderContext renderContext) GangwayClientSecret() string {
-	// ignore error for `skuba cluster init` case
 	client, err := kubernetes.GetAdminClientSet()
 	if err != nil {
-		return gangway.GetClientSecret(nil)
+		return ""
 	}
+
 	return gangway.GetClientSecret(client)
 }
 

--- a/internal/pkg/skuba/addons/gangway_test.go
+++ b/internal/pkg/skuba/addons/gangway_test.go
@@ -21,6 +21,8 @@ import (
 	"regexp"
 	"testing"
 
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
 	img "github.com/SUSE/skuba/pkg/skuba"
@@ -89,9 +91,11 @@ func Test_renderContext_GangwayImage(t *testing.T) {
 func Test_renderContext_GangwayClientSecret(t *testing.T) {
 	for _, ver := range kubernetes.AvailableVersions() {
 		t.Run("get gangway client secret when cluster version is "+ver.String(), func(t *testing.T) {
+			fake.NewSimpleClientset()
+
 			got := renderContext{}.GangwayClientSecret()
-			if got == "" {
-				t.Errorf("expect got client secret")
+			if got != "" {
+				t.Errorf("expect got client secret empty")
 				return
 			}
 		})

--- a/internal/pkg/skuba/gangway/gangway.go
+++ b/internal/pkg/skuba/gangway/gangway.go
@@ -91,12 +91,6 @@ func GetClientSecret(client clientset.Interface) string {
 		return gClientSecret
 	}
 
-	// generate a new client secret when `skuba cluster init`
-	if client == nil {
-		gClientSecret = dex.GenerateClientSecret()
-		return gClientSecret
-	}
-
 	// global client secret not exist, read from ConfigMap
 	clientSecret, err := getClientSecretFromConfigMap(client)
 	if err != nil || clientSecret == "" {

--- a/internal/pkg/skuba/gangway/gangway_test.go
+++ b/internal/pkg/skuba/gangway/gangway_test.go
@@ -151,10 +151,6 @@ customHTMLTemplatesDir: /usr/share/caasp-gangway/web/templates/caasp
 				},
 			}),
 		},
-		{
-			name:   "nil clientset",
-			client: nil,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Reverts SUSE/skuba#1173 due to https://github.com/SUSE/skuba/pull/1173#issuecomment-648521914
