### PR TITLE
Upgrade to k8s from 1.17.4 to 1.17.9

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -3,7 +3,7 @@ import time
 import yaml
 
 PREVIOUS_VERSION = "1.16.2"
-CURRENT_VERSION = "1.17.4"
+CURRENT_VERSION = "1.17.9"
 
 
 def check_nodes_ready(kubectl):

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -85,16 +85,16 @@ type ClusterAddonsKnownVersions = func(clusterVersion *version.Version) AddonsVe
 
 var (
 	supportedVersions = KubernetesVersions{
-		"1.17.4": KubernetesVersion{
+		"1.17.9": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
-				KubeletVersion:          "1.17.4",
+				KubeletVersion:          "1.17.9",
 				ContainerRuntimeVersion: "1.16.1",
 			},
 			ComponentContainerVersion: ComponentContainerVersion{
-				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
-				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
 				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
 				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
 				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
@@ -102,7 +102,7 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
-				Kured:         &AddonVersion{"1.3.0", 4},
+				Kured:         &AddonVersion{"1.3.0-rev4", 5},
 				Dex:           &AddonVersion{"2.16.0-rev6", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
 				MetricsServer: &AddonVersion{"0.3.6", 1},

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -37,7 +37,7 @@ func Test_RemoveNode(t *testing.T) {
 		Data: map[string]string{"ClusterConfiguration": `
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: "v1.17.4"
+kubernetesVersion: "v1.17.9"
 apiServer:
   extraArgs:
     advertiseAddress: 1.2.3.4


### PR DESCRIPTION
## Why is this PR needed?

This is backport of #1261 to CaaSPv4


## What does this PR do?

This PR upgrades the k8s version to 1.17.9. This upgrade is
motivated in order to include the upstream fixes for bsc#1173984 and
CVE-2020-8557

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
