### PR TITLE
Allow retaining cluster even if the job succeeds

### DIFF
--- a/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
@@ -88,6 +88,11 @@ pipeline {
         }
 
         stage('Run Skuba e2e Test') {
+            // skip stage if no test selected
+            when {
+                // e2e test is defined
+                expression { return env.E2E_MAKE_TARGET_NAME }
+            }
             steps {
                 sh(script: "make -f ci/Makefile test SUITE=${E2E_MAKE_TARGET_NAME} SKIP_SETUP='deployed'", label: "${E2E_MAKE_TARGET_NAME}")
             }

--- a/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-e2e-test.Jenkinsfile
@@ -105,8 +105,6 @@ pipeline {
                 sh(script: "make --keep-going -f ci/Makefile gather_logs", label: 'Gather Logs')
                 archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
             }
-        }}
-        failure{ script{
             if (retain_cluster) {
                 def retention_period= env.RETENTION_PERIOD?env.RETENTION_PERIOD:24
                 try{

--- a/ci/jenkins/templates/e2e-dev-template.yaml
+++ b/ci/jenkins/templates/e2e-dev-template.yaml
@@ -16,7 +16,7 @@
         - bool:
             name: RETAIN_CLUSTER
             default: false
-            description: Retain the cluster in case of failure
+            description: Retain the cluster when the job finishes 
         - string:
             name: RETENTION_PERIOD
             default: 24


### PR DESCRIPTION
## Why is this PR needed?

Sometimes developers require a quick way to deploy a cluster for testing. Reusing the manual e2e job will facilitate this task

## What does this PR do?

Move logic for cluster retention to the always stage to be executed in any case.

## Note to reviewers

The changes were tested in this job: https://ci.suse.de/job/caasp-jobs/job/dev/job/e2e-test/143/

## Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
