### PR TITLE
Backport: Update version to v4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ go get github.com/SUSE/skuba/cmd/skuba
 
 A development build will:
 
-* Pull container images from `registry.suse.de/devel/caasp/5/containers/containers/caasp/v5/`
+* Pull container images from `registry.suse.de/devel/caasp/4.5/containers/containers/caasp/v4.5/`
 
 To build it, run:
 
@@ -58,7 +58,7 @@ make
 
 A staging build will:
 
-* Pull container images from `registry.suse.de/suse/sle-15-sp2/update/products/caasp/5/containers/caasp/v5`
+* Pull container images from `registry.suse.de/suse/sle-15-sp2/update/products/caasp/4.5/containers/caasp/v4.5`
 
 To build it, run:
 
@@ -70,7 +70,7 @@ make staging
 
 A release build will:
 
-* Pull container images from `registry.suse.com/caasp/v5`
+* Pull container images from `registry.suse.com/caasp/v4.5`
 
 To build it, run:
 

--- a/ci/infra/aws/cloud-init/register-rmt.tpl
+++ b/ci/infra/aws/cloud-init/register-rmt.tpl
@@ -1,4 +1,4 @@
   - curl --tlsv1.2 --silent --insecure --connect-timeout 10 https://${rmt_server_name}/rmt.crt --output /etc/pki/trust/anchors/rmt-server.pem && /usr/sbin/update-ca-certificates &> /dev/null
   - SUSEConnect --url https://${rmt_server_name}
   - SUSEConnect -p sle-module-containers/15.2/x86_64
-  - SUSEConnect -p caasp/5/x86_64
+  - SUSEConnect -p caasp/4.5/x86_64

--- a/ci/infra/aws/cloud-init/register-scc.tpl
+++ b/ci/infra/aws/cloud-init/register-scc.tpl
@@ -1,3 +1,3 @@
   - SUSEConnect --url https://scc.suse.com -r ${caasp_registry_code}
   - SUSEConnect -p sle-module-containers/15.2/x86_64
-  - SUSEConnect -p caasp/5/x86_64 -r ${caasp_registry_code}
+  - SUSEConnect -p caasp/4.5/x86_64 -r ${caasp_registry_code}

--- a/ci/infra/azure/cloud-init/register-rmt.tpl
+++ b/ci/infra/azure/cloud-init/register-rmt.tpl
@@ -1,4 +1,4 @@
 curl --tlsv1.2 --silent --insecure --connect-timeout 10 https://${rmt_server_name}/rmt.crt --output /etc/pki/trust/anchors/rmt-server.pem && /usr/sbin/update-ca-certificates &> /dev/null
 SUSEConnect --url https://${rmt_server_name}
 SUSEConnect -p sle-module-containers/15.2/x86_64
-SUSEConnect -p caasp/5/x86_64
+SUSEConnect -p caasp/4.5/x86_64

--- a/ci/infra/azure/cloud-init/register-scc.tpl
+++ b/ci/infra/azure/cloud-init/register-scc.tpl
@@ -1,3 +1,3 @@
 SUSEConnect --url https://scc.suse.com -r ${caasp_registry_code}
 SUSEConnect -p sle-module-containers/15.2/x86_64
-SUSEConnect -p caasp/5/x86_64 -r ${caasp_registry_code}
+SUSEConnect -p caasp/4.5/x86_64 -r ${caasp_registry_code}

--- a/ci/infra/libvirt/cloud-init/register-rmt.tpl
+++ b/ci/infra/libvirt/cloud-init/register-rmt.tpl
@@ -2,5 +2,5 @@
   - /usr/sbin/update-ca-certificates &> /dev/null
   - SUSEConnect --url https://${rmt_server_name}
   - SUSEConnect -p sle-module-containers/15.2/x86_64
-  - SUSEConnect -p caasp/5/x86_64
+  - SUSEConnect -p caasp/4.5/x86_64
   - SUSEConnect -p sle-ha/15.2/x86_64

