### PR TITLE
Fix development image registry references

### DIFF
--- a/pkg/skuba/development_constants.go
+++ b/pkg/skuba/development_constants.go
@@ -21,5 +21,5 @@ package skuba
 
 const (
 	BuildType       = "development"
-	ImageRepository = "registry.suse.de/devel/caasp/5/containers/cr/containers/caasp/v5"
+	ImageRepository = "registry.suse.de/devel/caasp/5/containers/containers/caasp/v5"
 )


### PR DESCRIPTION
## Why is this PR needed?

To make use of the correct images for the development environment, specially affecting `release-caasp-5.0.0` branch as k8s version is bumped from 1.18.2 to 1.18.5 hence the images for 1.18.2 are no longer available in the Continuous Rebuild (CR) sub-project.


Fixes SUSE/avant-garde#1771

## What does this PR do?

Changes the reference that skuba uses for the development images to make sure they come from Devel:CaaSP:5:Containers project. 

## Anything else a reviewer needs to know?

Givent this affects the development environment the PR tests are definitely enough to validate this change.

This fix should also be backported into `release-caasp-5.0.0` branch.
