### PR TITLE
Fix stage2 upgrade

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -141,9 +141,9 @@ func kubernetesUpgradeStageTwo(t *Target, data interface{}) error {
 	if currentV == "1.17" {
 		// on 1.17 we need to finalize the cleanup for the
 		// caasp4 to 5 migration
-		pkgs = append(pkgs, "-kubernetes-kubelet")
+		pkgs = append(pkgs, "-\"kubernetes-kubelet<1.18\"")
 		pkgs = append(pkgs, "-kubernetes-common")
-		pkgs = append(pkgs, "-kubernetes-client")
+		pkgs = append(pkgs, "-\"kubernetes-client<1.18\"")
 		pkgs = append(pkgs, "-cri-o*")
 	} else {
 		pkgs = append(pkgs, fmt.Sprintf("-kubernetes-%s-*", currentV))


### PR DESCRIPTION
Without this patch, it's hard for the resolver to know which
version of kubernetes-client to remove, and therefore it will
be breaking skuba-updates requiring kubernetes-client.

By being explicit into what to remove, we keep kubernetes-1.18-client,
and it just works afterwards.

Fixes: https://github.com/SUSE/avant-garde/issues/1664
## Anything else a reviewer needs to know?

Nothing

## Info for QA

Needed for upgrades

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

Can't upgrade cluster to 1.18

### Status **AFTER** applying the patch

Goes further in the upgrade process.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
