### PR TITLE
If cpi_enable=true, disable hostname_from_dhcp

### DIFF
--- a/ci/infra/libvirt/lb-instances.tf
+++ b/ci/infra/libvirt/lb-instances.tf
@@ -97,7 +97,7 @@ data "template_file" "lb_cloud_init_userdata" {
     username           = var.username
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-lb"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/libvirt/master-instance.tf
+++ b/ci/infra/libvirt/master-instance.tf
@@ -51,7 +51,7 @@ data "template_file" "master-cloud-init" {
     username           = var.username
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-master-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/libvirt/worker-instance.tf
+++ b/ci/infra/libvirt/worker-instance.tf
@@ -51,7 +51,7 @@ data "template_file" "worker-cloud-init" {
     username           = var.username
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-worker-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/openstack/master-instance.tf
+++ b/ci/infra/openstack/master-instance.tf
@@ -48,7 +48,7 @@ data "template_file" "master-cloud-init" {
     username           = var.username
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "caasp-master-${var.stack_name}-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/openstack/worker-instance.tf
+++ b/ci/infra/openstack/worker-instance.tf
@@ -48,7 +48,7 @@ data "template_file" "worker-cloud-init" {
     username           = var.username
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "caasp-worker-${var.stack_name}-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/vmware/lb-instance.tf
+++ b/ci/infra/vmware/lb-instance.tf
@@ -124,7 +124,7 @@ data "template_file" "lb_cloud_init_userdata" {
     packages           = join("\n", formatlist("  - %s", var.packages))
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-lb-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/vmware/master-instance.tf
+++ b/ci/infra/vmware/master-instance.tf
@@ -56,7 +56,7 @@ data "template_file" "master_cloud_init_userdata" {
     commands           = join("\n", data.template_file.master_commands.*.rendered)
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-master-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 

--- a/ci/infra/vmware/worker-instance.tf
+++ b/ci/infra/vmware/worker-instance.tf
@@ -56,7 +56,7 @@ data "template_file" "worker_cloud_init_userdata" {
     commands           = join("\n", data.template_file.worker_commands.*.rendered)
     ntp_servers        = join("\n", formatlist("    - %s", var.ntp_servers))
     hostname           = "${var.stack_name}-worker-${count.index}"
-    hostname_from_dhcp = var.hostname_from_dhcp == true ? "yes" : "no"
+    hostname_from_dhcp = var.hostname_from_dhcp == true && var.cpi_enable == false ? "yes" : "no"
   }
 }
 


### PR DESCRIPTION
## Why is this PR needed?

In the CPI environment, the Kubernetes node name _must the same_ as VM name.

Fixes https://github.com/SUSE/avant-garde/issues/1817

## What does this PR do?

If cpi_enable=true, set hostname_from_dhcp=false.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
