### PR TITLE
Avoid pulling plugins from the Terraform online repositry

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -52,6 +52,8 @@ class Terraform(Platform):
         if self.conf.terraform.plugin_dir:
             logger.info(f"Installing plugins from {self.conf.terraform.plugin_dir}")
             init_cmd += f" -plugin-dir={self.conf.terraform.plugin_dir}"
+        else:
+            init_cmd += f" -get-plugins=false"
         self._run_terraform_command(init_cmd)
 
         self._run_terraform_command("version")


### PR DESCRIPTION
We'd like to test what we ship, so we should not allow terraform
to pull from the online repository additional plugins, as that would
hide issues in the state that we're trying to test in the CI.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes https://github.com/SUSE/avant-garde/issues/1759

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

See commit message. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
