### PR TITLE
Fix kucero PSP (bsc#1175352)

### DIFF
--- a/internal/pkg/skuba/addons/kucero.go
+++ b/internal/pkg/skuba/addons/kucero.go
@@ -49,30 +49,6 @@ metadata:
   name: kucero
   namespace: kube-system
 ---
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: kucero
-spec:
-  allowedHostPaths:
-  - pathPrefix: /etc/kubernetes/pki
-    readOnly: true
-  - pathPrefix: /var/lib/kubelet/pki
-    readOnly: true
-  fsGroup:
-    rule: RunAsAny
-  hostPID: true
-  privileged: true
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - secret
-  - hostPath
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -147,14 +123,6 @@ rules:
   verbs:
   - create
 - apiGroups:
-  - extensions
-  resourceNames:
-  - kucero
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-- apiGroups:
   - certificates.k8s.io
   resourceNames:
   - kubernetes.io/kubelet-serving
@@ -220,6 +188,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kucero
+subjects:
+- kind: ServiceAccount
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:kucero
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
   name: kucero

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -107,7 +107,7 @@ var (
 				Dex:           &AddonVersion{"2.23.0", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev5", 5},
 				MetricsServer: &AddonVersion{"0.3.6", 0},
-				Kucero:        &AddonVersion{"1.1.1", 0},
+				Kucero:        &AddonVersion{"1.1.1", 1},
 				PSP:           &AddonVersion{"", 2},
 			},
 		},


### PR DESCRIPTION
## Why is this PR needed?

The kucero control plane pods should use `suse.caasp.psp.priviliged` PodSecurityPolicy, same as kured.

Fixes https://github.com/SUSE/avant-garde/issues/1903

## What does this PR do?

Set kucero ClusterRole to `suse.caasp.psp.priviliged` PodSecurityPolicy.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

By admin user:
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: multitool
  namespace: default
spec:
  containers:
  - image: praqma/network-multitool
    imagePullPolicy: Always
    name: multitool
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: worker
  priority: 0
  restartPolicy: Never
  schedulerName: default-scheduler
EOF

kubectl describe pod multitool -n default | grep 'kubernetes.io/psp'
```
The output is _kucero_.

### Status **AFTER** applying the patch

By admin user:
```
cat <<EOF | kubectl apply -f -
apiVersion: v1
kind: Pod
metadata:
  name: multitool
  namespace: default
spec:
  containers:
  - image: praqma/network-multitool
    imagePullPolicy: Always
    name: multitool
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: worker
  priority: 0
  restartPolicy: Never
  schedulerName: default-scheduler
EOF

kubectl describe pod multitool -n default | grep 'kubernetes.io/psp'
```
The output is _suse.caasp.psp.kube-system_, not _kucero_.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
