### PR TITLE
Fix stage1 upgrade

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -115,7 +115,7 @@ func kubernetesUpgradeStageOne(t *Target, data interface{}) error {
 		// On 1.17 we can't remove kubernetes-1.17-kubeadm, because it doesn't exist.
 		// Removing kubeadm keeps kubelet alive.
 		// The rest needs to be removed on the next stage.
-		pkgs = append(pkgs, "-patterns-caasp-Node-1.17", "-kubernetes-kubeadm", "-cri-o-kubeadm-criconfig")
+		pkgs = append(pkgs, "-patterns-caasp-Node-1.17", "-\"kubernetes-kubeadm<1.18\"", "-caasp-config")
 	} else {
 		pkgs = append(pkgs, fmt.Sprintf("-kubernetes-%s-kubeadm", currentV))
 	}
@@ -144,7 +144,7 @@ func kubernetesUpgradeStageTwo(t *Target, data interface{}) error {
 		pkgs = append(pkgs, "-kubernetes-kubelet")
 		pkgs = append(pkgs, "-kubernetes-common")
 		pkgs = append(pkgs, "-kubernetes-client")
-		pkgs = append(pkgs, "-cri-o")
+		pkgs = append(pkgs, "-cri-o*")
 	} else {
 		pkgs = append(pkgs, fmt.Sprintf("-kubernetes-%s-*", currentV))
 		pkgs = append(pkgs, fmt.Sprintf("-cri-o-%s*", currentV))

--- a/internal/pkg/skuba/deployments/ssh/zypper.go
+++ b/internal/pkg/skuba/deployments/ssh/zypper.go
@@ -20,7 +20,7 @@ package ssh
 func (t *Target) zypperInstall(packages ...string) (stdout string, stderr string, error error) {
 	// Runs a zypper install command wrapped with the right userdata and parameters
 	var cliArgs []string
-	cliArgs = append(cliArgs, "--userdata", "skuba")
+	cliArgs = append(cliArgs, "--userdata", "skuba", "-i")
 	cliArgs = append(cliArgs, "--non-interactive", "install", "--")
 	cliArgs = append(cliArgs, packages...)
 	return t.ssh("zypper", cliArgs...)


### PR DESCRIPTION
- Not removing caasp-config prevents from manipulating kubeadm
  through the cri-o requirement. It needs to be removed anyway,
  as we don't want to use that package anymore.
- Not using the "-i" flag will make zypper return a 104 if the
  pattern to remove is absent from the target, which happens when
  you disable some repos/remove the old repos. We could either
  remove the removal of the pattern, or make sure that the action
  is idempotent by not failing on a removal (by introducing -i).
  I chose the latter.

## Why is this PR needed?

Fixes: https://github.com/SUSE/avant-garde/issues/1664

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
