### PR TITLE
Remain on kernel-default-base

### DIFF
--- a/ci/infra/openstack/terraform.tfvars.example
+++ b/ci/infra/openstack/terraform.tfvars.example
@@ -78,8 +78,7 @@ repositories = {}
 # Feel free to add more packages
 packages = [
   "zypper-needs-restarting",
-  "kernel-default",
-  "-kernel-default-base"
+  "kernel-default-base"
 ]
 
 # ssh keys to inject into all the nodes

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -27,8 +27,7 @@
     },
     "packages": [
         "zypper-needs-restarting",
-        "kernel-default",
-        "-kernel-default-base"
+        "kernel-default-base"
     ],
     "authorized_keys": [],
     "ntp_servers": [

--- a/ci/infra/openstack/variables.tf
+++ b/ci/infra/openstack/variables.tf
@@ -100,8 +100,8 @@ variable "packages" {
   type = list(string)
 
   default = [
-    "kernel-default",
-    "-kernel-default-base",
+    "zypper-needs-restarting",
+    "kernel-default-base",
   ]
 
   description = "list of additional packages to install"


### PR DESCRIPTION
As indicated in https://jira.suse.com/browse/PM-1909 the JeOS team is
interested to learn why kernel-default-base is not good enough, so
lets try without it.

I'll do so in OpenStack first as that is least priority and should help
the z-Squad in not disrupting important work.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
