### PR TITLE
Enable ExtendedResourceToleration by default (#1192)

### DIFF
--- a/internal/pkg/skuba/kubeadm/configmap.go
+++ b/internal/pkg/skuba/kubeadm/configmap.go
@@ -167,6 +167,7 @@ func setApiserverAdmissionPlugins(initCfg *kubeadmapi.InitConfiguration, cluster
 	admissionPlugins = append(admissionPlugins, "NodeRestriction")
 	// List of skuba-enabled plugins
 	admissionPlugins = append(admissionPlugins, "PodSecurityPolicy")
+	admissionPlugins = append(admissionPlugins, "ExtendedResourceToleration")
 	admissionPlugins = skubautil.UniqueStringSlice(admissionPlugins)
 	initCfg.APIServer.ControlPlaneComponent.ExtraArgs["enable-admission-plugins"] = strings.Join(admissionPlugins, ",")
 }

--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -339,19 +339,19 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 			name:                     "1.15.2 without duplicates",
 			clusterVersion:           version.MustParseSemantic("1.15.2"),
 			currentAdmissionPlugins:  []string{},
-			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "NodeRestriction", "PodSecurityPolicy"},
+			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "NodeRestriction", "PodSecurityPolicy", "ExtendedResourceToleration"},
 		},
 		{
 			name:                     "1.15.2 with duplicates",
 			clusterVersion:           version.MustParseSemantic("1.15.2"),
 			currentAdmissionPlugins:  []string{"NamespaceLifecycle", "NodeRestriction", "PodSecurityPolicy"},
-			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "NodeRestriction", "PodSecurityPolicy", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection"},
+			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "NodeRestriction", "PodSecurityPolicy", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "ExtendedResourceToleration"},
 		},
 		{
 			name:                     "1.16.2 without duplicates",
 			clusterVersion:           version.MustParseSemantic("1.16.2"),
 			currentAdmissionPlugins:  []string{},
-			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "RuntimeClass", "NodeRestriction", "PodSecurityPolicy"},
+			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "RuntimeClass", "NodeRestriction", "PodSecurityPolicy", "ExtendedResourceToleration"},
 		},
 	}
 


### PR DESCRIPTION
Enable the ExtendedResourceToleration admission controller[1] by default
for all deployments.

This admission controller is beneficial to heterogeneous clusters that
may want to make use of kubernetes node taints[2] for giving
preferential scheduling to workloads that require special hardware, such
as GPUs. This admission controller is a mutating admission controller
that automatically adds a resource toleration to pods that request an
extended resource that is being advertised by a device plugin[3]. It has
no effect on pods that don't request such resources, and the added
toleration would have no effect if the cluster administrator is not
using taints for this purpose, so it is safe to enable by default and a
convenience for cost-aware admins with these hardware requirements.

[1] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#extendedresourcetoleration
[2] https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/#example-use-cases
[3] https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/

(cherry picked from commit 92f652b4a204052c5a5ba40e26071ac6382e9a2f)

Backport of #1192

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
