### PR TITLE
Fix nodeVersion for all upgrade plan

### DIFF
--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -88,9 +88,17 @@ func plan(client clientset.Interface, availableVersions []*version.Version, clus
 			if nodeVersionInfo.EqualsClusterVersion(currentClusterVersion) {
 				fmt.Printf("  - %s: up to date", nodeName)
 			} else if !nodeVersionInfo.ToleratesClusterVersion(currentClusterVersion) {
-				fmt.Printf("  - %s; current version: %s (upgrade required)", nodeName, nodeVersionInfo.String())
+				if nodeVersionInfo.IsControlPlane() {
+					fmt.Printf("  - %s; current kubelet package version: %s, kube-apiserver container version: %s (upgrade required)", nodeName, nodeVersionInfo.KubeletVersion.String(), nodeVersionInfo.APIServerVersion.String())
+				} else {
+					fmt.Printf("  - %s; current kubelet package version: %s (upgrade required)", nodeName, nodeVersionInfo.KubeletVersion.String())
+				}
 			} else {
-				fmt.Printf("  - %s; current version: %s (upgrade suggested)", nodeName, nodeVersionInfo.String())
+				if nodeVersionInfo.IsControlPlane() {
+					fmt.Printf("  - %s; current kubelet package version: %s, kube-apiserver container version: %s (upgrade suggested)", nodeName, nodeVersionInfo.KubeletVersion.String(), nodeVersionInfo.APIServerVersion.String())
+				} else {
+					fmt.Printf("  - %s; current kubelet package version: %s (upgrade suggested)", nodeName, nodeVersionInfo.KubeletVersion.String())
+				}
 			}
 			if nodeVersionInfo.Unschedulable() {
 				fmt.Println("; unschedulable, ignored")

--- a/pkg/skuba/actions/cluster/upgrade/plan_test.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan_test.go
@@ -86,7 +86,7 @@ Latest Kubernetes version: 1.16.0
 
 Some nodes do not match the current cluster version (1.16.0):
   - control-plane-0: up to date
-  - worker-0; current version: 1.14.0 (upgrade required)
+  - worker-0; current kubelet package version: 1.14.0 (upgrade required)
 
 Addons at the current cluster version 1.16.0 are up to date.
 `,
@@ -106,7 +106,7 @@ Latest Kubernetes version: 1.16.0
 
 Some nodes do not match the current cluster version (1.16.0):
   - control-plane-0: up to date
-  - worker-unschedulable-0; current version: 1.14.0 (upgrade required); unschedulable, ignored
+  - worker-unschedulable-0; current kubelet package version: 1.14.0 (upgrade required); unschedulable, ignored
 
 Addons at the current cluster version 1.16.0 are up to date.
 `,
@@ -127,7 +127,7 @@ Latest Kubernetes version: 1.16.1
 
 Some nodes do not match the current cluster version (1.16.1):
   - control-plane-0: up to date
-  - worker-0; current version: 1.16.0 (upgrade suggested)
+  - worker-0; current kubelet package version: 1.16.0 (upgrade suggested)
 
 Addons at the current cluster version 1.16.1 are up to date.
 `,
@@ -148,7 +148,7 @@ Latest Kubernetes version: 1.16.0
 
 Some nodes do not match the current cluster version (1.16.0):
   - control-plane-0: up to date
-  - worker-0; current version: 1.15.0 (upgrade suggested)
+  - worker-0; current kubelet package version: 1.15.0 (upgrade suggested)
 
 Addons at the current cluster version 1.16.0 are up to date.
 `,
@@ -261,7 +261,7 @@ Latest Kubernetes version: 1.17.0
 
 Some nodes do not match the current cluster version (1.17.0):
   - control-plane-0: up to date
-  - worker-0; current version: 1.16.0 (upgrade suggested)
+  - worker-0; current kubelet package version: 1.16.0 (upgrade suggested)
 
 Addon upgrades for 1.17.0:
   - cilium: 1.0.1 -> 1.0.2


### PR DESCRIPTION
## Why is this PR needed?

We would like to distinguish Kubernetes version reported by `master` nodes on Node version (kubelet, crio and OS packages) and ControlPlane version (API, controller-manager, scheduler etc.)

Fixes #https://github.com/SUSE/avant-garde/issues/1863

## What does this PR do?

For master nodes it will report Node version and ControlPlan version when `skuba cluster upgra plan`

Example output:

```
Current Kubernetes cluster version: 1.18.4
Latest Kubernetes version: 1.18.12

Some nodes do not match the current cluster version (1.18.4):
  - caasp-master-mjura-0; current kubelet package version: 1.18.6, kube-apiserver container version: 1.18.6 (upgrade suggested)
  - caasp-worker-mjura-0; current kubelet package version: 1.18.6 (upgrade suggested)
  - caasp-worker-mjura-1; current kubelet package version: 1.18.6 (upgrade suggested)

Addons at the current cluster version 1.18.4 are up to date.
There is no need to run 'skuba addon upgrade apply' before starting the platform upgrade.

Upgrade path to update from 1.18.4 to 1.18.12:
  - 1.18.4 -> 1.18.12

Addon upgrades from 1.18.4 to 1.18.12:
  - cilium: 1.7.5 (new addon)
  - dex: 2.23.0 (new addon)
  - gangway: 3.1.0-rev5 (new addon)
  - kucero: 1.1.1 (new addon)
  - kured: 1.4.3 (new addon)
  - metrics-server: 0.3.6 (new addon)
  - psp (new addon)

It is required to run 'skuba addon upgrade apply' after you have completed the platform upgrade.
```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

