### PR TITLE
CI: Unify platform configuration

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -3,7 +3,7 @@
     "libvirt_keyfile": "",
     "network_name": "",
     "pool": "default",
-    "image_uri": "",
+    "image_uri": "https://download.suse.de/install/SLE-15-SP2-JeOS-GM/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM.qcow2",
     "stack_name": "testing",
     "network_cidr": "10.17.0.0/22",
     "dns_domain": "caasp.local",

--- a/ci/infra/testrunner/platforms/libvirt.py
+++ b/ci/infra/testrunner/platforms/libvirt.py
@@ -8,7 +8,6 @@ class Libvirt(Terraform):
         self.platform_new_vars = {
             "libvirt_uri": self.conf.libvirt.uri,
             "libvirt_keyfile": self.conf.libvirt.keyfile,
-            "image_uri": self.conf.libvirt.image_uri
         }
 
     def _env_setup_cmd(self):

--- a/ci/infra/testrunner/utils/config.py
+++ b/ci/infra/testrunner/utils/config.py
@@ -117,14 +117,12 @@ class BaseConfig:
     class VMware:
         def __init__(self):
             self.env_file = None
-            self.template_name = None
 
     class Libvirt:
         def __init__(self):
             super().__init__()
             self.uri = "qemu:///system"
             self.keyfile = None
-            self.image_uri = None
 
     class Packages:
         def __init__(self):

--- a/ci/infra/testrunner/vars.yaml
+++ b/ci/infra/testrunner/vars.yaml
@@ -47,12 +47,10 @@ utils:
 
 #vmware:
 #  env_file: "" #os.getenv("VMWARE_ENV_FILE")
-#  template_name: "SLES15-SP1-GM-guestinfo" #os.getenv("VMWARE_TEMPLATE_NAME")
 
 #libvirt:
 #  uri: "qemu:///system" #os.getenv("LIBVIRT_URI")
 #  keyfile: "" #os.getenv("LIBVIRT_KEYFILE")
-#  image_uri: "" #os.getenv("LIBVIRT_IMAGE_URI") 
 #
 #log:
 #  level: DEBUG

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -116,7 +116,6 @@ pipeline {
         REQUESTS_CA_BUNDLE = '/var/lib/ca-certificates/ca-bundle.pem'
         LIBVIRT_URI = 'qemu+ssh://jenkins@kvm-ci.nue.caasp.suse.net/system'
         LIBVIRT_KEYFILE = credentials('libvirt-keyfile')
-        LIBVIRT_IMAGE_URI = 'https://download.suse.de/install/SLE-15-SP2-JeOS-GM/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM.qcow2'
         BRANCH_REPO = "${branch_repo}"
         BRANCH_REGISTRY = "${branch_registry}"
         ORIGINAL_REGISTRY = "${original_registry}"


### PR DESCRIPTION
## Why is this PR needed?

Presently, the way images used in different platforms is defined in an inconsistent way: some in tfvars files, others in environment variable (libvirt). Also, some can be overridden from the testrunner's configuration, while others no.

## What does this PR do?

Make images defined in the terraform.tfvars.json.ci.example file for all platforms, not as environment variables or in the testrunner's configuration file.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