--- a/ci/infra/libvirt/cloud-init/register-scc.tpl
+++ b/ci/infra/libvirt/cloud-init/register-scc.tpl
@@ -1,6 +1,6 @@
   - [ SUSEConnect, -r, ${caasp_registry_code} ]
   - [ SUSEConnect, -p, sle-module-containers/15.2/x86_64 ]
-  - [ SUSEConnect, -p, caasp/5/x86_64, -r, ${caasp_registry_code} ]
+  - [ SUSEConnect, -p, caasp/4.5/x86_64, -r, ${caasp_registry_code} ]
 %{ if ha_registry_code != "" ~}
   - [ SUSEConnect, -p, sle-ha/15.2/x86_64, -r, ${ha_registry_code} ]
 %{ endif ~}

--- a/ci/infra/openstack/cloud-init/register-rmt.tpl
+++ b/ci/infra/openstack/cloud-init/register-rmt.tpl
@@ -2,4 +2,4 @@
   - /usr/sbin/update-ca-certificates &> /dev/null
   - SUSEConnect --url https://${rmt_server_name}
   - SUSEConnect -p sle-module-containers/15.2/x86_64
-  - SUSEConnect -p caasp/5/x86_64
+  - SUSEConnect -p caasp/4.5/x86_64

--- a/ci/infra/openstack/cloud-init/register-scc.tpl
+++ b/ci/infra/openstack/cloud-init/register-scc.tpl
@@ -1,3 +1,3 @@
   - [ SUSEConnect, -r, ${caasp_registry_code} ]
   - [ SUSEConnect, -p, sle-module-containers/15.2/x86_64 ]
-  - [ SUSEConnect, -p, caasp/5/x86_64, -r, ${caasp_registry_code} ]
+  - [ SUSEConnect, -p, caasp/4.5/x86_64, -r, ${caasp_registry_code} ]

--- a/ci/infra/vmware/README.md
+++ b/ci/infra/vmware/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 
-These terraform definitions are going to create the CaaSP v5 cluster on top of VMWare vSphere cluster.
+These terraform definitions are going to create the CaaSP v4.5 cluster on top of VMWare vSphere cluster.
 
 This code was developed and tested on VMware vSphere cluster based on VMware ESXi 6.7.20000.
 

--- a/ci/infra/vmware/cloud-init/register-rmt.tpl
+++ b/ci/infra/vmware/cloud-init/register-rmt.tpl
@@ -2,4 +2,4 @@
   - /usr/sbin/update-ca-certificates &> /dev/null
   - SUSEConnect --url https://${rmt_server_name}
   - SUSEConnect -p sle-module-containers/15.2/x86_64
-  - SUSEConnect -p caasp/5/x86_64
+  - SUSEConnect -p caasp/4.5/x86_64

--- a/ci/infra/vmware/cloud-init/register-scc.tpl
+++ b/ci/infra/vmware/cloud-init/register-scc.tpl
@@ -1,3 +1,3 @@
   - [ SUSEConnect, -r, ${caasp_registry_code} ]
   - [ SUSEConnect, -p, sle-module-containers/15.2/x86_64 ]
-  - [ SUSEConnect, -p, caasp/5/x86_64, -r, ${caasp_registry_code} ]
+  - [ SUSEConnect, -p, caasp/4.5/x86_64, -r, ${caasp_registry_code} ]

--- a/ci/infra/vmware/terraform.tfvars.example
+++ b/ci/infra/vmware/terraform.tfvars.example
@@ -29,7 +29,7 @@ firmware = "bios"
 # prefix that all of the booted machines will use
 # IMPORTANT: please enter unique identifier below as value of
 # stack_name variable to not interfere with other deployments
-stack_name = "caasp-v5"
+stack_name = "caasp-v4.5"
 
 # Number of master nodes
 masters = 1

