### PR TITLE
Update kured to 1.4.3

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -103,7 +103,7 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.7.5", 4},
-				Kured:         &AddonVersion{"1.3.0", 5},
+				Kured:         &AddonVersion{"1.4.3", 6},
 				Dex:           &AddonVersion{"2.23.0", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 0},


### PR DESCRIPTION
This version is declared as supporting k8s 1.18.x

## Why is this PR needed?

rebase of https://github.com/SUSE/skuba/pull/1215