### PR TITLE
Allow any version of k8s-client for skuba-update and allow cri-o bump during stage1

### DIFF
--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -60,7 +60,6 @@ Summary:        Utility to automatically refresh and update a skuba cluster
 Group:          System/Management
 Requires:       python3-setuptools
 Requires:       zypper >= 1.14.15
-Requires:       (k8s-client or kubernetes-client)
 Requires:       lsof
 BuildArch:      noarch
 %{?systemd_requires}

--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -60,7 +60,7 @@ Summary:        Utility to automatically refresh and update a skuba cluster
 Group:          System/Management
 Requires:       python3-setuptools
 Requires:       zypper >= 1.14.15
-Requires:       kubernetes-client
+Requires:       (k8s-client or kubernetes-client)
 Requires:       lsof
 BuildArch:      noarch
 %{?systemd_requires}


### PR DESCRIPTION
With the change of the virtual provides from kubernetes- to
k8s- and the version appended packages, we can now to decide
whether this package need _any_ version of a kubernetes, or
a specific one. skuba-update can rely on any version of kubectl,
therefore we should be updating the spec to rely on k8s-client
being present.

## Why is this PR needed?

Without this whole virtual provides, the migration will auto bump k8s to 1.18, which we want to avoid.

## What does this PR do?

Ensure we are not using kubernetes-component* packages.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
