### PR TITLE
Update cri-o runtime to version 1.18.2

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -89,7 +89,7 @@ var (
 		"1.18.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.18.2",
-				ContainerRuntimeVersion: "1.18.0",
+				ContainerRuntimeVersion: "1.18.2",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
 				APIServer:         &ContainerImageTag{Name: "api-server", Tag: "v1.18.2"},


### PR DESCRIPTION
## Why is this PR needed?

Update cri-o version to 1.18.2

## What does this PR do?

Bringing cri-o 1.18.2

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

