### PR TITLE
Update node repositories to official SP2 repos

### DIFF
--- a/ci/infra/libvirt/terraform.tfvars.json.ci.example
+++ b/ci/infra/libvirt/terraform.tfvars.json.ci.example
@@ -11,24 +11,24 @@
     "workers": 2,
     "username": "sles",
     "repositories": {
-        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2",
-        "caasp_ga": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2/",
+        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2/",
         "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle15sp2_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update/standard/",
-        "sle15sp2_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA/standard/",
-        "sle15sp1_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/",
-        "sle15sp1_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/",
-        "sle15_update": "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/",
-        "sle15_ga": "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "containers_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
+        "serverapps_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
+        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+        "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
     },
     "lb_repositories": {
-        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle15sp2_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update/standard/",
-        "sle15sp2_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA/standard/",
-        "sle15sp1_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/",
-        "sle15sp1_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/",
-        "sle15_update": "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/",
-        "sle15_ga": "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "ha_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP2/x86_64/product/",
+        "ha_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP2/x86_64/update/",
+        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/"
     },
     "packages": [
         "zypper-needs-restarting",

--- a/ci/infra/openstack/terraform.tfvars.json.ci.example
+++ b/ci/infra/openstack/terraform.tfvars.json.ci.example
@@ -15,15 +15,16 @@
     "workers_vol_enabled": false,
     "workers_vol_size": 5,
     "repositories": {
-        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2",
-        "caasp_ga": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2/",
+        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2/",
         "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle15sp2_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update/standard/",
-        "sle15sp2_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA/standard/",
-        "sle15sp1_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/",
-        "sle15sp1_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/",
-        "sle15_update": "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/",
-        "sle15_ga": "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "containers_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
+        "serverapps_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
+        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+        "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
     },
     "packages": [
         "zypper-needs-restarting",

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -12,24 +12,24 @@
     "workers": 2,
     "username": "sles",
     "lb_repositories": {
-        "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle15sp2_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update/standard/",
-        "sle15sp2_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA/standard/",
-        "sle15sp1_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/",
-        "sle15sp1_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/",
-        "sle15_update": "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/",
-        "sle15_ga": "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "ha_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-HA/15-SP2/x86_64/product/",
+        "ha_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-HA/15-SP2/x86_64/update/",
+        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/"
     },
     "repositories": {
-        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2",
-        "caasp_ga": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2/",
+        "caasp_devel": "http://download.suse.de/ibs/Devel:/CaaSP:/5/SLE_15_SP2/",
         "suse_ca": "http://download.suse.de/ibs/SUSE:/CA/SLE_15_SP2",
-        "sle15sp2_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update/standard/",
-        "sle15sp2_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA/standard/",
-        "sle15sp1_update": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update/standard/",
-        "sle15sp1_ga": "http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA/standard/",
-        "sle15_update": "http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/",
-        "sle15_ga": "http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/"
+        "sle_server_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product",
+        "basesystem_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product",
+        "containers_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Containers/15-SP2/x86_64/product",
+        "serverapps_pool": "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product",
+        "sle_server_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/",
+        "basesystem_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/",
+        "containers_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Containers/15-SP2/x86_64/update/",
+        "serverapps_updates": "http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/"
     },
     "packages": [
         "zypper-needs-restarting"


### PR DESCRIPTION
## Why is this PR needed?

To make sure we test deploying CaaSP nodes using the same base packages that the end user.

## What does this PR do?

This commit sets the nodes deployed by the CI to make use of the official SP2 repositories.

Fixes SUSE/avant-garde#1772