### PR TITLE
Fix incorrect output of `skuba cluster images`

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -106,7 +106,7 @@ type AddonConfiguration struct {
 
 type addonTemplater func(AddonConfiguration) string
 type preflightAddonTemplater func(AddonConfiguration) string
-type getImageCallback func(imageTag string) string
+type getImageCallback func(clusterVersion *version.Version, imageTag string) string
 
 type renderContext struct {
 	addon  Addon
@@ -449,10 +449,10 @@ func (addon Addon) Apply(client clientset.Interface, addonConfiguration AddonCon
 }
 
 // Images returns the images required for this Addon to properly function
-func (addon Addon) Images(imageTag string) []string {
+func (addon Addon) Images(clusterVersion *version.Version, imageTag string) []string {
 	images := []string{}
 	for _, cb := range addon.getImageCallbacks {
-		images = append(images, cb(imageTag))
+		images = append(images, cb(clusterVersion, imageTag))
 	}
 	return images
 }

--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -19,6 +19,7 @@ package addons
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/version"
 	"strings"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium_manifests"
@@ -35,28 +36,28 @@ func init() {
 	registerAddon(kubernetes.Cilium, CniAddOn, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumInitImage, GetCiliumOperatorImage, GetCiliumImage})
 }
 
-func GetCiliumInitImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "cilium-init", imageTag)
+func GetCiliumInitImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "cilium-init", imageTag)
 }
 
-func GetCiliumOperatorImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "cilium-operator", imageTag)
+func GetCiliumOperatorImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "cilium-operator", imageTag)
 }
 
-func GetCiliumImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "cilium", imageTag)
+func GetCiliumImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "cilium", imageTag)
 }
 
 func (renderContext renderContext) CiliumInitImage() string {
-	return GetCiliumInitImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
+	return GetCiliumInitImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
 }
 
 func (renderContext renderContext) CiliumOperatorImage() string {
-	return GetCiliumOperatorImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
+	return GetCiliumOperatorImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
 }
 
 func (renderContext renderContext) CiliumImage() string {
-	return GetCiliumImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
+	return GetCiliumImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
 }
 
 func renderCiliumTemplate(addonConfiguration AddonConfiguration) string {

--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -19,17 +19,18 @@ package addons
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/version"
 	"strings"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/addons/cilium_manifests"
 	"github.com/SUSE/skuba/internal/pkg/skuba/cni"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
 	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
-	"github.com/pkg/errors"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 )
 
 func init() {

--- a/internal/pkg/skuba/addons/cilium_test.go
+++ b/internal/pkg/skuba/addons/cilium_test.go
@@ -18,6 +18,7 @@
 package addons
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -37,21 +38,26 @@ func TestGetCiliumInitImage(t *testing.T) {
 		{
 			name:     "get cilium init image without revision",
 			imageTag: "1.7.5",
-			want:     img.ImageRepository + "/cilium-init:1.7.5",
+			want:     "cilium-init:1.7.5",
 		},
 		{
 			name:     "get cilium init image with revision",
 			imageTag: "1.7.5-rev2",
-			want:     img.ImageRepository + "/cilium-init:1.7.5-rev2",
+			want:     "cilium-init:1.7.5-rev2",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetCiliumInitImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetCiliumInitImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetCiliumInitImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetCiliumInitImage() = %v, want %v", got, tt.want)
+				}
+			})
+		}
 	}
 }
 
@@ -64,21 +70,26 @@ func TestGetCiliumOperatorImage(t *testing.T) {
 		{
 			name:     "get cilium operator image without revision",
 			imageTag: "1.7.5",
-			want:     img.ImageRepository + "/cilium-operator:1.7.5",
+			want:     "cilium-operator:1.7.5",
 		},
 		{
 			name:     "get cilium operator image with revision",
 			imageTag: "1.7.5-rev2",
-			want:     img.ImageRepository + "/cilium-operator:1.7.5-rev2",
+			want:     "cilium-operator:1.7.5-rev2",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetCiliumOperatorImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetCiliumOperatorImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetCiliumOperatorImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetCiliumOperatorImage() = %v, want %v", got, imageUri)
+				}
+			})
+		}
 	}
 }
 
