### PR TITLE
replace tabs that should be spaces in README

### DIFF
--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -465,7 +465,7 @@ optional arguments:
                         timeout for waiting a node to become ready (seconds)
   -m R M, --registry-mirror R M
                         Add to the registry R a mirror M. If an image is
-			available at the mirror it will be preferred, otherwise
+                        available at the mirror it will be preferred, otherwise
                         the image in the original registry is used. This
                         argument can be used multiple times, then mirrors will
                         be tried in that order. Example:
@@ -484,7 +484,7 @@ optional arguments:
                         timeout for waiting a node to become ready (seconds)
   -m R M, --registry-mirror R M
                         Add to the registry R a mirror M. If an image is
-			available at the mirror it will be preferred, otherwise
+                        available at the mirror it will be preferred, otherwise
                         the image in the original registry is used. This
                         argument can be used multiple times, then mirrors will
                         be tried in that order. Example:


### PR DESCRIPTION
## Why is this PR needed?

## What does this PR do?

replace tabs that should be spaces in README

Follow-Up: https://github.com/SUSE/skuba/pull/1127

## Anything else a reviewer needs to know?


## Info for QA

### Related info

### Status **BEFORE** applying the patch

### Status **AFTER** applying the patch

## Docs

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
