### PR TITLE
Gather logs only if platform was provisioned

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -217,18 +217,17 @@ pipeline {
     }
     post {
         always { script {
-            // collect artifacts only if pr-test stage was executed.
-            // FIXME: this will break if we add an stage after skuba-test
-            if (pr_context == 'jenkins/skuba-test'){
-                archiveArtifacts(artifacts: "ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
-                archiveArtifacts(artifacts: "ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
-                archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
-                archiveArtifacts(artifacts: 'ci/infra/testrunner/*.xml', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'ci/infra/testrunner/*.xml', allowEmptyArchive: true)
+            // only attempt to collect logs if platform was provisioned
+            if (fileExists("tfout.json")) {
+                archiveArtifacts(artifacts: 'tfout.json', allowEmptyArchive: true)
                 sh(script: "make --keep-going -f ci/Makefile gather_logs", label: 'Gather Logs')
                 archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
-                junit('ci/infra/testrunner/*.xml')
             }
-        } }
+        }}
         cleanup {
             sh(script: "make --keep-going -f ci/Makefile cleanup", label: 'Cleanup')
             dir("${WORKSPACE}@tmp") {


### PR DESCRIPTION
## Why is this PR needed?

When provisioning fails the archiving step also fails, creating unnecessary noise in the output of the job.

## What does this PR do?

Check if tfout.json was created before attempting to retrieve logs from nodes.

## Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
