### PR TITLE
Revert k8s 1.17.9 upgrade

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -2,7 +2,7 @@ import signal
 import time
 import yaml
 
-PREVIOUS_VERSION = "1.17.9"
+PREVIOUS_VERSION = "1.17.4"
 CURRENT_VERSION = "1.18.6"
 
 

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -111,30 +111,6 @@ var (
 				PSP:           &AddonVersion{"", 2},
 			},
 		},
-		"1.17.9": KubernetesVersion{
-			ComponentHostVersion: ComponentHostVersion{
-				KubeletVersion:          "1.17.9",
-				ContainerRuntimeVersion: "1.16.1",
-			},
-			ComponentContainerVersion: ComponentContainerVersion{
-				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
-				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
-				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
-				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.9"},
-				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
-				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
-				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
-				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
-			},
-			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
-				Kured:         &AddonVersion{"1.3.0-rev4", 5},
-				Dex:           &AddonVersion{"2.16.0-rev6", 7},
-				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
-				MetricsServer: &AddonVersion{"0.3.6", 1},
-				PSP:           &AddonVersion{"", 4},
-			},
-		},
 		"1.17.4": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.17.4",
@@ -151,10 +127,10 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.6.6", 3},
+				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
 				Kured:         &AddonVersion{"1.3.0", 4},
-				Dex:           &AddonVersion{"2.16.0", 6},
-				Gangway:       &AddonVersion{"3.1.0-rev4", 5},
+				Dex:           &AddonVersion{"2.16.0-rev6", 7},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
 				MetricsServer: &AddonVersion{"0.3.6", 1},
 				PSP:           &AddonVersion{"", 4},
 			},

--- a/pkg/skuba/actions/node/remove/remove_test.go
+++ b/pkg/skuba/actions/node/remove/remove_test.go
@@ -38,7 +38,7 @@ func Test_RemoveNode(t *testing.T) {
 		Data: map[string]string{"ClusterConfiguration": `
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-kubernetesVersion: "v1.17.9"
+kubernetesVersion: "v1.17.4"
 apiServer:
   extraArgs:
     advertiseAddress: 1.2.3.4


### PR DESCRIPTION
Fixes https://github.com/SUSE/skuba/pull/1856
This reverts commit:
  * 5757a237c798d6b78d2b3e592b9aea2a14351bc4
  * 48f33d67d256e820951bc783fbb642ae2d5c1d34
  * 925f9381befa55d9e4fb9d8d8f00455e1e55c288

In 4.2.2 we have reverted k8s to 1.17 prior releasing. So we need to
backport this change to master as well.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

