### PR TITLE
Drop hyperkube image version > v1.17

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -102,7 +102,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		// This updated UseHyperKube field in-memory (unsets it).
 		// Note: The cluster cm is uploaded at the end of the kubeadm process, as usual.
 		// The whole paragraph can be removed when upgrading from 1.17 is removed.
-		if currentClusterVersion.Minor() == 17 {
+		if currentClusterVersion.Minor() == 17 && kubernetes.LatestVersion().Minor() > 17 {
 			initCfg.UseHyperKubeImage = false
 		}
 


### PR DESCRIPTION
## Why is this PR needed?

This will improve check when exactly we have to drop hyperkube image during upgrade.

## What does this PR do?

It will check what is current Kubernetes version and what is latest Kubernetes version.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
