### PR TITLE
Use https://download.suse.de

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -11,25 +11,25 @@
     "workers": 2,
     "username": "sles",
     "repositories": {
-        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/",
-        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
-        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
-        "containers_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
-        "serverapps_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
-        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
-        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
-        "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
-        "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
+        "caasp_devel": "https://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/",
+        "suse_ca": "https://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
+        "sle_server_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "containers_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
+        "serverapps_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
+        "sle_server_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "containers_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+        "serverapps_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
     },
     "lb_repositories": {
-        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
-        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
-        "ha_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP2/x86_64/product/",
-        "ha_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP2/x86_64/update/",
-        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
-        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
-        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2"
+        "sle_server_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "ha_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP2/x86_64/product/",
+        "ha_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP2/x86_64/update/",
+        "sle_server_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "suse_ca": "https://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2"
     },
     "packages": [
         "zypper-needs-restarting",

--- a/ci/infra/libvirt/variables.tf
+++ b/ci/infra/libvirt/variables.tf
@@ -120,12 +120,12 @@ variable "lb_repositories" {
   type = map(string)
 
   default = {
-    sle_server_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
-    basesystem_pool    = "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
-    ha_pool            = "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/"
-    ha_updates         = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/"
-    sle_server_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
-    basesystem_updates = "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
+    sle_server_pool    = "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
+    basesystem_pool    = "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
+    ha_pool            = "https://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/"
+    ha_updates         = "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/"
+    sle_server_updates = "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
+    basesystem_updates = "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
   }
 }
 

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -15,16 +15,16 @@
     "workers_vol_enabled": false,
     "workers_vol_size": 5,
     "repositories": {
-        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/",
-        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
-        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
-        "containers_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
-        "serverapps_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
-        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
-        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
-        "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
-        "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
+        "caasp_devel": "https://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/",
+        "suse_ca": "https://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
+        "sle_server_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "containers_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
+        "serverapps_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
+        "sle_server_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "containers_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+        "serverapps_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
     },
     "packages": [
         "zypper-needs-restarting",

--- a/ci/infra/testrunner/README.md
+++ b/ci/infra/testrunner/README.md
@@ -322,7 +322,7 @@ or as an environment variable: `export VMWARE_ENV_FILE=/path/to/vmware-env.sh`
 
 #### Libvirt
 
-`testrunner` can provision a cluster of virtual machines using terraform libvirt provider. The only noticeable difference with other platforms is the dependency on the terraform libvirt provider plugin which is not available from the official terraform plugin site, neither is delivered as part of the CaaSP packages. However this is available from the development [CaaSP repositories](http://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/) for SLE15-SP1 or from the public [openSUSE repositories](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) for non SLE15-SP1 hosts. Notice it requires an updated version of libvirt (4.1.0 or above).
+`testrunner` can provision a cluster of virtual machines using terraform libvirt provider. The only noticeable difference with other platforms is the dependency on the terraform libvirt provider plugin which is not available from the official terraform plugin site, neither is delivered as part of the CaaSP packages. However this is available from the development [CaaSP repositories](https://download.suse.de/ibs/Devel:/CaaSP:/4.0/SLE_15_SP1/) for SLE15-SP1 or from the public [openSUSE repositories](https://build.opensuse.org/package/show/systemsmanagement:terraform:unstable/terraform-provider-libvirt) for non SLE15-SP1 hosts. Notice it requires an updated version of libvirt (4.1.0 or above).
 
 There three configuration variables required for libvirt operations, all configurable from the configuration yaml file or by environment variables like any other variable in the yaml file:
 

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -35,6 +35,7 @@ packages:
   additional_pkgs:
   - "ca-certificates-suse"
   additional_repos:
+    suse_ca: http://download.suse.de/ibs/SUSE:/CA/SLE_15
     branch_repo: $BRANCH_REPO
 
 utils:

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -22,12 +22,12 @@ variable "lb_repositories" {
   type = map(string)
 
   default = {
-    sle_server_pool    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
-    basesystem_pool    = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
-    ha_pool            = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/"
-    ha_updates         = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/"
-    sle_server_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
-    basesystem_updates = "http://ibs-mirror.prv.suse.net/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
+    sle_server_pool    = "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"
+    basesystem_pool    = "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/"
+    ha_pool            = "https://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP1/x86_64/product/"
+    ha_updates         = "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP1/x86_64/update/"
+    sle_server_updates = "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP1/x86_64/update/"
+    basesystem_updates = "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/"
   }
 }
 

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -12,24 +12,24 @@
     "workers": 2,
     "username": "sles",
     "lb_repositories": {
-        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
-        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
-        "ha_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP2/x86_64/product/",
-        "ha_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP2/x86_64/update/",
-        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
-        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/"
+        "sle_server_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "ha_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP2/x86_64/product/",
+        "ha_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP2/x86_64/update/",
+        "sle_server_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/"
     },
     "repositories": {
-        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/",
-        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
-        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
-        "containers_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
-        "serverapps_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
-        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
-        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
-        "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
-        "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
+        "caasp_devel": "https://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/",
+        "suse_ca": "https://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
+        "sle_server_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "containers_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
+        "serverapps_pool": "https://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
+        "sle_server_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "containers_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+        "serverapps_updates": "https://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
     },
     "packages": [
         "zypper-needs-restarting"

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -89,7 +89,7 @@ node('caasp-team-private-integration') {
            }
            if (pr_repo_label != null) {
                def branch_name = pr_repo_label.name.split(":")[1]
-               branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP2"
+               branch_repo = "https://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP2"
                branch_registry = "registry.suse.de/devel/caasp/4.5/branches/${branch_name}/containers"
                original_registry = "registry.suse.de/devel/caasp/4.5/containers/containers"
            }


### PR DESCRIPTION
download.suse.de is a download redirector that redirects to the most
local installation of the repositories, which is better than hardcoding
the provo site, for cases when VMWare is not deployed in Provo but lets
say, as an example, in Nuernberg.

Also, try to use https:// as it is 2020 after all.

## Why is this PR needed?

The business case is reducing inter-continental traffic between provo and nbg.

## What does this PR do?

See commit message.

## Anything else a reviewer needs to know?

No. 

## Info for QA

This does not need to be tested for QA

### Related info

Here's some information on why HTTPS should be used by default: 
https://web.dev/why-https-matters

### Status **BEFORE** applying the patch

The wrong download sites are used.

### Status **AFTER** applying the patch

The right download sites are used.

## Docs

No documentation updates needed.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
