### PR TITLE
Upgrade the k8s libraries we use to version 1.17.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,36 +9,36 @@ require (
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	k8s.io/api v0.17.5
-	k8s.io/apimachinery v0.17.5
-	k8s.io/client-go v0.17.5
-	k8s.io/cluster-bootstrap v0.17.5
+	k8s.io/api v0.17.9
+	k8s.io/apimachinery v0.17.9
+	k8s.io/client-go v0.17.9
+	k8s.io/cluster-bootstrap v0.17.9
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.0.0
-	k8s.io/kubernetes v1.17.5
+	k8s.io/kubernetes v1.17.9
 	sigs.k8s.io/yaml v1.1.0
 )
 
 replace (
-	k8s.io/api => k8s.io/api v0.17.5
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.5
-	k8s.io/apimachinery => k8s.io/apimachinery v0.17.5
-	k8s.io/apiserver => k8s.io/apiserver v0.17.5
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.5
-	k8s.io/client-go => k8s.io/client-go v0.17.5
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.5
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.5
-	k8s.io/code-generator => k8s.io/code-generator v0.17.5
-	k8s.io/component-base => k8s.io/component-base v0.17.5
-	k8s.io/cri-api => k8s.io/cri-api v0.17.5
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.17.5
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.5
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.5
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.5
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.5
-	k8s.io/kubectl => k8s.io/kubectl v0.17.5
-	k8s.io/kubelet => k8s.io/kubelet v0.17.5
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.5
-	k8s.io/metrics => k8s.io/metrics v0.17.5
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.5
+	k8s.io/api => k8s.io/api v0.17.9
+	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.17.9
+	k8s.io/apimachinery => k8s.io/apimachinery v0.17.9
+	k8s.io/apiserver => k8s.io/apiserver v0.17.9
+	k8s.io/cli-runtime => k8s.io/cli-runtime v0.17.9
+	k8s.io/client-go => k8s.io/client-go v0.17.9
+	k8s.io/cloud-provider => k8s.io/cloud-provider v0.17.9
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.17.9
+	k8s.io/code-generator => k8s.io/code-generator v0.17.9
+	k8s.io/component-base => k8s.io/component-base v0.17.9
+	k8s.io/cri-api => k8s.io/cri-api v0.17.9
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.17.9
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.17.9
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.17.9
+	k8s.io/kube-proxy => k8s.io/kube-proxy v0.17.9
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.17.9
+	k8s.io/kubectl => k8s.io/kubectl v0.17.9
+	k8s.io/kubelet => k8s.io/kubelet v0.17.9
+	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.9
+	k8s.io/metrics => k8s.io/metrics v0.17.9
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.9
 )


### PR DESCRIPTION
##  Why is this PR needed?

PR is needed to complete the kubernetes version bump in v4 from 1.17.4 to 1.17.9

## What does this PR do?

This commit is a follow up of commit 48f33d67 in which the k8s version
references were updated

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
