### PR TITLE
Make sure k8s 1.17.9 is appended and not substituting 1.17.4

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -127,8 +127,32 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.6.6", 3},
+				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
 				Kured:         &AddonVersion{"1.3.0-rev4", 5},
+				Dex:           &AddonVersion{"2.16.0-rev6", 7},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
+				MetricsServer: &AddonVersion{"0.3.6", 1},
+				PSP:           &AddonVersion{"", 4},
+			},
+		},
+		"1.17.4": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.17.4",
+				ContainerRuntimeVersion: "1.16.1",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.6.6", 3},
+				Kured:         &AddonVersion{"1.3.0", 4},
 				Dex:           &AddonVersion{"2.16.0", 6},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 1},


### PR DESCRIPTION
## Why is this PR needed?

This commit fixes v4.2.2 release and keeps the whole history of v4 in v5.

## What does this PR do?

This commit fixes the changes introduced in 1ce13211, in which 1.17.4
was substituted by 1.17.9, however the new version should have been
appended instead.

## Anything else a reviewer needs to know?

In v5 this is only needed for completeness and consistency, but from a functional PoV I see no reason to require it in v5, we can easily backport it there in the context of GMC2 IMHO. 

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

On `skuba addons upgrade` there is a failure because of missing information in `versions.go`. This causes 4.2.1 -> 4.2.2 upgrade to fail.

### Status **AFTER** applying the patch

The upgrade from 4.2.1 to 4.2.2 is expected to properly work.