@@ -91,21 +102,26 @@ func TestGetCiliumImage(t *testing.T) {
 		{
 			name:     "get cilium image without revision",
 			imageTag: "1.7.5",
-			want:     img.ImageRepository + "/cilium:1.7.5",
+			want:     "cilium:1.7.5",
 		},
 		{
 			name:     "get cilium image with revision",
 			imageTag: "1.7.5-rev2",
-			want:     img.ImageRepository + "/cilium:1.7.5-rev2",
+			want:     "cilium:1.7.5-rev2",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetCiliumImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetCiliumImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetCiliumImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetCiliumImage() = %v, want %v", got, tt.want)
+				}
+			})
+		}
 	}
 }
 
@@ -125,7 +141,7 @@ func Test_renderContext_CiliumInitImage(t *testing.T) {
 					ClusterName:    "",
 				},
 			},
-			want: img.ImageRepository + "/cilium-init:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+			want: img.ImageRepository(ver) + "/cilium-init:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.CiliumInitImage()
@@ -158,7 +174,7 @@ func Test_renderContext_CiliumOperatorImage(t *testing.T) {
 					ClusterName:    "",
 				},
 			},
-			want: img.ImageRepository + "/cilium-operator:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+			want: img.ImageRepository(ver) + "/cilium-operator:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.CiliumOperatorImage()
@@ -191,7 +207,7 @@ func Test_renderContext_CiliumImage(t *testing.T) {
 					ClusterName:    "",
 				},
 			},
-			want: img.ImageRepository + "/cilium:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+			want: img.ImageRepository(ver) + "/cilium:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.CiliumImage()

--- a/internal/pkg/skuba/addons/dex.go
+++ b/internal/pkg/skuba/addons/dex.go
@@ -19,6 +19,7 @@ package addons
 
 import (
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
@@ -33,12 +34,12 @@ func init() {
 	registerAddon(kubernetes.Dex, GenericAddOn, renderDexTemplate, nil, dexCallbacks{}, normalPriority, []getImageCallback{GetDexImage})
 }
 
-func GetDexImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "caasp-dex", imageTag)
+func GetDexImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "caasp-dex", imageTag)
 }
 
 func (renderContext renderContext) DexImage() string {
-	return GetDexImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Dex, renderContext.config.ClusterVersion).Version)
+	return GetDexImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Dex, renderContext.config.ClusterVersion).Version)
 }
 
 func renderDexTemplate(addonConfiguration AddonConfiguration) string {

--- a/internal/pkg/skuba/addons/dex_test.go
+++ b/internal/pkg/skuba/addons/dex_test.go
@@ -18,6 +18,7 @@
 package addons
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -37,21 +38,26 @@ func TestGetDexImage(t *testing.T) {
 		{
 			name:     "get dex init image without revision",
 			imageTag: "2.16.0",
-			want:     img.ImageRepository + "/caasp-dex:2.16.0",
+			want:     "caasp-dex:2.16.0",
 		},
 		{
 			name:     "get dex init image with revision",
 			imageTag: "2.16.0-rev2",
-			want:     img.ImageRepository + "/caasp-dex:2.16.0-rev2",
+			want:     "caasp-dex:2.16.0-rev2",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetDexImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetDexImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetDexImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetDexImage() = %v, want %v", got, imageUri)
+				}
+			})
+		}
 	}
 }
 
@@ -71,7 +77,7 @@ func Test_renderContext_DexImage(t *testing.T) {
 					ClusterName:    "",
 				},
 			},
-			want: img.ImageRepository + "/caasp-dex:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+			want: img.ImageRepository(ver) + "/caasp-dex:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.DexImage()

