### PR TITLE
Fix duplicate name issues with secgroup handling

### DIFF
--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -67,8 +67,8 @@ resource "openstack_compute_instance_v2" "master" {
   }
 
   security_groups = [
-    openstack_networking_secgroup_v2.common.name,
-    openstack_networking_secgroup_v2.master_nodes.name,
+    openstack_networking_secgroup_v2.common.id,
+    openstack_networking_secgroup_v2.master_nodes.id,
   ]
 
   user_data = data.template_file.master-cloud-init.rendered

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -82,7 +82,7 @@ resource "openstack_compute_instance_v2" "worker" {
   }
 
   security_groups = [
-    openstack_networking_secgroup_v2.common.name,
+    openstack_networking_secgroup_v2.common.id,
   ]
 
   user_data = data.template_file.worker-cloud-init.rendered


### PR DESCRIPTION
security groups can have duplicate names, so when specifying a name
that is ambigous deployment or cleanup fails, which leaves trash behind.

Better use ids, those are unique identifiers.

(cherry picked from commit 81f1f0de23d09a0041bde065e609b6c50a7fbd22)

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.


# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
