### PR TITLE
Remove cri-tools on upgrade

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -85,7 +85,7 @@ func kubernetesFreshInstallAllPkgs(t *Target, data interface{}) error {
 	var pkgs []string
 
 	// Standard packages for a new cluster
-	pkgs = append(pkgs, "+caasp-release", "skuba-update", "supportutils-plugin-suse-caasp", "cri-tools")
+	pkgs = append(pkgs, "+caasp-release", "skuba-update", "supportutils-plugin-suse-caasp")
 	// Version specific
 	pkgs = append(pkgs, fmt.Sprintf("+kubernetes-%s-kubeadm", current))
 	pkgs = append(pkgs, fmt.Sprintf("+kubernetes-%s-kubelet", current))
@@ -153,6 +153,7 @@ func kubernetesUpgradeStageTwo(t *Target, data interface{}) error {
 		pkgs = append(pkgs, "-kubernetes-common")
 		pkgs = append(pkgs, "-\"kubernetes-client<1.18\"")
 		pkgs = append(pkgs, "-\"cri-o<1.18\"")
+		pkgs = append(pkgs, "-\"cri-tools<1.18\"")
 	} else {
 		pkgs = append(pkgs, fmt.Sprintf("-kubernetes-%s-*", currentV))
 		pkgs = append(pkgs, fmt.Sprintf("-cri-o-%s*", currentV))


### PR DESCRIPTION
cri-tools-1.18 is well installed for new clusters, but
it's incorrectly not removed during the first upgrade for the
caasp 4 to 5 migration.

This should fix it.

(cherry picked from commit df967d77c37e11cec23acb4c2aaff3287c79f83f)

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
