### PR TITLE
Enable ExtendedResourceToleration by default

### DIFF
--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -186,6 +186,7 @@ func setApiserverAdmissionPlugins(initCfg *kubeadmapi.InitConfiguration, cluster
 	admissionPlugins = append(admissionPlugins, "NodeRestriction")
 	// List of skuba-enabled plugins
 	admissionPlugins = append(admissionPlugins, "PodSecurityPolicy")
+	admissionPlugins = append(admissionPlugins, "ExtendedResourceToleration")
 	admissionPlugins = skubautil.UniqueStringSlice(admissionPlugins)
 	initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = strings.Join(admissionPlugins, ",")
 }

--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -339,19 +339,19 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 			name:                     "1.15.2 without duplicates",
 			clusterVersion:           version.MustParseSemantic("1.15.2"),
 			currentAdmissionPlugins:  []string{},
-			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "NodeRestriction", "PodSecurityPolicy"},
+			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "NodeRestriction", "PodSecurityPolicy", "ExtendedResourceToleration"},
 		},
 		{
 			name:                     "1.15.2 with duplicates",
 			clusterVersion:           version.MustParseSemantic("1.15.2"),
 			currentAdmissionPlugins:  []string{"NamespaceLifecycle", "NodeRestriction", "PodSecurityPolicy"},
-			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "NodeRestriction", "PodSecurityPolicy", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection"},
+			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "NodeRestriction", "PodSecurityPolicy", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "ExtendedResourceToleration"},
 		},
 		{
 			name:                     "1.16.2 without duplicates",
 			clusterVersion:           version.MustParseSemantic("1.16.2"),
 			currentAdmissionPlugins:  []string{},
-			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "RuntimeClass", "NodeRestriction", "PodSecurityPolicy"},
+			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "RuntimeClass", "NodeRestriction", "PodSecurityPolicy", "ExtendedResourceToleration"},
 		},
 	}
 


### PR DESCRIPTION
Enable the ExtendedResourceToleration admission controller[1] by default
for all deployments.

This admission controller is beneficial to heterogeneous clusters that
may want to make use of kubernetes node taints[2] for giving
preferential scheduling to workloads that require special hardware, such
as GPUs. This admission controller is a mutating admission controller
that automatically adds a resource toleration to pods that request an
extended resource that is being advertised by a device plugin[3]. It has
no effect on pods that don't request such resources, and the added
toleration would have no effect if the cluster administrator is not
using taints for this purpose, so it is safe to enable by default and a
convenience for cost-aware admins with these hardware requirements.

[1] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#extendedresourcetoleration
[2] https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#example-use-cases
[3] https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/

Fixes https://github.com/SUSE/avant-garde/issues/1699