### PR TITLE
Update Cilium 1.7 configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/SUSE/skuba
 
 require (
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
@@ -123,6 +124,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc h1:nwStfwjRx+GgKD5lxZnky7Cyy8o45Cj5JznhJKgZij0=
+github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -398,6 +401,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 h1:0XM1XL/OFFJjXsYXlG30spTkV/E9+gmd5GD1w2HE8xM=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=

--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -92,6 +92,10 @@ func (ciliumCallbacks) beforeApply(client clientset.Interface, addonConfiguratio
 		return err
 	}
 
+	if err := cni.DeleteKubeProxy(client, ciliumVersion); err != nil {
+		return err
+	}
+
 	// Handle migration from etcd to CRD when upgrading from Cilium 1.5.
 	needsMigration, err := cni.NeedsEtcdToCrdMigration(client, ciliumVersion)
 	if err != nil {

--- a/internal/pkg/skuba/addons/cilium_manifests/v17.go
+++ b/internal/pkg/skuba/addons/cilium_manifests/v17.go
@@ -277,7 +277,11 @@ spec:
               key: custom-cni-conf
               name: cilium-config
               optional: true
-        image: {{.CiliumImage}}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{.ControlPlaneHost}}
+        - name: KUBERNETES_SERVICE_PORT
+          value: "{{.ControlPlanePort}}"
+        image: "{{.CiliumImage}}"
         imagePullPolicy: IfNotPresent
         lifecycle:
           postStart:

--- a/internal/pkg/skuba/addons/generic.go
+++ b/internal/pkg/skuba/addons/generic.go
@@ -42,6 +42,10 @@ func (renderContext renderContext) ControlPlaneHost() string {
 	return util.ControlPlaneHost(renderContext.config.ControlPlane)
 }
 
+func (renderContext renderContext) ControlPlanePort() string {
+	return util.ControlPlanePort(renderContext.config.ControlPlane)
+}
+
 func (renderContext renderContext) ControlPlaneHostAndPort() string {
 	return util.ControlPlaneHostAndPort(renderContext.config.ControlPlane)
 }

--- a/internal/pkg/skuba/cni/cilium.go
+++ b/internal/pkg/skuba/cni/cilium.go
@@ -217,8 +217,6 @@ func CreateOrUpdateCiliumConfigMap(client clientset.Interface, ciliumVersion str
 			"etcd-config": string(etcdConfigDataByte),
 		}
 	case strings.HasPrefix(ciliumVersion, "1.6"):
-		fallthrough
-	case strings.HasPrefix(ciliumVersion, "1.7"):
 		ciliumConfigMapData = map[string]string{
 			"bpf-ct-global-tcp-max":    "524288",
 			"bpf-ct-global-any-max":    "262144",
@@ -252,6 +250,17 @@ func CreateOrUpdateCiliumConfigMap(client clientset.Interface, ciliumVersion str
 			ciliumConfigMapData["identity-allocation-mode"] = "kvstore"
 			ciliumConfigMapData["kvstore"] = "etcd"
 			ciliumConfigMapData["kvstore-opt"] = "{\"etcd.config\": \"/var/lib/etcd-config/etcd.config\"}"
+		}
+	case strings.HasPrefix(ciliumVersion, "1.7"):
+		ciliumConfigMapData = map[string]string{
+			"bpf-map-dynamic-size-ratio":  "0.0025",
+			"debug":                       "false",
+			"enable-ipv4":                 "true",
+			"enable-ipv6":                 "false",
+			"enable-remote-node-identity": "true",
+			"identity-allocation-mode":    "crd",
+			"kube-proxy-replacement":      "strict",
+			"preallocate-bpf-maps":        "false",
 		}
 	}
 

--- a/internal/pkg/skuba/cni/cilium_test.go
+++ b/internal/pkg/skuba/cni/cilium_test.go
@@ -302,6 +302,24 @@ key-file: /tmp/cilium-etcd/tls.key
 			errExpected:   true,
 			errMessage:    "unable to get api endpoints: could not retrieve the kubeadm-config configmap to get apiEndpoints: configmaps \"kubeadm-config\" not found",
 		},
