### PR TITLE
Skip PR test in master/release branches

### DIFF
--- a/ci/jenkins/templates/test-template.yaml
+++ b/ci/jenkins/templates/test-template.yaml
@@ -19,4 +19,4 @@
           discover-pr-forks-strategy: current
           discover-pr-forks-trust: contributors
           discover-pr-origin: current
-          head-filter-regex: ^(master|release\-\d\.\d|PR\-\d+)$
+          head-filter-regex: ^(PR\-\d+)$


### PR DESCRIPTION
## Why is this PR needed?

After https://github.com/SUSE/skuba/pull/1285 the PRs are merged into the target branch before testing. Therefore running the PR tests against master/release branches is redundant.

## What does this PR do?

Removes the master and release branches from the branch selector in the multi-branch pipeline definition for the pr-test job

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
