### PR TITLE
Drain nodes before kubadm upgrade and uncordon afterwards

### DIFF
--- a/internal/pkg/skuba/kubernetes/nodes_test.go
+++ b/internal/pkg/skuba/kubernetes/nodes_test.go
@@ -397,3 +397,35 @@ func TestDrainNode(t *testing.T) {
 		})
 	}
 }
+
+func TestUncordonNode(t *testing.T) {
+	for _, tc := range []struct {
+		client    *fake.Clientset
+		node      *corev1.Node
+		expectNil bool
+	}{
+		{
+			client:    fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{{}}}),
+			node:      &corev1.Node{Spec: corev1.NodeSpec{Unschedulable: true}},
+			expectNil: true,
+		},
+		{
+			client:    fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{{}}}),
+			node:      &corev1.Node{Spec: corev1.NodeSpec{Unschedulable: false}},
+			expectNil: true,
+		},
+		{
+			client:    fake.NewSimpleClientset(&corev1.NodeList{Items: []corev1.Node{}}),
+			node:      &corev1.Node{Spec: corev1.NodeSpec{Unschedulable: true}},
+			expectNil: false,
+		},
+	} {
+		err := UncordonNode(tc.client, tc.node)
+		if tc.expectNil && err != nil {
+			t.Errorf("expected nil err, got %v", err)
+		}
+		if !tc.expectNil && err == nil {
+			t.Errorf("expected non nil err")
+		}
+	}
+}


### PR DESCRIPTION
## Why is this PR needed?

This implements a basic drain and uncordon before/after running `kubeadm upgrade`. To achieve that we also have to add a new helper function `kubernetes.UncordonNode()`.

Fixes https://github.com/SUSE/avant-garde/issues/1842

## What does this PR do?

Implements drain and uncordon during kubeadm upgrade.

## Anything else a reviewer needs to know?

None

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

None

### Status **BEFORE** applying the patch

No drain or uncordon on upgrade.

### Status **AFTER** applying the patch

Check if the nodes get drained when doing an upgrade.

## Docs

We could add some troubleshooting to help users if the upgrade fails and the node is still cordon'ed.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