--- a/ci/infra/vmware/terraform.tfvars.json.ci.example
+++ b/ci/infra/vmware/terraform.tfvars.json.ci.example
@@ -7,7 +7,7 @@
     "template_name": "SLES15-SP2-RC2-up200525-guestinfo",
     "wait_for_guest_net_routable": false,
     "firmware": "bios",
-    "stack_name": "caasp-jenkins-v5",
+    "stack_name": "caasp-jenkins-v4.5",
     "masters": 1,
     "workers": 2,
     "username": "sles",

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -23,7 +23,7 @@
               sonobuoy_version: 'v0.17'
               schedule: '1-3'
               branch: maintenance-caasp-v4 
-          - v5
+          - v4.5
       jobs:
           - '{name}/{version}/{platform}'
 
@@ -59,7 +59,7 @@
         - '{name}/{platform}/update-daily'
 
 - project:
-    name: caasp-jobs/e2e/v5
+    name: caasp-jobs/e2e/v4.5
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token

--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -90,8 +90,8 @@ node('caasp-team-private-integration') {
            if (pr_repo_label != null) {
                def branch_name = pr_repo_label.name.split(":")[1]
                branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/${repo_version}:/Branches:/${branch_name}/SLE_15_SP2"
-               branch_registry = "registry.suse.de/devel/caasp/5/branches/${branch_name}/containers"
-               original_registry = "registry.suse.de/devel/caasp/5/containers/cr/containers"
+               branch_registry = "registry.suse.de/devel/caasp/4.5/branches/${branch_name}/containers"
+               original_registry = "registry.suse.de/devel/caasp/4.5/containers/containers"
            }
 
         } catch (Exception e) {

--- a/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
@@ -35,8 +35,8 @@ node('caasp-team-private-integration') {
 
         if (env.REPO_BRANCH){
                branch_repo = "http://download.suse.de/ibs/Devel:/CaaSP:/5:/Branches:/${env.REPO_BRANCH}/SLE_15_SP2"
-               branch_registry = "registry.suse.de/devel/caasp/5/branches/${env.REPO_BRANCH}/containers"
-               original_registry = "registry.suse.de/devel/caasp/5/containers/cr/containers"
+               branch_registry = "registry.suse.de/devel/caasp/4.5/branches/${env.REPO_BRANCH}/containers"
+               original_registry = "registry.suse.de/devel/caasp/4.5/containers/containers"
          }
     }
 }

--- a/ci/packaging/suse/skuba_spec_template
+++ b/ci/packaging/suse/skuba_spec_template
@@ -23,7 +23,7 @@
 Name:           skuba
 Version:        %%VERSION
 Release:        0
-Summary:        CLI tool used to deploy CaaS Platform v5
+Summary:        CLI tool used to deploy CaaS Platform v4.5
 License:        Apache-2.0
 Group:          System/Management
 URL:            https://github.com/SUSE/skuba

--- a/internal/pkg/skuba/kubernetes/node_version_test.go
+++ b/internal/pkg/skuba/kubernetes/node_version_test.go
@@ -565,7 +565,7 @@ func createFakePod(podName string, nodeName string, version string) corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  podName,
-					Image: "registry.suse.com/caasp/v5/" + podName + ":" + version,
+					Image: "registry.suse.com/caasp/v4.5/" + podName + ":" + version,
 				},
 			},
 			NodeName: nodeName,

--- a/internal/pkg/skuba/kubernetes/nodes_test.go
+++ b/internal/pkg/skuba/kubernetes/nodes_test.go
@@ -322,7 +322,7 @@ func TestDrainNode(t *testing.T) {
 						Containers: []corev1.Container{
 							{
 								Name:  "test",
-								Image: "registry.suse.com/caasp/v5/test:1.1.1",
+								Image: "registry.suse.com/caasp/v4.5/test:1.1.1",
 							},
 						},
 					},