+		// This test case represents the new deployment with Cilium 1.7
+		// which should habe kube-proxy replacement enabled.
+		{
+			name:          "should create cilium configmap for a new 1.7 deployment",
+			clientset:     fake.NewSimpleClientset(),
+			ciliumVersion: "1.7.5",
+			dataExpected: map[string]string{
+				"bpf-map-dynamic-size-ratio":  "0.0025",
+				"debug":                       "false",
+				"enable-ipv4":                 "true",
+				"enable-ipv6":                 "false",
+				"enable-remote-node-identity": "true",
+				"identity-allocation-mode":    "crd",
+				"kube-proxy-replacement":      "strict",
+				"preallocate-bpf-maps":        "false",
+			},
+			errExpected: false,
+		},
 		// This test case represents the new deployment with Cilium 1.6
 		// which should use CRD for identity allocation.
 		{

--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -62,7 +62,13 @@ func kubeadmInit(t *Target, data interface{}) error {
 	if len(ignorePreflightErrorsVal) > 0 {
 		ignorePreflightErrors = "--ignore-preflight-errors=" + ignorePreflightErrorsVal
 	}
-	_, _, err := t.ssh("kubeadm", "init", "--config", remoteKubeadmInitConfFile, "--skip-token-print", ignorePreflightErrors, "-v", t.verboseLevel)
+	_, _, err := t.ssh(
+		"kubeadm",
+		"init",
+		"--config", remoteKubeadmInitConfFile,
+		"--skip-phases", "addon/kube-proxy",
+		"--skip-token-print", ignorePreflightErrors,
+		"-v", t.verboseLevel)
 	return err
 }
 

--- a/internal/pkg/skuba/util/controlplane.go
+++ b/internal/pkg/skuba/util/controlplane.go
@@ -34,6 +34,20 @@ func ControlPlaneHost(cp string) string {
 	return controlPlane
 }
 
+// ControlPlanePort parses a control plane address of the form "host:port", "ipv4:port", "[ipv6]:port" into port;
+// ":port" can be eventually omitted.
+// If the port is empty, a default control plane port 6443 returns.
+func ControlPlanePort(cp string) string {
+	_, controlPlanePort, err := kubeadmutil.ParseHostPort(cp)
+	if err != nil {
+		return ""
+	}
+	if controlPlanePort == "" {
+		controlPlanePort = "6443"
+	}
+	return controlPlanePort
+}
+
 // ControlPlaneHostAndPort parses a control plane address of the form "host:port", "ipv4:port", "[ipv6]:port" into host and port;
 // ":port" can be eventually omitted.
 // If the port is empty, a default control plane port 6443 added.

--- a/internal/pkg/skuba/util/controlplane_test.go
+++ b/internal/pkg/skuba/util/controlplane_test.go
@@ -63,6 +63,60 @@ func TestControlPlaneHost(t *testing.T) {
 	}
 }
 
