### PR TITLE
Bump etcd image tag

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -96,7 +96,7 @@ var (
 				ControllerManager: &ContainerImageTag{Name: "kube-controller-manager", Tag: "v1.18.6"},
 				Scheduler:         &ContainerImageTag{Name: "kube-scheduler", Tag: "v1.18.6"},
 				Proxy:             &ContainerImageTag{Name: "kube-proxy", Tag: "v1.18.6"},
-				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3-rev1"},
 				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
 				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.2"},
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},


### PR DESCRIPTION
## Why is this PR needed?

This PR is needed to make sure the new ectd image version is being used when upgrading from v4.2.3 to v4.5.0. Note that despite the etcd version is the same the image is different as the first is based on SLE-15-SP1 and the latter on SLE-15-SP2.

Fixes SUSE/avant-garde#1924

## What does this PR do?

This commit appends the revision to the etcd image reference. This is
done to force kubeadm to write a new manifest including the new image
reference when upgrading from v4.2.3 (SLE15-SP1 based) to v4.5.0
(SLE15-SP2 based) CaaSP version.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

Fixes SUSE/avant-garde#1924, after the migration from v4.2.3 to v4.5.0 the upgraded clusters should be using the etcd image tagged with `3.4.3-rev1`.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
