### PR TITLE
Fixes selection of kubeadm-criconfig version

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -131,6 +131,10 @@ func kubernetesUpgradeStageOne(t *Target, data interface{}) error {
 		pkgs = append(pkgs, fmt.Sprintf("-patterns-caasp-Node-%s", skubaconstants.LastCaaSP4KubernetesVersion))
 		pkgs = append(pkgs, fmt.Sprintf("-\"kubernetes-kubeadm<%s\"", skubaconstants.FirstCaaSP5KubernetesVersion))
 		pkgs = append(pkgs, "-caasp-config", "-cri-o-kubeadm-criconfig")
+		// We also need to install cri-o-1.18-kubeadm-criconfig at the same time
+		// that we remove cri-o-kubeadm-criconfig, because otherwise the kubernetes-1.18-kubeadm requirements would trigger the installation of any cri-o-*-kubeadm-criconfig
+		// leading to unexpected results on late migrations to SP2 and therefore late upgrades to caasp 4.5
+		pkgs = append(pkgs, fmt.Sprintf("cri-o-%s-kubeadm-criconfig", skubaconstants.FirstCaaSP5KubernetesVersion))
 	} else {
 		pkgs = append(pkgs, fmt.Sprintf("-kubernetes-%s-kubeadm", currentV))
 	}


### PR DESCRIPTION
Fixes selection of `kubeadm-criconfig` version.

When removing the `kubeadm-criconfig` package zypper will install freely any version it finds more suitable, if there is a new one it will install that one.


## Why is this PR needed?
We also need to install cri-o-1.18-kubeadm-criconfig at the same time that we remove cri-o-kubeadm-criconfig, because otherwise the kubernetes-1.18-kubeadm requirements would trigger the installation of any cri-o-*-kubeadm-criconfig leading to unexpected results on late migrations to SP2 and therefore late upgrades to caasp 4.5
Does it fix an issue? addresses a business case?

Relates https://github.com/SUSE/avant-garde/issues/1756

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Installs cri-o-1.18-kubeadm-criconfig at the same time that we remove cri-o-kubeadm-criconfig

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This needs to be tested against the test repository

https://build.suse.de/project/show/Devel:CaaSP:5:Branches:PackageUpgradeTesting

- Deploy a v4 cluster in version 1.17.4
- Perform an upgrade to 1.18.5

All should work.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
