### PR TITLE
Add option for skipping cleanup to e2e test pipeline

### DIFF
--- a/ci/jenkins/templates/e2e-dev-template.yaml
+++ b/ci/jenkins/templates/e2e-dev-template.yaml
@@ -3,10 +3,7 @@
     project-type: pipeline
     number-to-keep: 30
     days-to-keep: 30
-    wrappers:
-      - timeout:
-          timeout: 120
-          fail: true
+    concurrent: true
     parameters:
         - string:
             name: BRANCH
@@ -16,6 +13,14 @@
               name: PLATFORM
               default: 'vmware'
               description: The platform to perform the tests on
+        - bool:
+            name: RETAIN_CLUSTER
+            default: false
+            description: Retain the cluster in case of failure
+        - string:
+            name: RETENTION_PERIOD
+            default: 24
+            description: retention period for cluster (in hours)
         - string:
             name: E2E_MAKE_TARGET_NAME
             default: ''


### PR DESCRIPTION
## Why is this PR needed?

To ease debugging failures in the tests

Fixes https://github.com/SUSE/avant-garde/issues/1755

## What does this PR do?

Add option for skipping the cleanup of a job in case of failure and resume it later for completing the cleanup.

## Anything else a reviewer needs to know?

This PR was tested running the e2e test with the PR branch

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
