### PR TITLE
QUICK FIX: fix image repositor url for mirrors

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -90,8 +90,8 @@ node('caasp-team-private-integration') {
            if (pr_repo_label != null) {
                def branch_name = pr_repo_label.name.split(":")[1]
                branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP2"
-               branch_registry = "registry.suse.de/Devel/CaaSP/${repo_version}/Branches/${branch_name}/containers/cr/containers/caasp/v${repo_version}"
-               original_registry = "registry.suse.de/devel/caasp/5/containers/cr/containers/caasp/v5"
+               branch_registry = "registry.suse.de/devel/caasp/5/branches/${branch_name}/containers"
+               original_registry = "registry.suse.de/devel/caasp/5/containers/cr/containers"
            }
 
         } catch (Exception e) {


### PR DESCRIPTION
Fix the url used for the image mirror when a branch repository is specified

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