--- a/internal/pkg/skuba/addons/gangway.go
+++ b/internal/pkg/skuba/addons/gangway.go
@@ -19,6 +19,7 @@ package addons
 
 import (
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
@@ -33,12 +34,12 @@ func init() {
 	registerAddon(kubernetes.Gangway, GenericAddOn, renderGangwayTemplate, nil, gangwayCallbacks{}, normalPriority, []getImageCallback{GetGangwayImage})
 }
 
-func GetGangwayImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "gangway", imageTag)
+func GetGangwayImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "gangway", imageTag)
 }
 
 func (renderContext renderContext) GangwayImage() string {
-	return GetGangwayImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Gangway, renderContext.config.ClusterVersion).Version)
+	return GetGangwayImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Gangway, renderContext.config.ClusterVersion).Version)
 }
 
 func renderGangwayTemplate(addonConfiguration AddonConfiguration) string {

--- a/internal/pkg/skuba/addons/gangway_test.go
+++ b/internal/pkg/skuba/addons/gangway_test.go
@@ -18,6 +18,7 @@
 package addons
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -37,21 +38,26 @@ func TestGetGangwayImage(t *testing.T) {
 		{
 			name:     "get gangway init image without revision",
 			imageTag: "3.1.0",
-			want:     img.ImageRepository + "/gangway:3.1.0",
+			want:     "gangway:3.1.0",
 		},
 		{
 			name:     "get gangway init image with revision",
 			imageTag: "3.1.0-rev2",
-			want:     img.ImageRepository + "/gangway:3.1.0-rev2",
+			want:     "gangway:3.1.0-rev2",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetGangwayImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetGangwayImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetGangwayImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetGangwayImage() = %v, want %v", got, imageUri)
+				}
+			})
+		}
 	}
 }
 
@@ -71,7 +77,7 @@ func Test_renderContext_GangwayImage(t *testing.T) {
 					ClusterName:    "",
 				},
 			},
-			want: img.ImageRepository + "/gangway:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+			want: img.ImageRepository(ver) + "/gangway:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.GangwayImage()

--- a/internal/pkg/skuba/addons/kucero.go
+++ b/internal/pkg/skuba/addons/kucero.go
@@ -18,6 +18,7 @@
 package addons
 
 import (
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
@@ -28,12 +29,12 @@ func init() {
 	registerAddon(kubernetes.Kucero, GenericAddOn, renderKuceroTemplate, nil, nil, normalPriority, []getImageCallback{GetKuceroImage})
 }
 
-func GetKuceroImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "kucero", imageTag)
+func GetKuceroImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "kucero", imageTag)
 }
 
 func (renderContext renderContext) KuceroImage() string {
-	return GetKuceroImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Kucero, renderContext.config.ClusterVersion).Version)
+	return GetKuceroImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Kucero, renderContext.config.ClusterVersion).Version)
 }
 
 func renderKuceroTemplate(addonConfiguration AddonConfiguration) string {

--- a/internal/pkg/skuba/addons/kucero_test.go
+++ b/internal/pkg/skuba/addons/kucero_test.go
@@ -19,9 +19,10 @@ package addons
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	img "github.com/SUSE/skuba/pkg/skuba"
-	"testing"
 )
 
 func TestGetKuceroImage(t *testing.T) {
@@ -54,5 +55,4 @@ func TestGetKuceroImage(t *testing.T) {
 			})
 		}
 	}
-
 }

--- a/internal/pkg/skuba/addons/kucero_test.go
+++ b/internal/pkg/skuba/addons/kucero_test.go
@@ -18,9 +18,10 @@
 package addons
 
 import (
-	"testing"
-
+	"fmt"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	img "github.com/SUSE/skuba/pkg/skuba"
+	"testing"
 )
 
 func TestGetKuceroImage(t *testing.T) {
@@ -32,20 +33,26 @@ func TestGetKuceroImage(t *testing.T) {
 		{
 			name:     "get kucero image without revision",
 			imageTag: "1.1.1",
-			want:     img.ImageRepository + "/kucero:1.1.1",
+			want:     "kucero:1.1.1",
 		},
 		{
 			name:     "get kucero image with revision",
 			imageTag: "1.1.1-rev1",
-			want:     img.ImageRepository + "/kucero:1.1.1-rev1",
+			want:     "kucero:1.1.1-rev1",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetKuceroImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetKuceroImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetKuceroImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetKuceroImage() = %v, want %v", got, imageUri)
+				}
+			})
+		}
 	}
