### PR TITLE
test: Bump Cilium version

### DIFF
--- a/internal/pkg/skuba/addons/cilium_test.go
+++ b/internal/pkg/skuba/addons/cilium_test.go
@@ -36,13 +36,13 @@ func TestGetCiliumInitImage(t *testing.T) {
 	}{
 		{
 			name:     "get cilium init image without revision",
-			imageTag: "1.5.3",
-			want:     img.ImageRepository + "/cilium-init:1.5.3",
+			imageTag: "1.7.5",
+			want:     img.ImageRepository + "/cilium-init:1.7.5",
 		},
 		{
 			name:     "get cilium init image with revision",
-			imageTag: "1.5.3-rev2",
-			want:     img.ImageRepository + "/cilium-init:1.5.3-rev2",
+			imageTag: "1.7.5-rev2",
+			want:     img.ImageRepository + "/cilium-init:1.7.5-rev2",
 		},
 	}
 	for _, tt := range tests {
@@ -63,13 +63,13 @@ func TestGetCiliumOperatorImage(t *testing.T) {
 	}{
 		{
 			name:     "get cilium operator image without revision",
-			imageTag: "1.5.3",
-			want:     img.ImageRepository + "/cilium-operator:1.5.3",
+			imageTag: "1.7.5",
+			want:     img.ImageRepository + "/cilium-operator:1.7.5",
 		},
 		{
 			name:     "get cilium operator image with revision",
-			imageTag: "1.5.3-rev2",
-			want:     img.ImageRepository + "/cilium-operator:1.5.3-rev2",
+			imageTag: "1.7.5-rev2",
+			want:     img.ImageRepository + "/cilium-operator:1.7.5-rev2",
 		},
 	}
 	for _, tt := range tests {
@@ -90,13 +90,13 @@ func TestGetCiliumImage(t *testing.T) {
 	}{
 		{
 			name:     "get cilium image without revision",
-			imageTag: "1.5.3",
-			want:     img.ImageRepository + "/cilium:1.5.3",
+			imageTag: "1.7.5",
+			want:     img.ImageRepository + "/cilium:1.7.5",
 		},
 		{
 			name:     "get cilium image with revision",
-			imageTag: "1.5.3-rev2",
-			want:     img.ImageRepository + "/cilium:1.5.3-rev2",
+			imageTag: "1.7.5-rev2",
+			want:     img.ImageRepository + "/cilium:1.7.5-rev2",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/pkg/skuba/upgrade/addon/versions_test.go
+++ b/internal/pkg/skuba/upgrade/addon/versions_test.go
@@ -164,14 +164,14 @@ func TestHasAddonUpdate(t *testing.T) {
 			name: "has addon update",
 			aviu: AddonVersionInfoUpdate{
 				Current: kubernetes.AddonsVersion{
-					kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 0},
+					kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.7.5", ManifestVersion: 0},
 					kubernetes.Kured:   &kubernetes.AddonVersion{Version: "1.2.0", ManifestVersion: 0},
 					kubernetes.Dex:     &kubernetes.AddonVersion{Version: "2.16.0", ManifestVersion: 0},
 					kubernetes.Gangway: &kubernetes.AddonVersion{Version: "3.1.0", ManifestVersion: 0},
 					kubernetes.PSP:     &kubernetes.AddonVersion{Version: "1.0.0", ManifestVersion: 1},
 				},
 				Updated: kubernetes.AddonsVersion{
-					kubernetes.Cilium: &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 1},
+					kubernetes.Cilium: &kubernetes.AddonVersion{Version: "1.7.5", ManifestVersion: 1},
 				},
 			},
 			expected: true,
@@ -180,7 +180,7 @@ func TestHasAddonUpdate(t *testing.T) {
 			name: "no addon update",
 			aviu: AddonVersionInfoUpdate{
 				Current: kubernetes.AddonsVersion{
-					kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 0},
+					kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.7.5", ManifestVersion: 0},
 					kubernetes.Kured:   &kubernetes.AddonVersion{Version: "1.2.0", ManifestVersion: 0},
 					kubernetes.Dex:     &kubernetes.AddonVersion{Version: "2.16.0", ManifestVersion: 0},
 					kubernetes.Gangway: &kubernetes.AddonVersion{Version: "3.1.0", ManifestVersion: 0},
@@ -206,20 +206,20 @@ func TestHasAddonUpdate(t *testing.T) {
 func ExamplePrintAddonUpdates() {
 	PrintAddonUpdates(AddonVersionInfoUpdate{
 		Current: kubernetes.AddonsVersion{
-			kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 0},
+			kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.7.5", ManifestVersion: 0},
 			kubernetes.Kured:   &kubernetes.AddonVersion{Version: "1.2.0", ManifestVersion: 0},
 			kubernetes.Dex:     &kubernetes.AddonVersion{Version: "2.16.0", ManifestVersion: 1},
 			kubernetes.Gangway: nil,
 		},
 		Updated: kubernetes.AddonsVersion{
-			kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 1},
+			kubernetes.Cilium:  &kubernetes.AddonVersion{Version: "1.7.5", ManifestVersion: 1},
 			kubernetes.Dex:     &kubernetes.AddonVersion{Version: "2.17.0", ManifestVersion: 1},
 			kubernetes.Gangway: &kubernetes.AddonVersion{Version: "3.1.0", ManifestVersion: 0},
 		},
 	})
 
 	// Output:
-	//   - cilium: 1.5.3 (manifest version from 0 to 1)
+	//   - cilium: 1.7.5 (manifest version from 0 to 1)
 	//   - dex: 2.16.0 -> 2.17.0
 	//   - gangway: 3.1.0 (new addon)
 }

--- a/internal/pkg/skuba/upgrade/node/versions_test.go
+++ b/internal/pkg/skuba/upgrade/node/versions_test.go
@@ -229,7 +229,7 @@ func versionInquirer(versions ...string) kubernetes.VersionInquirer {
 				kubernetes.Tooling:           &kubernetes.ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: kubernetes.AddonsVersion{
-				kubernetes.Cilium: &kubernetes.AddonVersion{Version: "1.5.3", ManifestVersion: 0},
+				kubernetes.Cilium: &kubernetes.AddonVersion{Version: "1.7.5", ManifestVersion: 0},
 				kubernetes.Kured:  &kubernetes.AddonVersion{Version: "1.2.0", ManifestVersion: 0},
 			},
 		}


### PR DESCRIPTION
Backport of https://github.com/SUSE/skuba/pull/1223/commits
See https://github.com/SUSE/avant-garde/issues/1898

Cilium version in unit tests which are modified here do not have any
direct impact on the version deployed by skuba, but let's bump them to
avoid confusion.

Suggested-by: Madhu Mohan Nelemane <mmnelemane@suse.com>
Signed-off-by: Michal Rostecki <mrostecki@suse.de>

