### PR TITLE
Ensure services are enabled

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -43,6 +43,7 @@ func init() {
 	stateMap["kubernetes.upgrade-stage-one"] = kubernetesUpgradeStageOne
 	stateMap["kubernetes.upgrade-stage-two"] = kubernetesUpgradeStageTwo
 	stateMap["kubernetes.restart-services"] = kubernetesRestartServices
+	stateMap["kubernetes.enable-services"] = kubernetesEnsureServicesEnabled
 }
 
 func kubernetesUploadSecrets(errorHandling KubernetesUploadSecretsErrorBehavior) Runner {
@@ -170,5 +171,10 @@ func kubernetesUpgradeStageTwo(t *Target, data interface{}) error {
 
 func kubernetesRestartServices(t *Target, data interface{}) error {
 	_, _, err := t.ssh("systemctl", "restart", "crio", "kubelet")
+	return err
+}
+
+func kubernetesEnsureServicesEnabled(t *Target, data interface{}) error {
+	_, _, err := t.ssh("systemctl", "enable", "crio", "kubelet")
 	return err
 }

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -178,6 +178,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 	err = target.Apply(nil,
 		"kubelet.rootcert.upload",
 		"kubernetes.restart-services",
+		"kubernetes.enable-services",
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
When removing a package and re-installing a new one, like we
do in the upgrade, the systemd service will be automatically
disabled. We should always ensure the services for cri-o
and kubelet are started.

## Anything else a reviewer needs to know?

None

## Info for QA

Upon 1.18 upgrade, `systemctl status crio` should show the service `enabled`.
Current state without this patch is `disabled`.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