+
 }

--- a/internal/pkg/skuba/addons/kured.go
+++ b/internal/pkg/skuba/addons/kured.go
@@ -20,6 +20,7 @@ package addons
 import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 )
 
@@ -27,12 +28,12 @@ func init() {
 	registerAddon(kubernetes.Kured, GenericAddOn, renderKuredTemplate, nil, nil, normalPriority, []getImageCallback{GetKuredImage})
 }
 
-func GetKuredImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "kured", imageTag)
+func GetKuredImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "kured", imageTag)
 }
 
 func (renderContext renderContext) KuredImage() string {
-	return GetKuredImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Kured, renderContext.config.ClusterVersion).Version)
+	return GetKuredImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Kured, renderContext.config.ClusterVersion).Version)
 }
 
 func renderKuredTemplate(addonConfiguration AddonConfiguration) string {

--- a/internal/pkg/skuba/addons/kured_test.go
+++ b/internal/pkg/skuba/addons/kured_test.go
@@ -18,6 +18,7 @@
 package addons
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -34,21 +35,26 @@ func TestGetKuredImage(t *testing.T) {
 		{
 			name:     "get kured image without revision",
 			imageTag: "1.2.0",
-			want:     img.ImageRepository + "/kured:1.2.0",
+			want:     "kured:1.2.0",
 		},
 		{
 			name:     "get kured image with revision",
 			imageTag: "1.2.0-rev4",
-			want:     img.ImageRepository + "/kured:1.2.0-rev4",
+			want:     "kured:1.2.0-rev4",
 		},
 	}
-	for _, tt := range tests {
-		tt := tt // Parallel testing
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetKuredImage(tt.imageTag); got != tt.want {
-				t.Errorf("GetKuredImage() = %v, want %v", got, tt.want)
-			}
-		})
+
+	for _, ver := range kubernetes.AvailableVersions() {
+		for _, tt := range tests {
+			tt := tt // Parallel testing
+			t.Run(tt.name, func(t *testing.T) {
+				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
+
+				if got := GetKuredImage(ver, tt.imageTag); got != imageUri {
+					t.Errorf("GetKuredImage() = %v, want %v", got, imageUri)
+				}
+			})
+		}
 	}
 }
 
@@ -68,7 +74,7 @@ func Test_renderContext_KuredImage(t *testing.T) {
 					ClusterName:    "",
 				},
 			},
-			want: img.ImageRepository + "/kured:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
+			want: img.ImageRepository(ver) + "/kured:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.KuredImage()

--- a/internal/pkg/skuba/addons/metricsserver.go
+++ b/internal/pkg/skuba/addons/metricsserver.go
@@ -21,11 +21,11 @@ import (
 	"bufio"
 	"encoding/base64"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/version"
 	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"

--- a/internal/pkg/skuba/addons/metricsserver.go
+++ b/internal/pkg/skuba/addons/metricsserver.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"encoding/base64"
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/util/version"
 	"os"
 	"path/filepath"
 
@@ -39,12 +40,12 @@ func init() {
 	registerAddon(kubernetes.MetricsServer, GenericAddOn, renderMetricsServerTemplate, nil, metricsServerCallbacks{}, normalPriority, []getImageCallback{GetMetricsServerImage})
 }
 
-func GetMetricsServerImage(imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository, "metrics-server", imageTag)
+func GetMetricsServerImage(clusterVersion *version.Version, imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "metrics-server", imageTag)
 }
 
 func (renderContext renderContext) MetricsServerImage() string {
-	return GetMetricsServerImage(kubernetes.AddonVersionForClusterVersion(kubernetes.MetricsServer, renderContext.config.ClusterVersion).Version)
+	return GetMetricsServerImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.MetricsServer, renderContext.config.ClusterVersion).Version)
 }
 
 // CABundle returns base64 encoded Kubernetes CA certificate.

