### PR TITLE
Remove basedir from scm definition in ci jobs

### DIFF
--- a/ci/jenkins/templates/conformance-template.yaml
+++ b/ci/jenkins/templates/conformance-template.yaml
@@ -35,5 +35,4 @@
                     - '$BRANCH'
                 browser: auto
                 suppress-automatic-scm-triggering: true
-                basedir: skuba
         script-path: ci/jenkins/pipelines/skuba-conformance.Jenkinsfile

--- a/ci/jenkins/templates/e2e-daily-template.yaml
+++ b/ci/jenkins/templates/e2e-daily-template.yaml
@@ -39,6 +39,5 @@
                     - '$BRANCH'
                 browser: auto
                 suppress-automatic-scm-triggering: true
-                basedir: skuba
-        script-path: skuba/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
+        script-path: ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
 

--- a/ci/jenkins/templates/e2e-dev-template.yaml
+++ b/ci/jenkins/templates/e2e-dev-template.yaml
@@ -46,6 +46,5 @@
                     - '$BRANCH'
                 browser: auto
                 suppress-automatic-scm-triggering: true
-                basedir: skuba
-        script-path: skuba/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
+        script-path: ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
 

--- a/ci/jenkins/templates/test-template.yaml
+++ b/ci/jenkins/templates/test-template.yaml
@@ -20,4 +20,3 @@
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
           head-filter-regex: ^(master|release\-\d\.\d|PR\-\d+)$
-          basedir: skuba


### PR DESCRIPTION
After #1168 the skuba repository must be checked out in the workspace not in a subdir, to maintain compatibility with pr jobs.

Also fix a regression in the location of the jenkins script introduced in #1180.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
