### PR TITLE
Enhance skuba addon upgrade [plan|apply]

### DIFF
--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -202,6 +202,13 @@ class Skuba:
         return self._run_skuba("cluster status")
 
     @step
+    def addon_refresh(self, action):
+        self._verify_bootstrap_dependency()
+        if action not in ['localconfig']:
+            raise ValueError("Invalid action '{}'".format(action))
+        return self._run_skuba("addon refresh {0}".format(action))
+
+    @step
     def addon_upgrade(self, action):
         self._verify_bootstrap_dependency()
         if action not in ['plan', 'apply']:

--- a/ci/infra/testrunner/tests/test_addon_upgrade.py
+++ b/ci/infra/testrunner/tests/test_addon_upgrade.py
@@ -56,6 +56,9 @@ def test_addon_upgrade_apply(deployment, kubectl, skuba):
     )
     assert not addons_up_to_date(skuba)
 
+    out = skuba.addon_refresh('localconfig')
+    assert out.find("Successfully refreshed addons base manifests") != -1
+
     out = skuba.addon_upgrade('apply')
     assert out.find("Successfully upgraded addons") != -1
     assert addons_up_to_date(skuba)

--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -67,7 +67,8 @@ func Apply(client clientset.Interface) error {
 			ControlPlane:   clusterConfiguration.ControlPlaneEndpoint,
 			ClusterName:    clusterConfiguration.ClusterName,
 		}
-		if err := addons.DeployAddons(client, addonConfiguration); err != nil {
+		dryRun := false
+		if err := addons.DeployAddons(client, addonConfiguration, dryRun); err != nil {
 			return errors.Wrap(err, "[apply] Failed to deploy addons")
 		}
 

--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -36,6 +36,29 @@ func Apply(client clientset.Interface) error {
 	if err != nil {
 		return err
 	}
+
+	clusterConfiguration, err := kubeadm.GetClusterConfiguration(client)
+	if err != nil {
+		return errors.Wrap(err, "[apply] Could not fetch cluster configuration")
+	}
+
+	addonConfiguration := addons.AddonConfiguration{
+		ClusterVersion: currentClusterVersion,
+		ControlPlane:   clusterConfiguration.ControlPlaneEndpoint,
+		ClusterName:    clusterConfiguration.ClusterName,
+	}
+
+	// check local addons cluster folder configuration is up-to-date
+	match, err := addons.CheckLocalAddonsBaseManifests(addonConfiguration)
+	if err != nil {
+		return err
+	}
+	if !match {
+		fmt.Println("Current local addons cluster folder configuration is out-of-date.")
+		fmt.Println("Please run \"skuba addon refresh localconfig\" before you perform addon upgrade.")
+		return nil
+	}
+
 	currentVersion := currentClusterVersion.String()
 	latestVersion := kubernetes.LatestVersion().String()
 	allNodesVersioningInfo, err := kubernetes.AllNodesVersioningInfo(client)
@@ -51,22 +74,12 @@ func Apply(client clientset.Interface) error {
 		return errors.Errorf("[apply] Not all nodes match clusterVersion %s", currentVersion)
 	}
 
-	clusterConfiguration, err := kubeadm.GetClusterConfiguration(client)
-	if err != nil {
-		return errors.Wrap(err, "[apply] Could not fetch cluster configuration")
-	}
-
 	updatedAddons, err := addon.UpdatedAddons(client, currentClusterVersion)
 	if err != nil {
 		return err
 	}
 
 	if addon.HasAddonUpdate(updatedAddons) {
-		addonConfiguration := addons.AddonConfiguration{
-			ClusterVersion: currentClusterVersion,
-			ControlPlane:   clusterConfiguration.ControlPlaneEndpoint,
-			ClusterName:    clusterConfiguration.ClusterName,
-		}
 		dryRun := false
 		if err := addons.DeployAddons(client, addonConfiguration, dryRun); err != nil {
 			return errors.Wrap(err, "[apply] Failed to deploy addons")

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -78,7 +78,8 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		ControlPlane:   initConfiguration.ControlPlaneEndpoint,
 		ClusterName:    initConfiguration.ClusterName,
 	}
-	if err := addons.DeployAddons(clientSet, addonConfiguration); err != nil {
+	dryRun := false
+	if err := addons.DeployAddons(clientSet, addonConfiguration, dryRun); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Why is this PR needed?

The users would use kustomize to overlay the default base addon manifest value.

However, we did not perform a dry-run check before applied to the current Kubernetes cluster, the user provides kustomize patch manifests might have some problem like manifest indentation error.

Therefore, for `skuba addon upgrade plan`, we not only display is there any new addon or existed addon need to be upgraded, moreover, we also perform the Kubernetes server-side validation by running `kubectl apply -k addons/<addon> --dry-run=server` and outputs the stderr to the user if present.

Besides, we'll generate `kustomization.yaml` inside `addons/<addon>` to make the user have the ability to run `kubectl apply -f addons/<addon>` after addons upgraded because the user might want to add more patches into the cluster and make sure the patches manifests will keep overtime for each addon upgrade.

By the way, before actually perform the `skuba addon upgrade [plan|apply]`, we will check the local addons base manifests match to the current Kubernetes cluster version, to make sure it's up-to-date.

The command `skuba addon refresh localconfig` is in another PR #1226 to not make a single PR too large.

Fixes https://github.com/SUSE/avant-garde/issues/1765

## What does this PR do?

1. Perform local addon base manifests check for `skuba addon upgrade [plan|apply]`.
2. Generates `kustomization.yaml` inside `addons/<addon>` for  `skuba addon upgrade [plan|apply]`
3. Perform Kubernetes server-side dry-run validation for `skuba addon upgrade plan`

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

An updated [RFC](https://github.com/SUSE/caasp-rfc/pull/65) for this PR.

### Status **BEFORE** applying the patch

1. The `kustomization.yaml` won't exist inside `addons/<addon>`.
2. The `skuba addon upgrade plan` won't do Kubernetes server-side dry-run.

### Status **AFTER** applying the patch

1. It'll check the local addons base manifests is up-to-date for `skuba addon upgrade [plan|apply]`
2. The `kustomization.yaml` will exist after `skuba addon upgrade [plan|apply]`
3. The `skuba addon upgrade plan` will do Kubernetes server-side dry-run.

## Docs

https://github.com/SUSE/doc-caasp/pull/923

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
