### PR TITLE
Add Resource Groups + AZ filter for AWS tf

### DIFF
--- a/ci/infra/aws/README.md
+++ b/ci/infra/aws/README.md
@@ -213,3 +213,7 @@ in the cluster.
 ### Availability zones
 
 Right now all the nodes are created inside of the same availability zone.
+
+It is possible to filter the available AZ by configuring `availability_zones_filter`.
+
+The available filters can be found [here in the AWS API Reference](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeAvailabilityZones.html)

--- a/ci/infra/aws/aws.tf
+++ b/ci/infra/aws/aws.tf
@@ -35,3 +35,40 @@ resource "aws_key_pair" "kube" {
   )
 }
 
+resource "aws_resourcegroups_group" "kube" {
+  name = "${var.stack_name}-resourcegroup"
+
+  tags = merge(
+    local.basic_tags,
+    {
+      "Name"  = "${var.stack_name}-resourcegroup"
+      "Class" = "ResourceGroup"
+    },
+  )
+
+  resource_query {
+    query = jsonencode({
+      "ResourceTypeFilters" : [
+        "AWS::EC2::DHCPOptions",
+        "AWS::EC2::EIP",
+        "AWS::EC2::Instance",
+        "AWS::EC2::InternetGateway",
+        "AWS::EC2::NatGateway",
+        "AWS::EC2::NetworkInterface",
+        "AWS::EC2::RouteTable",
+        "AWS::EC2::SecurityGroup",
+        "AWS::EC2::Subnet",
+        "AWS::EC2::VPC",
+        "AWS::EC2::VPCPeeringConnection",
+        "AWS::ElasticLoadBalancing::LoadBalancer",
+        "AWS::ResourceGroups::Group"
+      ],
+      "TagFilters" : [
+        {
+          "Key" : "Environment",
+          "Values" : [var.stack_name]
+        }
+      ]
+    })
+  }
+}

