### PR TITLE
Remove hyperkube migration

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -99,14 +99,6 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 			return errors.Wrap(err, "error adding target information to init configuration")
 		}
 
-		// Upgrade 1.17 to 1.18.
-		// This updated UseHyperKube field in-memory (unsets it).
-		// Note: The cluster cm is uploaded at the end of the kubeadm process, as usual.
-		// The whole paragraph can be removed when upgrading from 1.17 is removed.
-		if currentClusterVersion.Minor() == 17 {
-			initCfg.UseHyperKubeImage = false
-		}
-
 		kubeadm.UpdateClusterConfigurationWithClusterVersion(initCfg, nodeVersionInfoUpdate.Update.APIServerVersion)
 		initCfgContents, err = kubeadmconfigutil.MarshalInitConfigurationToBytes(initCfg, schema.GroupVersion{
 			Group:   "kubeadm.k8s.io",


### PR DESCRIPTION
Without this patch, hyperkube will be migrated from 1.17.4 to
1.17.x, which is not something we want.

This is a re-implementation for backport reasons of the
patch https://github.com/SUSE/skuba/pull/1293.

## Why is this PR needed?

This prevents us for releasing a caasp v4.2+ (below 4.5) that would migrate away from hyperkube.

Partial-Fix https://github.com/SUSE/avant-garde/issues/1859

## What does this PR do?

Remove hyperkube migration, which is only required in the skuba master/v5/v4.5 branch.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
