### PR TITLE
Use the Proper SLE15 SP2 JeOS GM image for testing on OpenStack

### DIFF
--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -1,7 +1,7 @@
 # Name of the image to use
 # EXAMPLE:
-# image_name = "SLE-15-SP1-JeOS-GMC"
-image_name = ""
+# image_name = "
+image_name = "SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM"
 
 # Name of the internal network to be created
 # EXAMPLE:

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -1,5 +1,5 @@
 {
-    "image_name": "SLES15-SP2-JeOS.x86_64-PublicRC2",
+    "image_name": "SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM",
     "internal_net": "testing",
     "internal_subnet": "testing-subnet",
     "internal_router": "testing-router",

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
         LIBVIRT_URI = 'qemu+ssh://jenkins@kvm-ci.nue.caasp.suse.net/system'
         LIBVIRT_KEYFILE = credentials('libvirt-keyfile')
-        LIBVIRT_IMAGE_URI = 'http://dist.suse.de/install/SLE-15-SP2-JeOS-PublicRC2/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-PublicRC2.qcow2'
+        LIBVIRT_IMAGE_URI = 'https://download.suse.de/install/SLE-15-SP2-JeOS-GM/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM.qcow2'
         BRANCH_REPO = "${branch_repo}"
         BRANCH_REGISTRY = "${branch_registry}"
         ORIGINAL_REGISTRY = "${original_registry}"


### PR DESCRIPTION
## Why is this PR needed?

The business case this fixes is that the CI is using the final SP2 image that we ship to customers rather than something older and unsupported. 

As such it brings more relevance to what we test and how we test and that is considered a good thing. 

## What does this PR do?

It fixes the Image configuration to point to the right image. 

## Anything else a reviewer needs to know?

There is no manual testing needed. 

## Info for QA

There is no QA needed. if CI passes its good. 


### Related info

This PR can be merged independently.

### Status **BEFORE** applying the patch

The wrong image is used. 


### Status **AFTER** applying the patch

The SLE15 SP2 GM JeOS image for OpenStack is being used for OpenStack testing.

## Docs

The docs need to refer to the same image. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
