### PR TITLE
[WIP] Delete Cilium pod after 1.18 upgrade

### DIFF
--- a/internal/pkg/skuba/kubernetes/pod.go
+++ b/internal/pkg/skuba/kubernetes/pod.go
@@ -53,3 +53,28 @@ func getPodFromPodList(list *v1.PodList, name string) (*v1.Pod, error) {
 	}
 	return nil, fmt.Errorf("could not find pod %s in pod list", name)
 }
+
+// return the pod associated with the label and FieldSelector
+func GetFirstPodMatchingSelectors(client clientset.Interface, namespace string, labelSelector string, fieldSelector string) (*v1.Pod, error) {
+	pods, err := client.CoreV1().Pods(namespace).List(
+		context.Background(),
+		metav1.ListOptions{
+			LabelSelector: labelSelector,
+			FieldSelector: fieldSelector,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	pod := &pods.Items[0]
+	return pod, nil
+}
+
+func DeletePod(client clientset.Interface, namespace, name string) error {
+	err := client.CoreV1().Pods(namespace).Delete(
+		context.Background(),
+		name,
+		metav1.DeleteOptions{},
+	)
+	return err
+}


### PR DESCRIPTION
After the node upgrade to Kubernetes 1.18, Cilium pods are stuck in the
Init:Error state due to cri-o issue:

"Error reserving pod name k8s_cilium-<endofpodname>kube-system<number> for id <id>: name is reserved"

Deleting the pod will trigger its creation by k8s, without problm of
name reservation. To avoid a massive flood of deletion, we only select
the Cilium pod running on the node on which we have done the upgrade.

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@suse.com>
Signed-off-by: Michal Rostecki <mrostecki@suse.de>

Fixes: SUSE/avant-garde#1808