### PR TITLE
Forcing to use rev5 for cilium image for bugfix (bsc#1173039)

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -101,7 +101,7 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.6.6", 3},
+				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
 				Kured:         &AddonVersion{"1.3.0", 4},
 				Dex:           &AddonVersion{"2.16.0-rev6", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 6},


### PR DESCRIPTION
## Why is this PR needed?

Fixes #1173039

## What does this PR do?

Provides caasp-cilium-image revision update for the bug fix for bsc#1173039

## Anything else a reviewer needs to know?

## Info for QA

* Ensure skuba downloads the correct image with rev5 label
* Test the image for resolution of the bug described in bsc#1173039

### Related info

Info that can be relevant for QA:
* PR to be merged to access the image https://github.com/SUSE/caasp-container-images/pull/88
* Upstream Commit for the cilium source: https://github.com/cilium/cilium/commit/ef01850f7cb6c53933d28438c94411b15e557370
* caasp-cilium-image build version rev5 is used for testing

### Status **BEFORE** applying the patch

### Status **AFTER** applying the patch

## Docs


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
