### PR TITLE
Make sure k8s 1.17.9 is appended and not substituting 1.17.4

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -109,6 +109,30 @@ var (
 				PSP:           &AddonVersion{"", 4},
 			},
 		},
+		"1.17.4": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.17.4",
+				ContainerRuntimeVersion: "1.16.1",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.4"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.6.6", 3},
+				Kured:         &AddonVersion{"1.3.0", 4},
+				Dex:           &AddonVersion{"2.16.0", 6},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
+				MetricsServer: &AddonVersion{"0.3.6", 1},
+				PSP:           &AddonVersion{"", 4},
+			},
+		},
 		"1.16.2": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.16.2",


### PR DESCRIPTION
## Why is this PR needed?

This commit fixes versions.go for the v4.2.2 release

## What does this PR do?

This commit fixes the changes introduced in 1ce13211, in which 1.17.4
was substituted by 1.17.9, however the new version should have been
appended instead.

## Anything else a reviewer needs to know?

Nothing special

## Info for QA

This is needed to fix the upgrade from 1.17.4 to 1.17.9, meaning the upgrade from CaaSP v4.2.1 to v4.2.2

### Related info

This is the backport of #1286 to v4, it should not be merged before #1286.

### Status **BEFORE** applying the patch

On `skuba addons upgrade` there is a failure because of missing information in `versions.go`. This causes 4.2.1 -> 4.2.2 upgrade to fail.

### Status **AFTER** applying the patch

The upgrade from 4.2.1 to 4.2.2 should not fail on `skuba addons upgrade`.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