@@ -340,7 +340,7 @@ func TestDrainNode(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name:  "test",
-										Image: "registry.suse.com/caasp/v5/test:1.1.1",
+										Image: "registry.suse.com/caasp/v4.5/test:1.1.1",
 									},
 								},
 							},

--- a/internal/pkg/skuba/kubernetes/pod_test.go
+++ b/internal/pkg/skuba/kubernetes/pod_test.go
@@ -38,7 +38,7 @@ func Test_getPodContainerImageTag(t *testing.T) {
 				Containers: []corev1.Container{
 					{
 						Name:  "test",
-						Image: "registry.suse.com/caasp/v5/test:1.1.1",
+						Image: "registry.suse.com/caasp/v4.5/test:1.1.1",
 					},
 				},
 			},

--- a/pkg/skuba/development_constants.go
+++ b/pkg/skuba/development_constants.go
@@ -20,6 +20,7 @@
 package skuba
 
 const (
-	BuildType       = "development"
-	ImageRepository = "registry.suse.de/devel/caasp/5/containers/containers/caasp/v5"
+	BuildType         = "development"
+	imageRepositoryV4 = "registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4"
+	imageRepository   = "registry.suse.de/devel/caasp/4.5/containers/containers/caasp/v4.5"
 )

--- a/pkg/skuba/development_constants.go
+++ b/pkg/skuba/development_constants.go
@@ -21,6 +21,5 @@ package skuba
 
 const (
 	BuildType         = "development"
-	imageRepositoryV4 = "registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4"
-	imageRepository   = "registry.suse.de/devel/caasp/4.5/containers/containers/caasp/v4.5"
+	ImageRepository   = "registry.suse.de/devel/caasp/4.5/containers/containers/caasp/v4.5"
 )

--- a/pkg/skuba/release_constants.go
+++ b/pkg/skuba/release_constants.go
@@ -20,6 +20,7 @@
 package skuba
 
 const (
-	BuildType       = "release"
-	ImageRepository = "registry.suse.com/caasp/v5"
+	BuildType         = "release"
+	imageRepositoryV4 = "registry.suse.com/caasp/v4"
+	imageRepository   = "registry.suse.com/caasp/v4.5"
 )

--- a/pkg/skuba/release_constants.go
+++ b/pkg/skuba/release_constants.go
@@ -21,6 +21,5 @@ package skuba
 
 const (
 	BuildType         = "release"
-	imageRepositoryV4 = "registry.suse.com/caasp/v4"
-	imageRepository   = "registry.suse.com/caasp/v4.5"
+	ImageRepository   = "registry.suse.com/caasp/v4.5"
 )

--- a/pkg/skuba/staging_constants.go
+++ b/pkg/skuba/staging_constants.go
@@ -21,6 +21,5 @@ package skuba
 
 const (
 	BuildType         = "staging"
-	imageRepositoryV4 = "registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4"
-	imageRepository   = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/4.5/containers/caasp/v4.5"
+	ImageRepository   = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/4.5/containers/caasp/v4.5"
 )

--- a/pkg/skuba/staging_constants.go
+++ b/pkg/skuba/staging_constants.go
@@ -20,6 +20,7 @@
 package skuba
 
 const (
-	BuildType       = "staging"
-	ImageRepository = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/5/containers/caasp/v5"
+	BuildType         = "staging"
+	imageRepositoryV4 = "registry.suse.de/suse/sle-15-sp1/update/products/casp40/containers/caasp/v4"
+	imageRepository   = "registry.suse.de/suse/sle-15-sp2/update/products/caasp/4.5/containers/caasp/v4.5"
 )


### PR DESCRIPTION
## Why is this PR needed?

Updated versions to v4.5

includes packages and ci

Backport of https://github.com/SUSE/skuba/pull/1294/files

https://github.com/SUSE/avant-garde/issues/1862

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

