### PR TITLE
Upgrade to k8s from 1.17.4 to 1.17.9

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -2,7 +2,7 @@ import signal
 import time
 import yaml
 
-PREVIOUS_VERSION = "1.17.4"
+PREVIOUS_VERSION = "1.17.9"
 CURRENT_VERSION = "1.18.5"
 
 

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -47,13 +47,13 @@
         - test_upgrade_plan_all_fine
         - test_upgrade_apply_all_fine
         - test_upgrade_apply_from_previous:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.17.9
         - test_upgrade_apply_user_lock:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.17.9
         - test_upgrade_plan_from_previous:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.17.9
         - test_upgrade_plan_from_previous_with_upgraded_control_plane:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.17.9
     jobs:
         - '{name}/{platform}/{test}-daily'
         - '{name}/{platform}/update-daily'

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -111,16 +111,16 @@ var (
 				PSP:           &AddonVersion{"", 2},
 			},
 		},
-		"1.17.4": KubernetesVersion{
+		"1.17.9": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
-				KubeletVersion:          "1.17.4",
+				KubeletVersion:          "1.17.9",
 				ContainerRuntimeVersion: "1.16.1",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
-				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
 				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
 				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
 				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
@@ -128,7 +128,7 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.6.6", 3},
-				Kured:         &AddonVersion{"1.3.0", 4},
+				Kured:         &AddonVersion{"1.3.0-rev4", 5},
 				Dex:           &AddonVersion{"2.16.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 1},

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -38,7 +38,7 @@ func Test_RemoveNode(t *testing.T) {
 		Data: map[string]string{"ClusterConfiguration": `
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: "v1.17.4"
+kubernetesVersion: "v1.17.9"
 apiServer:
   extraArgs:
     advertiseAddress: 1.2.3.4


### PR DESCRIPTION
## Why is this PR needed?

This commit upgrades the k8s version to 1.17.9. This upgrade is
motivated in order to include the upstream fixes for bsc#1173984 and
CVE-2020-8557.

Fixes SUSE/avant-garde#1821 and bsc#1173984

## What does this PR do?

This commit upgrades the k8s version to 1.17.9 in the scope of CaaSPv4. This change needs to be backported to CaaSPv5 release and caaspv4 maintenance branches. Note the versions.go file includes pre CaaSPv5 k8s references, thus changes in versions.go that are in the scope of 1.17.x should also be part of CaaSPv5 release.

## Anything else a reviewer needs to know?

This change has no impact on the tests executed in this PR. However the tests have been tested in the scope of CaaSPv4 in #1260

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
