### PR TITLE
declare environment for all Jenkinsfile steps

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -116,7 +116,10 @@ pipeline {
         LIBVIRT_URI = 'qemu+ssh://jenkins@kvm-ci.nue.caasp.suse.net/system'
         LIBVIRT_KEYFILE = credentials('libvirt-keyfile')
         LIBVIRT_IMAGE_URI = 'http://dist.suse.de/install/SLE-15-SP2-JeOS-PublicRC2/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-PublicRC2.qcow2'
-    }
+        BRANCH_REPO = "${branch_repo}"
+        BRANCH_REGISTRY = "${branch_registry}"
+        ORIGINAL_REGISTRY = "${original_registry}"
+   }
 
     stages {
         stage('Collaborator Check') { steps { script {
@@ -219,11 +222,6 @@ pipeline {
         }
 
         stage('Provision cluster') {
-            environment {
-                BRANCH_REPO = "${branch_repo}"
-                BRANCH_REGISTRY = "${branch_registry}"
-                ORIGINAL_REGISTRY = "${original_registry}"
-            }
             steps {
                 sh(script: 'make -f skuba/ci/Makefile provision', label: 'Provision')
             }


### PR DESCRIPTION
## Why is this PR needed?

declare environment for all Jenkinsfile steps

not only for one step. These variables are also used in e.g. the deploy
step. Without this these options do not take effect.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
