### PR TITLE
Remove addon upgrade test from pr pipeline

### DIFF
--- a/ci/infra/testrunner/tests/test_addon_upgrade.py
+++ b/ci/infra/testrunner/tests/test_addon_upgrade.py
@@ -44,7 +44,6 @@ def remove_one_addon(addons_dict, skip=None):
     raise Exception('Could not remove any addon!')
 
 
-@pytest.mark.pr
 def test_addon_upgrade_apply(deployment, kubectl, skuba):
     skubaconf_dict = get_skuba_configuration_dict(kubectl)
     addons_dict = skubaconf_dict['AddonsVersion']


### PR DESCRIPTION
#  Why is this PR needed?

The PR pipeline tests only check the changes introduced the PR do not break the ability to deploy a new cluster. The `addon upgrade apply` test does not comply with this objective.

Fixes https://github.com/SUSE/avant-garde/issues/1867 

## What does this PR do?

Removes the `pr` mark from the `test_upgrade_addon_apply` test to prevent its execution in the PR pipeline

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