--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -358,6 +358,8 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 	for _, tt := range scenarios {
 		tt := tt // Parallel testing
 		t.Run(tt.name, func(t *testing.T) {
+			imageRepository := skuba.ImageRepository(tt.clusterVersion)
+
 			expectedAdmissionPlugins := strings.Join(tt.expectedAdmissionPlugins, ",")
 			initCfg := kubeadmapi.InitConfiguration{}
 			if len(tt.currentAdmissionPlugins) > 0 {
@@ -374,15 +376,15 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 				t.Errorf("admission plugins %s do not match expected admission plugins %s", gotAdmissionPlugins, expectedAdmissionPlugins)
 			}
 			// Check different configuration settings
-			if initCfg.ImageRepository != skuba.ImageRepository {
-				t.Errorf("image repository %s does not match expected image repository %s", initCfg.ImageRepository, skuba.ImageRepository)
+			if initCfg.ImageRepository != imageRepository {
+				t.Errorf("image repository %s does not match expected image repository %s", initCfg.ImageRepository, imageRepository)
 			}
 			expectedClusterVersion := fmt.Sprintf("v%s", tt.clusterVersion.String())
 			if initCfg.KubernetesVersion != expectedClusterVersion {
 				t.Errorf("kubernetes version %s does not match expected kubernetes version %s", initCfg.KubernetesVersion, expectedClusterVersion)
 			}
-			if initCfg.Etcd.Local.ImageRepository != skuba.ImageRepository {
-				t.Errorf("etcd image repository %s does not match expected etcd image repository %s", initCfg.Etcd.Local.ImageRepository, skuba.ImageRepository)
+			if initCfg.Etcd.Local.ImageRepository != imageRepository {
+				t.Errorf("etcd image repository %s does not match expected etcd image repository %s", initCfg.Etcd.Local.ImageRepository, imageRepository)
 			}
 			etcdExpectedTag := kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, tt.clusterVersion)
 			if initCfg.Etcd.Local.ImageTag != etcdExpectedTag {

--- a/internal/pkg/skuba/kubeadm/images.go
+++ b/internal/pkg/skuba/kubeadm/images.go
@@ -26,16 +26,18 @@ import (
 )
 
 func setContainerImagesWithClusterVersion(initConfiguration *kubeadmapi.InitConfiguration, clusterVersion *version.Version) {
-	initConfiguration.ImageRepository = skuba.ImageRepository
+	imageRepository := skuba.ImageRepository(clusterVersion)
+
+	initConfiguration.ImageRepository = imageRepository
 	initConfiguration.KubernetesVersion = kubernetes.ComponentVersionForClusterVersion(kubernetes.APIServer, clusterVersion)
 	initConfiguration.Etcd.Local = &kubeadmapi.LocalEtcd{
 		ImageMeta: kubeadmapi.ImageMeta{
-			ImageRepository: skuba.ImageRepository,
+			ImageRepository: imageRepository,
 			ImageTag:        kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, clusterVersion),
 		},
 	}
 	initConfiguration.DNS.ImageMeta = kubeadmapi.ImageMeta{
-		ImageRepository: skuba.ImageRepository,
+		ImageRepository: imageRepository,
 		ImageTag:        kubernetes.ComponentVersionForClusterVersion(kubernetes.CoreDNS, clusterVersion),
 	}
 }

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -218,7 +218,7 @@ func AllComponentContainerImagesForClusterVersion(clusterVersion *version.Versio
 func ComponentContainerImageForClusterVersion(component Component, clusterVersion *version.Version) string {
 	currentKubernetesVersion := supportedVersions[clusterVersion.String()]
 	if componentDetails, found := currentKubernetesVersion.ComponentContainerVersion[component]; found {
-		return images.GetGenericImage(skuba.ImageRepository, componentDetails.Name, componentDetails.Tag)
+		return images.GetGenericImage(skuba.ImageRepository(clusterVersion), componentDetails.Name, componentDetails.Tag)
 	}
 	klog.Errorf("unknown component %q container image", component)
 	return ""

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -194,7 +194,7 @@ func TestComponentContainerImageForClusterVersion(t *testing.T) {
 					return
 				}
 			} else {
-				expect := images.GetGenericImage(skuba.ImageRepository, tt.imageName, tt.expectVersion)
+				expect := images.GetGenericImage(skuba.ImageRepository(tt.clusterVersion), tt.imageName, tt.expectVersion)
 				if actual != expect {
 					t.Errorf("returned image (%s) does not match the expected one (%s)", actual, expect)
 					return

--- a/pkg/skuba/actions/cluster/images/images.go
+++ b/pkg/skuba/actions/cluster/images/images.go
@@ -41,7 +41,7 @@ func Images() error {
 			if addonVersion == nil {
 				continue
 			}
-			for _, addonImageLoc := range addon.Images(addonVersion.Version) {
+			for _, addonImageLoc := range addon.Images(version, addonVersion.Version) {
 				imagesEncountered[addonImageLoc] = true
 			}
 		}

--- a/pkg/skuba/actions/cluster/init/init.go
+++ b/pkg/skuba/actions/cluster/init/init.go
@@ -90,7 +90,7 @@ func NewInitConfiguration(clusterName, cloudProvider, controlPlane, kubernetesDe
 		ControlPlane:      controlPlane,
 		PauseImage:        kubernetes.ComponentContainerImageForClusterVersion(kubernetes.Pause, kubernetesVersion),
 		KubernetesVersion: kubernetesVersion,
-		ImageRepository:   skuba.ImageRepository,
+		ImageRepository:   skuba.ImageRepository(kubernetesVersion),
 		EtcdImageTag:      kubernetes.ComponentVersionForClusterVersion(kubernetes.Etcd, kubernetesVersion),
 		CoreDNSImageTag:   kubernetes.ComponentVersionForClusterVersion(kubernetes.CoreDNS, kubernetesVersion),
 		StrictCapDefaults: strictCapDefaults,

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -19,6 +19,7 @@ package skuba
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/util/version"
 	"path"
 	"path/filepath"
 
@@ -197,4 +198,14 @@ func AWSDir() string {
 // AWSReadmeFile returns the location for the AWS cloud integrations README.md
 func AWSReadmeFile() string {
 	return path.Join(AWSDir(), "README.md")
+}
+
+//ImageRepository returns the image registry of the cluster version
+func ImageRepository(clusterVersion *version.Version) string {
+	result, _ := clusterVersion.Compare("1.18.0")
+	if result < 0 {
+		return imageRepositoryV4
+	}
+
+	return imageRepository
 }

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -19,10 +19,10 @@ package skuba
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/version"
 	"path"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"

--- a/pkg/skuba/development_constants.go
+++ b/pkg/skuba/development_constants.go
@@ -20,6 +20,7 @@
 package skuba
 
 const (
-	BuildType       = "development"
-	ImageRepository = "registry.suse.de/devel/caasp/5/containers/containers/caasp/v5"
+	BuildType         = "development"
+	imageRepositoryV4 = "registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4"
+	imageRepository   = "registry.suse.de/devel/caasp/5/containers/containers/caasp/v5"
 )

--- a/pkg/skuba/release_constants.go
+++ b/pkg/skuba/release_constants.go
@@ -20,6 +20,7 @@
 package skuba
 
 const (
-	BuildType       = "release"
-	ImageRepository = "registry.suse.com/caasp/v5"
+	BuildType         = "release"
+	imageRepositoryV4 = "registry.suse.com/caasp/v4"
+	imageRepository   = "registry.suse.com/caasp/v5"
 )

--- a/pkg/skuba/staging_constants.go
+++ b/pkg/skuba/staging_constants.go
@@ -20,6 +20,7 @@
 package skuba
 
 const (
-	BuildType       = "staging"
-	ImageRepository = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/5/containers/caasp/v5"
+	BuildType         = "staging"
+	imageRepositoryV4 = "registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4"
+	imageRepository   = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/5/containers/caasp/v5"
 )


### PR DESCRIPTION
Fix SUSE/avant-garde#1750

Because of v5 regsitry path change, the output of `skuba cluster images`
has incorrect info for v4 related images of previous cluster versions.

The original code has hard-coded registry path for v4, so this will be
fixed in this commit to have adaptive way to have right registry path
for the corresponding cluster version.

Also, `--kubernetes-version` will be kept to use w/o issues.

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