--- a/ci/infra/aws/network.tf
+++ b/ci/infra/aws/network.tf
@@ -14,6 +14,11 @@ resource "aws_vpc" "platform" {
 # list of az which can be access from the current region
 data "aws_availability_zones" "az" {
   state = "available"
+
+  filter {
+    name = var.availability_zones_filter.name
+    values = var.availability_zones_filter.values
+  }
 }
 
 resource "aws_vpc_dhcp_options" "platform" {

--- a/ci/infra/aws/terraform.tfvars.example
+++ b/ci/infra/aws/terraform.tfvars.example
@@ -43,3 +43,9 @@ authorized_keys = [
 #
 # Note well: you must  have the right set of permissions.
 # iam_profile_worker = "caasp-k8s-worker-vm-profile"
+
+# Use specific Availibility Zone
+#availability_zones_filter= {
+#    name   = "zone-name"
+#    values = ["eu-west-3c"]
+#}

--- a/ci/infra/aws/variables.tf
+++ b/ci/infra/aws/variables.tf
@@ -111,3 +111,14 @@ variable "peer_vpc_ids" {
   description = "IDs of a VPCs to connect to via a peering connection"
 }
 
+variable "availability_zones_filter" {
+  type = object({
+    name   = string
+    values = list(string)
+  })
+  default = {
+    name   = "zone-name"
+    values = ["*"]
+  }
+  description = "Filter Availability Zones"
+}


### PR DESCRIPTION
## Why is this PR needed?

* This commits add the support for resource groups when deploying on AWS. This gives great benefits for operators and accountants. This also aligns this with our Azure Terraform which uses resource group as well.


Quoting [official documentation:](https://docs.aws.amazon.com/ARG/latest/userguide/welcome.html)

```
In AWS, a resource is an entity that you can work with. 
Examples include an Amazon EC2 instance, an AWS CloudFormation stack, or an Amazon S3 bucket. 
If you work with multiple resources, you might find it useful to manage them as a group 
rather than move from one AWS service to another for each task.
If you manage large numbers of related resources, such as EC2 instances that make up an application layer, 
you likely need to perform bulk actions on these resources at one time. Examples of bulk actions include:

    Applying updates or security patches.
    Upgrading applications.
    Opening or closing ports to network traffic.
    Collecting specific log and monitoring data from your fleet of instances.

A resource group is a collection of AWS resources that are all in the same AWS region, 
and that match criteria provided in a query. In Resource Groups, there are two types of 
queries on which you can build a group. 
```

It is required for a user to have the following permissions:

```
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Action": [
        "resource-groups:*",
        "cloudformation:DescribeStacks",
        "cloudformation:ListStackResources",
        "tag:GetResources",
        "tag:TagResources",
        "tag:UntagResources",
        "tag:getTagKeys",
        "tag:getTagValues",
        "resource-explorer:*"
      ],
      "Resource": "*"
    }
  ]
}
```

* This also adds a variable to filter the Availability Zones in order to select a specific one. This is a requirement for instance when the operator wants to select an instance type which is only available in a specific AZ.

## What does this PR do?

* This groups the resources in a resource groups, then the resources can be queried using cli, for example:

```sh
$ aws resource-groups list-group-resources --group-name lcavajani-resourcegroup
{
    "ResourceIdentifiers": [
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:instance/i-0cccb729b542bb524",
            "ResourceType": "AWS::EC2::Instance"
        },
        {
            "ResourceArn": "arn:aws:resource-groups:eu-west-3:434479817650:group/lcavajani-resourcegroup",
            "ResourceType": "AWS::ResourceGroups::Group"
        },
        {
            "ResourceArn": "arn:aws:elasticloadbalancing:eu-west-3:434479817650:loadbalancer/lcavajani-elb",
            "ResourceType": "AWS::ElasticLoadBalancing::LoadBalancer"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:dhcp-options/dopt-082d777578a6deb0d",
            "ResourceType": "AWS::EC2::DHCPOptions"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:subnet/subnet-0b8c8808302a90802",
            "ResourceType": "AWS::EC2::Subnet"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:internet-gateway/igw-06359216ee8a9bdb3",
            "ResourceType": "AWS::EC2::InternetGateway"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:security-group/sg-05564e7ba971934bc",
            "ResourceType": "AWS::EC2::SecurityGroup"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:route-table/rtb-007014fbfd78140be",
            "ResourceType": "AWS::EC2::RouteTable"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:security-group/sg-0ee9898ed02233532",
            "ResourceType": "AWS::EC2::SecurityGroup"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:instance/i-05b5e97dc6ba4bc22",
            "ResourceType": "AWS::EC2::Instance"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:natgateway/nat-0c3a684be52648a89",
            "ResourceType": "AWS::EC2::NatGateway"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:route-table/rtb-05ed4e0f00ed5ff0d",
            "ResourceType": "AWS::EC2::RouteTable"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:security-group/sg-07cc7e042dd8a60f7",
            "ResourceType": "AWS::EC2::SecurityGroup"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:security-group/sg-0e9315e76c12fa7d8",
            "ResourceType": "AWS::EC2::SecurityGroup"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:instance/i-018c5cf790cc6eb29",
            "ResourceType": "AWS::EC2::Instance"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:vpc/vpc-0de4553a6c791433c",
            "ResourceType": "AWS::EC2::VPC"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:elastic-ip/eipalloc-072b35e226c21325a",
            "ResourceType": "AWS::EC2::EIP"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:instance/i-0a2a30dd401595107",
            "ResourceType": "AWS::EC2::Instance"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:subnet/subnet-067027e19652efeb7",
            "ResourceType": "AWS::EC2::Subnet"
        },
        {
            "ResourceArn": "arn:aws:ec2:eu-west-3:434479817650:security-group/sg-08ebbcf8d61219632",
            "ResourceType": "AWS::EC2::SecurityGroup"
        }
    ]
}
```

* AZ can be selected

If all the regions are working correctly and the operator uses the region `eu-west-3`. 

With the default filter, the availability zone selected will be the first one in the list so `eu-west-3-a`.

If the operator defines the following variable:

```hcl
availability_zones_filter= {
    name   = "zone-name"
    values = ["eu-west-3c"]
}
```

Then the `subnet` will be created in `eu-west-3c`

## Docs

There is currently no doc about the required IAM permission for the **operator** in the doc (only for instance profiles).

cc @nkoranova @r0ckarong do you have something on your side regarding this topic ? otherwise I will open a bug.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