+func TestControlPlanePort(t *testing.T) {
+	tests := []struct {
+		name         string
+		controlPlane string
+		expected     string
+	}{
+		{
+			name:         "IP",
+			controlPlane: "1.1.1.1",
+			expected:     "6443",
+		},
+		{
+			name:         "IP:6443",
+			controlPlane: "1.1.1.1:6443",
+			expected:     "6443",
+		},
+		{
+			name:         "IP:8443",
+			controlPlane: "1.1.1.1:8443",
+			expected:     "8443",
+		},
+		{
+			name:         "DNS",
+			controlPlane: "a.b.c",
+			expected:     "6443",
+		},
+		{
+			name:         "DNS:6443",
+			controlPlane: "a.b.c:6443",
+			expected:     "6443",
+		},
+		{
+			name:         "DNS:8443",
+			controlPlane: "a.b.c:8443",
+			expected:     "8443",
+		},
+		{
+			name:         "invalid control plane",
+			controlPlane: "6443:1.1.1.1",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cp := ControlPlanePort(tt.controlPlane)
+			if cp != tt.expected {
+				t.Errorf("expect %s not equal to got %s", tt.expected, cp)
+			}
+		})
+	}
+}
+
 func TestControlPlaneHostAndPort(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/pkg/skuba/util/versioncheck.go
+++ b/internal/pkg/skuba/util/versioncheck.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package util
+
+import (
+	"github.com/blang/semver"
+)
+
+func VersionCompare(versionS, constraintS string) bool {
+	version, err := semver.ParseTolerant(versionS)
+	if err != nil {
+		panic(err)
+	}
+	constraint, err := semver.ParseRange(constraintS)
+	if err != nil {
+		panic(err)
+	}
+	return constraint(version)
+}

--- a/internal/pkg/skuba/util/versioncheck_test.go
+++ b/internal/pkg/skuba/util/versioncheck_test.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package util
+
+import (
+	"testing"
+)
+
+func TestVersionCompare(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		constraint string
+		exp        bool
+	}{
+		{
+			name:       "equal, should match",
+			version:    "1.7.5",
+			constraint: "1.7.5",
+			exp:        true,
+		},
+		{
+			name:       "greater or equal, should match",
+			version:    "1.7.5",
+			constraint: ">=1.7.5",
+			exp:        true,
+		},
+		{
+			name:       "lower or equal, should match",
+			version:    "1.7.5",
+			constraint: "<=1.7.5",
+			exp:        true,
+		},
+		{
+			name:       "greater, should match",
+			version:    "1.7.5",
+			constraint: ">1.7.0",
+			exp:        true,
+		},
+		{
+			name:       "lower, should match",
+			version:    "1.7.5",
+			constraint: "<1.8.0",
+			exp:        true,
+		},
+		{
+			name:       "equal, should not match, is lower",
+			version:    "1.7.5",
+			constraint: "1.5.3",
+			exp:        false,
+		},
+		{
+			name:       "equal, should not match, is greater",
+			version:    "1.7.5",
+			constraint: "1.8.0",
+			exp:        false,
+		},
+		{
+			name:       "greater, should not match",
+			version:    "1.7.5",
+			constraint: ">1.7.5",
+			exp:        false,
+		},
+		{
+			name:       "lower, should not match",
+			version:    "1.7.5",
+			constraint: "<1.7.5",
+			exp:        false,
+		},
+		{
+			name:       "greater or equal, should not match",
+			version:    "1.7.5",
+			constraint: ">=1.8.0",
+			exp:        false,
+		},
+		{
+			name:       "lower or equal, should not match",
+			version:    "1.7.5",
+			constraint: "<=1.5.0",
+			exp:        false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cmp := VersionCompare(tt.version, tt.constraint)
+			if cmp != tt.exp {
+				t.Errorf("version comparison does not match, expected %v, got %v", tt.exp, cmp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why is this PR needed?

It addresses the tech-debt in the current support of Cilium 1.7 by enabling new options which allow us to use the new Cilium functionality.

Fixes SUSE/avant-garde#1731

## What does this PR do?

It enables the following configuration options of Cilium:

- kube-proxy replacement
- dynamic BPF map allocation
- a new identity for remote cluster nodes

## Anything else a reviewer needs to know?

Nothing more than the info for QA below, which is important for everyone reviewing this PR.

## Info for QA

The `enable-remote-node-identity` option (which is enabled in this PR) might break network connectivity from pods using `net: host` to pods managed by Cilium. As far as I know, we don't have any `host: net` Deployments or DaemonSets which would require an access to any service deployed on Kubernetes and having a network isolation. But if I am wrong, or you observe any pods in the cluster failing, please let me know!

### Related info

Info that can be relevant for QA:
* https://docs.cilium.io/en/v1.7/install/upgrade/#important-changes-required-before-upgrading-to-1-7-x

## Docs

Maybe we need to put this link (https://docs.cilium.io/en/v1.7/install/upgrade/#important-changes-required-before-upgrading-to-1-7-x) to our docs, or write a short info about new options and potential consequences.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
