### PR TITLE
Fix name of kubernetes client package

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -72,7 +72,7 @@ update_jenkins_jobs:
 
 .PHONY: update_pkgs
 update_pkgs:
-	sudo zypper update --allow-vendor-change -y kubernetes-client terraform terraform-provider-*
+	sudo zypper update --allow-vendor-change -y k8s-client terraform terraform-provider-*
 
 # Stages
 .PHONY: pre_deployment


### PR DESCRIPTION
## Why is this PR needed?

The CI jobs automatically update the packages used by skuba to deploy a cluster. The name of the package that provides the kubernetes client has changed and must be updated

## What does this PR do?

Use the proper name for the K8s client package when updating tools in the CI.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
