### PR TITLE
fix kured version to match latest 4.2.2 release

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -128,7 +128,7 @@ var (
 			},
 			AddonsVersion: AddonsVersion{
 				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
-				Kured:         &AddonVersion{"1.3.0-rev4", 5},
+				Kured:         &AddonVersion{"1.3.0", 4},
 				Dex:           &AddonVersion{"2.16.0-rev6", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
 				MetricsServer: &AddonVersion{"0.3.6", 1},


### PR DESCRIPTION
kured version was mismatching. Now it should match master and maintenance branch

fixes https://github.com/SUSE/avant-garde/issues/1901

https://github.com/SUSE/skuba/blob/master/internal/pkg/skuba/kubernetes/versions.go#L131
https://github.com/SUSE/skuba/blob/maintenance-caasp-v4/internal/pkg/skuba/kubernetes/versions.go#L105