### PR TITLE
Fix k8s version in upgrade tests maintanance v4

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -47,13 +47,13 @@
         - test_upgrade_plan_all_fine
         - test_upgrade_apply_all_fine
         - test_upgrade_apply_from_previous:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.16.2
         - test_upgrade_apply_user_lock:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.16.2
         - test_upgrade_plan_from_previous:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.16.2
         - test_upgrade_plan_from_previous_with_upgraded_control_plane:
-           kubernetes_version: 1.17.4
+           kubernetes_version: 1.16.2
     jobs:
         - '{name}/{platform}/{test}-daily'
         - '{name}/{platform}/update-daily'


### PR DESCRIPTION
## Why is this PR needed?

Upgrade tests must deploy a previous version of k8s which for maintenance branch is 1.16.2

Fixes https://github.com/SUSE/avant-garde/issues/1905

## What does this PR do?

Sets the correct k8s version

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
