### PR TITLE
Use env var for AWS credentials

### DIFF
--- a/ci/infra/aws/README.md
+++ b/ci/infra/aws/README.md
@@ -25,6 +25,40 @@ the cluster.
 
 ## Starting the cluster
 
+### Credentials
+
+The three following arguments must be provided:
+
+* AWS_ACCESS_KEY_ID: This is the AWS access key.
+* AWS_SECRET_ACCESS_KEY This is the AWS secret key.
+* AWS_DEFAULT_REGION This is the AWS region. A list of region names
+can be found [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions)
+
+To do so, source the following variables,
+for security reasons turn off bash history:
+
+```sh
+set +o history
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export AWS_DEFAULT_REGION="eu-central-1"
+set -o history
+```
+
+It can also be stored in a file, for example `aws-credentials`
+
+```
+AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+AWS_DEFAULT_REGION="eu-central-1"
+```
+
+and sourced:
+
+```sh
+set -a; source aws-credentials; set +a
+```
+
 ### Configuration
 
 You can use the `terraform.tfvars.example` as a template for configuring
@@ -34,13 +68,8 @@ the Terraform variables, or create your own file like `my-cluster.auto.tfvars`:
 # customize any variables defined in variables.tf
 stack_name = "my-k8s-cluster"
 
-access_key = "<KEY>"
-
-secret_key = "<SECRET>"
-
 authorized_keys = ["ssh-rsa AAAAB3NzaC1y..."]
 ```
-
 
 The terraform files will create a new dedicated VPC for the kubernetes cluster.
 It's possible to join this VPC with other existing ones by specifying the IDs

--- a/ci/infra/aws/ami.tf
+++ b/ci/infra/aws/ami.tf
@@ -1,9 +1,10 @@
 data "susepubliccloud_image_ids" "sles15sp1_chost_byos" {
   cloud  = "amazon"
-  region = var.aws_region
+  region = data.aws_region.current.name
   state  = "active"
 
   # USE SLES 15 SP1 Container host AMI - this is needed to avoid issues like bsc#1146774
   name_regex = "suse-sles-15-sp1-chost-byos.*-hvm-ssd-x86_64"
 }
 
+data "aws_region" "current" {}

--- a/ci/infra/aws/aws.tf
+++ b/ci/infra/aws/aws.tf
@@ -19,9 +19,6 @@ locals {
 }
 
 provider "aws" {
-  region     = var.aws_region
-  access_key = var.aws_access_key
-  secret_key = var.aws_secret_key
   profile    = "default"
 }
 

--- a/ci/infra/aws/network.tf
+++ b/ci/infra/aws/network.tf
@@ -17,7 +17,7 @@ data "aws_availability_zones" "az" {
 }
 
 resource "aws_vpc_dhcp_options" "platform" {
-  domain_name         = "${var.aws_region}.compute.internal"
+  domain_name         = "${data.aws_region.current.name}.compute.internal"
   domain_name_servers = ["AmazonProvidedDNS"]
   tags = merge(
     local.tags,

--- a/ci/infra/aws/terraform.tfvars.example
+++ b/ci/infra/aws/terraform.tfvars.example
@@ -1,6 +1,12 @@
 # prefix for resources
 stack_name = "my-k8s"
 
+# Number of master nodes
+masters = 1
+
+# Number of worker nodes
+workers = 2
+
 # Extra tags to add to all the resources
 #tags = {
 #  "key": "value"
@@ -10,16 +16,6 @@ stack_name = "my-k8s"
 authorized_keys = [
   "ssh-rsa AAAAB3NzaC1yc2EA...",
 ]
-
-# AWS region
-# A list of region names can be found here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-aws_region = "eu-central-1"
-
-# access key for AWS services
-aws_access_key = "AKIXU..."
-
-# secret key used for AWS services
-aws_secret_key = "ORd..."
 
 ## To register CaaSP product please use ONLY ONE of the following method
 # - register against SUSE Customer Service, with SUSE CaaSP Product Registration Code

--- a/ci/infra/aws/variables.tf
+++ b/ci/infra/aws/variables.tf
@@ -3,11 +3,6 @@ variable "stack_name" {
   description = "identifier to make all your resources unique and avoid clashes with other users of this terraform project"
 }
 
-variable "aws_region" {
-  default     = "eu-north-1"
-  description = "Name of the AWS region to be used"
-}
-
 variable "ami_name_pattern" {
   default     = "suse-sles-15-*"
   description = "Pattern for choosing the AMI image"
@@ -35,16 +30,6 @@ variable "vpc_cidr_block" {
   type        = string
   description = "CIRD blocks for vpc"
   default     = "10.1.0.0/16"
-}
-
-variable "aws_access_key" {
-  default     = ""
-  description = "AWS access key"
-}
-
-variable "aws_secret_key" {
-  default     = ""
-  description = "AWS secret key"
 }
 
 variable "master_size" {
@@ -86,8 +71,10 @@ variable "packages" {
     "kmod",
     "-docker",
     "-containerd",
+    "-containerd-ctr",
     "-docker-runc",
     "-docker-libnetwork",
+    "-docker-img-store-setup",
   ]
 
   description = "list of additional packages to install"


### PR DESCRIPTION
## Why is this PR needed?

It is not a best practice to hard code credentials into `terraform.tfvars` because there a high risk of leakage. 

## What does this PR do?

This commit defaults to using default environment variables for AWS credentials. Having these variables exported is also handy as it allows one to use `aws-cli` as well.

It also adds two more packages to remove when bootstrapping on a `CHOST`, without these two packages, `containerd` cannot be uninstalled, hence `cloud-init` does not complete.

## Anything else a reviewer needs to know?

## Info for QA

### Status **BEFORE** applying the patch

values must be hardcoded in `terraform.tfvars`

### Status **AFTER** applying the patch

`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION` must be exported before running terraform.

## Docs

https://github.com/SUSE/doc-caasp/pull/903

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
