### PR TITLE
Revert kubelet server tls bootstrap

### DIFF
--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -367,10 +367,7 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 				}
 				initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = currentAdmissionPlugins
 			}
-			_, err := UpdateClusterConfigurationWithClusterVersion(&initCfg, tt.clusterVersion)
-			if err != nil {
-				t.Errorf("expected no error but an error returned: %v", err)
-			}
+			UpdateClusterConfigurationWithClusterVersion(&initCfg, tt.clusterVersion)
 			// Check admission plugins
 			gotAdmissionPlugins := initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"]
 			if gotAdmissionPlugins != expectedAdmissionPlugins {

--- a/internal/pkg/skuba/kubernetes/kubelet.go
+++ b/internal/pkg/skuba/kubernetes/kubelet.go
@@ -45,6 +45,13 @@ const (
 	KubeletCACertName = "kubelet-ca.crt"
 	// KubeletCAKeyName defines kubelet's CA key name
 	KubeletCAKeyName = "kubelet-ca.key"
+
+	// KubeletServerCertAndKeyBaseName defines kubelet server certificate and key base name
+	KubeletServerCertAndKeyBaseName = "kubelet"
+	// KubeletServerCertName defines kubelet server certificate name
+	KubeletServerCertName = "kubelet.crt"
+	// KubeletServerKeyName defines kubelet server key name
+	KubeletServerKeyName = "kubelet.key"
 )
 
 // GenerateKubeletRootCert generates kubelet root CA certificate and key

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -132,7 +132,6 @@ var (
 				Dex:           &AddonVersion{"2.16.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 1},
-				Kucero:        &AddonVersion{"1.1.1", 0},
 				PSP:           &AddonVersion{"", 4},
 			},
 		},

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -33,6 +33,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmscheme "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/scheme"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	kubeadmconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
@@ -283,12 +284,14 @@ func writeKubeadmInitConf(initConfiguration InitConfiguration) error {
 	if len(initConfiguration.CloudProvider) > 0 {
 		updateInitConfigurationWithCloudIntegration(&initCfg, initConfiguration)
 	}
-
-	initCfgContents, err := kubeadm.UpdateClusterConfigurationWithClusterVersion(&initCfg, initConfiguration.KubernetesVersion)
+	kubeadm.UpdateClusterConfigurationWithClusterVersion(&initCfg, initConfiguration.KubernetesVersion)
+	initCfgContents, err := kubeadmconfigutil.MarshalInitConfigurationToBytes(&initCfg, schema.GroupVersion{
+		Group:   "kubeadm.k8s.io",
+		Version: kubeadm.GetKubeadmApisVersion(initConfiguration.KubernetesVersion),
+	})
 	if err != nil {
 		return err
 	}
-
 	if err := ioutil.WriteFile(skuba.KubeadmInitConfFile(), initCfgContents, 0600); err != nil {
 		return errors.Wrap(err, "error writing init configuration")
 	}

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -87,6 +87,7 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		criSetup,
 		"cri.start",
 		"kubelet.rootcert.upload",
+		"kubelet.servercert.create-and-upload",
 		"kubelet.configure",
 		"kubelet.enable",
 		"kubeadm.join",


### PR DESCRIPTION
## Why is this PR needed?

The kucero will not officially release at CaaSv4, so remove it from Kubernetes 1.17.

The kucero _must_ existed before kubelet `serverTLSBootstrap: true`, therefore, we revert the code
to configures `serverTLSBootstrap: true`.

We'll enable the kubelet `serverTLSBootstrap: true` in the next coming release.

## What does this PR do?

Revert the code for enabling kubelet `serverTLSBootstrap: true`, related to #1152.

## Anything else a reviewer needs to know?

It needs to backport to v5 branch `release-caasp-5.0.0`.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

The kubelet configuration `/var/lib/kubelet/config.yaml` would have `serverTLSBootstrap: true` in fresh install _or_ upgraded cluster.

### Status **AFTER** applying the patch

The kubelet configuration `/var/lib/kubelet/config.yaml` would not have `serverTLSBootstrap: true` in fresh install _or_ upgraded cluster.

## Docs

https://github.com/SUSE/doc-caasp/pull/912

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
