### PR TITLE
Fix reference to skuba subdir in conformance test

### DIFF
--- a/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-conformance.Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
 
         stage('Getting Ready For Cluster Deployment') { steps {
             sh(script: 'make -f ci/Makefile pre_deployment', label: 'Pre Deployment')
-            sh(script: 'cd skuba; make install; cd ../', label: 'Install skuba')
+            sh(script: 'make install; cd ../', label: 'Install skuba')
         } }
 
         stage('Provision  cluster') { steps {


### PR DESCRIPTION
After #1168 the skuba project is in the workspace dir.

This PR was tested in this execution of the conformance test: 
https://ci.suse.de/view/CaaSP/view/v5%20Dashboard/job/caasp-jobs/job/conformance/job/v5/job/vmware/39/

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
