### PR TITLE
Fix check for null environment variable

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
@@ -24,16 +24,16 @@ node('caasp-team-private-integration') {
         }
 
         // Overrride the worker type if explicitly requested
-        if (env.WORKER_TYPE != '') {
+        if (env.WORKER_TYPE) {
             worker_type = env.WORKER_TYPE  
         }
 
         // Set additional labels for worker selection
-        if (env.WORKER_LABELS != '') {
+        if (env.WORKER_LABELS) {
             labels = env.WORKER_LABELS
         }
 
-        if (env.REPO_BRANCH != ""){
+        if (env.REPO_BRANCH){
                branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/5:/Branches:/${env.REPO_BRANCH}/SLE_15_SP2"
                branch_registry = "registry.suse.de/devel/caasp/5/branches/${env.REPO_BRANCH}/containers"
                original_registry = "registry.suse.de/devel/caasp/5/containers/cr/containers"


### PR DESCRIPTION
# Why is this PR needed?

After changes introduced in  https://github.com/SUSE/skuba/pull/1180 the daily e2e tests fail because some environment variables are not defined. 

## What does this PR do?

Fix the check for environment variables not set. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
