### PR TITLE
Use the SUSE NTP pool servers instead of Novell

### DIFF
--- a/ci/infra/bare-metal/autoyast.xml
+++ b/ci/infra/bare-metal/autoyast.xml
@@ -133,7 +133,7 @@ sles ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/sles
     <ntp_servers config:type="list">
       <ntp_server>
         <!-- replace ntp server address value bellow with one from your infrastructure -->
-        <address>0.novell.pool.ntp.org</address>
+        <address>0.suse.pool.ntp.org</address>
         <iburst config:type="boolean">true</iburst>
         <offline config:type="boolean">true</offline>
       </ntp_server>

--- a/ci/infra/libvirt/terraform.tfvars.example
+++ b/ci/infra/libvirt/terraform.tfvars.example
@@ -69,7 +69,7 @@ authorized_keys = [
 ]
 
 # IMPORTANT: Replace these ntp servers with ones from your infrastructure
-ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]
+ntp_servers = ["0.suse.pool.ntp.org", "1.suse.pool.ntp.org", "2.suse.pool.ntp.org", "3.suse.pool.ntp.org"]
 
 # Set node's hostname from DHCP server
 #hostname_from_dhcp = false

--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -36,9 +36,9 @@
     ],
     "authorized_keys": [],
     "ntp_servers": [
-        "0.novell.pool.ntp.org",
-        "1.novell.pool.ntp.org",
-        "2.novell.pool.ntp.org",
-        "3.novell.pool.ntp.org"
+        "0.suse.pool.ntp.org",
+        "1.suse.pool.ntp.org",
+        "2.suse.pool.ntp.org",
+        "3.suse.pool.ntp.org"
     ]
 }

--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -96,7 +96,7 @@ authorized_keys = [
 key_pair = ""
 
 # IMPORTANT: Replace these ntp servers with ones from your infrastructure
-ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]
+ntp_servers = ["0.suse.pool.ntp.org", "1.suse.pool.ntp.org", "2.suse.pool.ntp.org", "3.suse.pool.ntp.org"]
 
 # Set node's hostname from DHCP server
 #hostname_from_dhcp = false

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -31,9 +31,9 @@
     ],
     "authorized_keys": [],
     "ntp_servers": [
-        "0.novell.pool.ntp.org",
-        "1.novell.pool.ntp.org",
-        "2.novell.pool.ntp.org",
-        "3.novell.pool.ntp.org"
+        "0.suse.pool.ntp.org",
+        "1.suse.pool.ntp.org",
+        "2.suse.pool.ntp.org",
+        "3.suse.pool.ntp.org"
     ]
 }

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -64,7 +64,7 @@ packages = [
 authorized_keys = []
 
 # IMPORTANT: Replace these ntp servers with ones from your infrastructure
-ntp_servers = ["0.novell.pool.ntp.org", "1.novell.pool.ntp.org", "2.novell.pool.ntp.org", "3.novell.pool.ntp.org"]
+ntp_servers = ["0.suse.pool.ntp.org", "1.suse.pool.ntp.org", "2.suse.pool.ntp.org", "3.suse.pool.ntp.org"]
 
 # Enable CPI integration with vSphere
 #cpi_enable = true

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -34,10 +34,10 @@
     ],
     "authorized_keys": [],
     "ntp_servers": [
-        "0.novell.pool.ntp.org",
-        "1.novell.pool.ntp.org",
-        "2.novell.pool.ntp.org",
-        "3.novell.pool.ntp.org"
+        "0.suse.pool.ntp.org",
+        "1.suse.pool.ntp.org",
+        "2.suse.pool.ntp.org",
+        "3.suse.pool.ntp.org"
     ],
     "cpi_enable": false
 }


### PR DESCRIPTION
SUSE has left the Novell group of products in 2014, about 6 years ago.
It is time to use the SUSE ntp pool entries.

For details, see https://suse.com/c/news/the-attachmate-group-enters-into-agreement-to-merge-with-micro-focus/

## Why is this PR needed?

The business case this PR fixes it  that SUSE has become independent from Novell and we should remove references
to this business engagement starting September 2014. 

## What does this PR do?

It fixes the default provided (example) 'NTP server entries to refer to SUSE rather than the Novell pool of servers.

## Anything else a reviewer needs to know?

This is nothing special.

## Info for QA

With the patch applied, the default shipped NTP servers with skuba should refer to SUSE rather than Novell.

### Related info

No related PRs, this is fully independent.

### Status **BEFORE** applying the patch

Before applying the patch, the default configured ntp servers are referring to the novell pool of ntp servers.

### Status **AFTER** applying the patch

After applying the patch, the default configured ntp servers are referring tot he SUSE pool of ntp servers.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
