### PR TITLE
[CI] Implement pipeline for testing 4.2 to 4.5 upgrades

### DIFF
--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -168,6 +168,7 @@ class Skuba:
         except Exception as ex:
             raise Exception("Error executing cmd {}".format(cmd)) from ex
 
+
     @step
     def node_upgrade(self, action, role, nr, ignore_errors=False):
         self._verify_bootstrap_dependency()
@@ -192,9 +193,13 @@ class Skuba:
         return self._run_skuba(cmd, ignore_errors=ignore_errors)
 
     @step
-    def cluster_upgrade_plan(self):
+    def cluster_upgrade(self, action):
         self._verify_bootstrap_dependency()
-        return self._run_skuba("cluster upgrade plan")
+
+        if action not in ["plan", "localconfig"]:
+            raise ValueError(f'Invalid cluster upgrade action: {action}')
+
+        return self._run_skuba(f'cluster upgrade {action}')
 
     @step
     def cluster_status(self):

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -63,8 +63,8 @@ def cluster_status(options):
     print(Skuba(options.conf, options.platform).cluster_status())
 
 
-def cluster_upgrade_plan(options):
-    Skuba(options.conf, options.platform).cluster_upgrade_plan()
+def cluster_upgrade(options):
+    Skuba(options.conf, options.platform).cluster_upgrade(action=options.upgrade_action)
 
 
 def get_logs(options):
@@ -202,9 +202,11 @@ def main():
     cmd_status = commands.add_parser("status", help="check K8s cluster status")
     cmd_status.set_defaults(func=cluster_status)
 
-    cmd_cluster_upgrade_plan = commands.add_parser(
-        "cluster-upgrade-plan", help="Cluster upgrade plan")
-    cmd_cluster_upgrade_plan.set_defaults(func=cluster_upgrade_plan)
+    cmd_cluster_upgrade = commands.add_parser(
+        "cluster-upgrade", help="Cluster upgrade")
+    cmd_cluster_upgrade.add_argument(
+        "-a", "--action", dest="upgrade_action", choices=["plan", "localconfig"])
+    cmd_cluster_upgrade.set_defaults(func=cluster_upgrade)
 
     # common parameters for node commands
     node_args = ArgumentParser(add_help=False)

--- a/ci/infra/testrunner/tests/test_node_reboot.py
+++ b/ci/infra/testrunner/tests/test_node_reboot.py
@@ -3,15 +3,11 @@ import time
 
 import pytest
 
-from tests.utils import (check_pods_ready, node_is_ready, wait)
+from tests.utils import (check_pods_ready, check_node_is_ready, wait)
 
 from timeout_decorator import timeout
 
 logger = logging.getLogger("testrunner")
-
-
-def check_node_is_ready(platform, kubectl, role, nr):
-    assert node_is_ready(platform, kubectl, role, nr)
 
 
 @pytest.mark.pr

--- a/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
+++ b/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
@@ -1,0 +1,54 @@
+import os
+import pytest
+
+from tests.utils import (check_node_is_ready, check_node_version, CURRENT_VERSION, wait)
+
+# Migrates a node to the upgrate option speficied in the option
+def migrate_node(platform, kubectl, role, node, regcode, option=1):
+    platform.ssh_run(role, node, f'sudo SUSEConnect -r {regcode}')
+    platform.ssh_run(role, node, "sudo SUSEConnect -p sle-module-containers/15.1/x86_64")
+    platform.ssh_run(role, node, f'sudo SUSEConnect -p caasp/4.0/x86_64 -r {regcode}')
+    platform.ssh_run(role, node, "sudo sudo zypper in -y --no-recommends zypper-migration-plugin")
+    platform.ssh_run(role, node, (f'sudo zypper migration --migration {option}'
+                                  ' --no-recommends --non-interactive'
+                                  ' --auto-agree-with-licenses --allow-vendor-change'))
+    #:FIXME use kured for controlled reboot.
+    platform.ssh_run(role, node, "sudo reboot &")
+
+    # wait the node become live
+    wait(platform.ssh_run,
+        role,
+        node,
+        "true",
+        wait_delay=60,
+        wait_timeout=10,
+        wait_backoff=30,
+        wait_elapsed=180,
+        wait_allow=(RuntimeError))
+
+def test_upgrade_from_4_2(deployment, platform, skuba, kubectl):
+
+    skuba.cluster_upgrade(action="localconfig")
+
+    # TODO: find a more elegant way to pick the REG_CODE
+    reg_code = os.environ['REG_CODE']
+    assert reg_code is not None
+
+    for role in ("master", "worker"):
+        num_nodes = platform.get_num_nodes(role)
+        for node in range(0, num_nodes):
+            migrate_node(platform, kubectl, role, node, reg_code)
+            result = skuba.node_upgrade("apply", role, node)
+            assert result.find("successfully upgraded") != -1
+
+            # check node version is update
+            wait(check_node_version,
+                platform,
+                kubectl,
+                role,
+                node,
+                CURRENT_VERSION,
+                wait_delay=60,
+                wait_backoff=30,
+                wait_elapsed=60 * 10,
+                wait_allow=(AssertionError))

--- a/ci/infra/testrunner/tests/test_upgrade_plan_all_fine.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_all_fine.py
@@ -7,7 +7,7 @@ def test_upgrade_plan_all_fine(provision, skuba, kubectl, platform):
     Starting from a up-to-date cluster, check what cluster/node plan report.
     """
 
-    out = skuba.cluster_upgrade_plan()
+    out = skuba.cluster_upgrade(action="plan")
 
     assert out.find(
         "All nodes match the current cluster version"

--- a/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
+++ b/ci/infra/testrunner/tests/test_upgrade_plan_from_previous.py
@@ -10,7 +10,7 @@ def test_upgrade_plan_from_previous(deployment, skuba, kubectl, platform):
     """
 
     # cluster upgrade plan
-    out = skuba.cluster_upgrade_plan()
+    out = skuba.cluster_upgrade(action="plan")
     assert out.find("Current Kubernetes cluster version: {pv}".format(
         pv=PREVIOUS_VERSION)) != -1
     assert out.find("Latest Kubernetes version: {cv}".format(

--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -6,6 +6,9 @@ PREVIOUS_VERSION = "1.17.4"
 CURRENT_VERSION = "1.18.6"
 
 
+def check_node_is_ready(platform, kubectl, role, nr):
+    assert node_is_ready(platform, kubectl, role, nr)
+
 def check_nodes_ready(kubectl):
     # Retrieve the node name and the Ready condition (True, or False)
     cmd = ("get nodes -o jsonpath='{ range .items[*]}{@.metadata.name}{\":\"}"
@@ -51,6 +54,12 @@ def node_is_upgraded(kubectl, platform, role, nr):
 
     cmd = "get nodes {} -o jsonpath='{{.status.nodeInfo.kubeletVersion}}'".format(node_name)
     return kubectl.run_kubectl(cmd).find(CURRENT_VERSION) != -1
+
+
+def check_node_version(platform, kubectl, role, node, version):
+    node_name = platform.get_nodes_names(role)[node]
+    cmd = "get nodes {} -o jsonpath='{{.status.nodeInfo.kubeletVersion}}'".format(node_name)
+    assert kubectl.run_kubectl(cmd).find(CURRENT_VERSION) != -1
 
 
 def check_pods_ready(kubectl, namespace=None, node=None, pods=[], statuses=['Running', 'Succeeded']):

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -60,6 +60,7 @@
 
 - project:
     name: caasp-jobs/e2e/v4.5
+    branch: master
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
@@ -81,6 +82,8 @@
     jobs:
         - '{name}/{platform}/{test}-daily'
         - '{name}/{platform}/update-daily'
+        - '{name}/{platform}/trigger-upgrade-from-4-2-daily'
+        - '{name}/{platform}/upgrade-from-4-2-daily'
 
 - project:
     name: caasp-jobs/dev

--- a/ci/jenkins/pipelines/skuba-trigger-upgrade-from-4.2.Jenkisfile
+++ b/ci/jenkins/pipelines/skuba-trigger-upgrade-from-4.2.Jenkisfile
@@ -1,0 +1,98 @@
+def worker_name
+def worker_host
+def keep_worker = false
+
+pipeline {
+    agent { node {label 'caasp-team-private-experimental && openstack' }}
+
+    environment {
+        OPENRC = credentials('ecp-openrc')
+        JENKINS_ID = credentials('jenkins-ssh')
+        CAASP_CI   = credentials('ci.suse.de.caasp-user')
+    }
+    
+    stages {
+        stage('cleanup'){
+            steps {
+                dir("${WORKSPACE}/credentials") {
+                    deleteDir()
+                }
+            }
+        }
+        stage('Setup') {
+            steps {
+                // Get automation code from a GitHub repository
+                git url: 'https://github.com/SUSE/caasp-automation.git', credentialsId: 'github-token'
+
+                // setup credentials
+                dir('jenkins-worker'){
+                    sh 'mkdir -p credentials >> /dev/null || true'
+                    sh "cp ${env.JENKINS_ID} credentials/jenkins"
+                    sh "cp ${env.OPENRC} credentials/ecp.openrc"
+                    sh "cp ${env.CAASP_CI} credentials/ci.suse.de.caasp-user"
+                }
+            }
+        }
+        
+        stage('Create-worker') {
+            steps { script {
+                worker_name = "caasp-team-${BUILD_NUMBER}-dynamic-worker"
+                dir('jenkins-worker'){
+                    sh "./manage-workers.sh -c --worker-name ${worker_name} --worker-type dynamic --worker-template ${WORKER_TEMPLATE} --labels ${worker_name} --ssh-key ${env.JENKINS_ID}"
+                    worker_host  = sh(script: "./manage-workers.sh -i --worker-name ${worker_name}", returnStdout: true).trim()
+                    echo "woker ip ${worker_host}"
+                }
+            }}
+        }
+        stage('run-test'){
+            steps { script {
+                build   job: env.DOWNSTREAM_JOB, 
+                        wait: true, 
+                        propagate: true,
+                        parameters: [
+                            string(name: 'WORKER_LABEL', value: "${worker_name}"),
+                            string(name: 'WORKER_HOST', value: "${worker_host}"),
+                            string(name: 'BRANCH', value: env.BRANCH),
+                            string(name: 'RETAIN_CLUSTER', value: env.RETAIN_CLUSTER),
+                            string(name: 'RETENTION_PERIOD', value: env.RETENTION_PERIOD),
+                            string(name: 'INITIAL_VERSION', value: env.INITIAL_VERSION),
+                            string(name: 'TARGET_VERSION', value: env.TARGET_VERSION)
+                        ]
+            }}    
+        }
+    }
+    post {
+        always { script {
+            if (Boolean.parseBoolean(env.RETAIN_WORKER)) {
+                def retention_period= env.RETENTION_PERIOD?env.RETENTION_PERIOD:24
+                try{
+                    timeout(time: retention_period, unit: 'HOURS'){
+                        input(message: 'Waiting '+retention_period +' hours before cleaning up worker \n. ' +
+                                        'Press <abort> to cleanup inmediately, <keep> for keeping it',
+                                ok: 'keep')
+                        keep_worker = true
+                    }
+                }catch (err){
+                    // either timeout occurred or <abort> was selected
+                    keep_worker = false
+                }
+            }
+        }}
+        cleanup { script {
+            if (!keep_worker){
+                dir('jenkins-worker'){
+                    sh "./manage-workers.sh -d --worker-name ${worker_name} || true"
+                }
+            }
+            dir("${WORKSPACE}") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script") {
+                deleteDir()
+            }
+        }}
+    }
+}

--- a/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
@@ -1,0 +1,133 @@
+def cleanup_cluster=true
+
+pipeline {
+
+    agent { label "${WORKER_LABEL}" }
+    
+    environment {
+        SKUBA_BINPATH = "/home/jenkins/go/bin/skuba"
+        OPENSTACK_OPENRC = credentials('ecp-openrc')
+        GITHUB_TOKEN = credentials('github-token')
+        VMWARE_ENV_FILE = credentials('vmware-env')
+        TERRAFORM_STACK_NAME = "${BUILD_NUMBER}-${JOB_NAME.replaceAll("/","-")}".take(70)
+     }
+
+     stages {
+
+        stage("Build skuba"){
+            steps{
+                sh(script: "git checkout ${INITIAL_VERSION}")
+                sh(script: "make -f Makefile install", label: "Build Skuba ${INITIAL_VERSION}")
+            }
+        }
+
+        stage('Provision cluster') {
+            steps {
+                sh(script: 'make -f ci/Makefile provision', label: 'Provision')
+            }
+        }
+
+        stage('Deploy cluster') {
+            steps {
+                sh(script: 'make -f ci/Makefile deploy KUBERNETES_VERSION=${KUBERNETES_VERSION}', label: 'Deploy')
+                sh(script: 'make -f ci/Makefile check_cluster', label: 'Check cluster')
+            }
+        }
+
+        stage('upgrade admin node') {
+            environment {
+                REG_CODE = credentials('scc-regcode-caasp')
+            }
+            steps {
+                echo 'upgrading sles'
+                sh "sudo sudo zypper in -y --no-recommends zypper-migration-plugin"
+                sh "sudo SUSEConnect -r ${REG_CODE}"
+                sh "sudo zypper migration --migration 2 --no-recommends --non-interactive --auto-agree-with-licenses"
+                echo "upgrade completed"
+            }
+        }
+    
+        stage('reboot'){
+            agent { label 'caasp-team-private-integration' } 
+            environment {
+                JENKINS_ID = credentials('jenkins-ssh')
+            }
+            steps{
+                echo 'rebooting ${WORKER_HOST} ...'
+                sh "ssh -i ${JENKINS_ID} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T jenkins@${WORKER_HOST} sudo reboot &"
+               
+                sleep 60
+ 
+                timeout(180){
+                    waitUntil { script {
+                        sh(script: "ssh -i ${JENKINS_ID} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T jenkins@${WORKER_HOST} true", returnStatus: true) == 0
+                    }}
+                }
+            }
+        }
+        
+        stage('upgrade skuba') { 
+            steps {
+                sh(script: "sudo zypper in -y --no-recommends go1.13")
+                sh(script: "git checkout -f ${TARGET_VERSION}")
+                sh(script: "make install", label: "Build ${TARGET_VERSION}")
+            }   
+        }
+
+        stage('upgrade cluster'){
+            environment {
+                REG_CODE = credentials('scc-regcode-caasp')
+                
+            }
+            steps {
+                sh(script: "make -f ci/Makefile test SUITE='test_upgrade_from_4_2' SKIP_SETUP='deployed'", label: "Test upgrade")
+            }
+        }
+    }   
+    post {
+        always { script {
+            archiveArtifacts(artifacts: "ci/infra/${PLATFORM}/terraform.tfstate", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: "ci/infra/${PLATFORM}/terraform.tfvars.json", allowEmptyArchive: true)
+            archiveArtifacts(artifacts: 'testrunner.log', allowEmptyArchive: true)
+            // only attempt to collect logs if platform was provisioned
+            if (fileExists("tfout.json")) {
+                archiveArtifacts(artifacts: 'tfout.json', allowEmptyArchive: true)
+                sh(script: "make --keep-going -f ci/Makefile gather_logs", label: 'Gather Logs')
+                archiveArtifacts(artifacts: 'platform_logs/**/*', allowEmptyArchive: true)
+            }
+            if (Boolean.parseBoolean(env.RETAIN_CLUSTER)) {
+                def retention_period= env.RETENTION_PERIOD?env.RETENTION_PERIOD:24
+                try{
+                    timeout(time: retention_period, unit: 'HOURS'){
+                        input(message: 'Waiting '+retention_period +' hours before cleaning up cluster \n. ' +
+                                       'Press <abort> to cleanup inmediately, <keep> for keeping it',
+                              ok: 'keep')
+                        cleanup_cluster = false
+                    }
+                }catch (err){
+                    // either timeout occurred or <abort> was selected
+                    cleanup_cluster = true
+                }
+            }
+        }}
+        cleanup{ script{
+            if(cleanup_cluster){
+                sh(script: "make --keep-going -f ci/Makefile cleanup", label: 'Cleanup')
+            }
+            dir("${WORKSPACE}@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}@script@tmp") {
+                deleteDir()
+            }
+            dir("${WORKSPACE}") {
+                deleteDir()
+            }
+            sh(script: "rm -f ${SKUBA_BINPATH}; ", label: 'Remove built skuba')
+        }}
+    }
+}
+

--- a/ci/jenkins/templates/trigger-upgrade-from-4-2-daily.yaml
+++ b/ci/jenkins/templates/trigger-upgrade-from-4-2-daily.yaml
@@ -1,0 +1,57 @@
+- job-template:
+    name: '{name}/{platform}/trigger-upgrade-from-4-2-daily'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    schedule: '3-5'
+    triggers:
+        - timed: 'H H({schedule}) * * *'
+    parameters:
+        - string:
+            name: BRANCH
+            default: '{branch}'
+            description: The branch to checkout
+        - string:
+            name: PLATFORM
+            default: '{platform}'
+            description: The platform to perform the tests on
+        - string:
+            name: DOWNSTREAM_JOB
+            description: Job to be triggered downstream
+            default: '{name}/{platform}/upgrade-from-4-2-daily'  
+        - string:
+            name: WORKER_TEMPLATE
+            description: Template for worker
+            default: 'maintenance-caasp-v4.2'
+        - bool:
+            name: RETAIN_WORKER
+            default: false
+            description: Retain worker at the end of the job
+        - bool:
+            name: RETAIN_CLUSTER
+            default: false
+            description: Retain cluster at the end of the job
+        - string:
+            name: RETENTION_PERIOD
+            default: 24
+            description: Retention period for worker (in hours)  
+        - string:
+            name: INITIAL_VERSION
+            description: 'Initial version of skuba to deploy'
+            default: 'maintenance-caasp-v4.2'
+        - string:
+            name: TARGET_VERSION
+            description: 'version of skuba to migrate to'
+            default: 'master'
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://github.com/{repo-owner}/{repo-name}.git'
+                credentials-id: '{repo-credentials}'
+                refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*'
+                branches:
+                    - '$BRANCH'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+        script-path: ci/jenkins/pipelines/skuba-trigger-upgrade-from-4.2.Jenkinsfile
+

--- a/ci/jenkins/templates/upgrade-from-4.2.yaml
+++ b/ci/jenkins/templates/upgrade-from-4.2.yaml
@@ -1,0 +1,48 @@
+- job-template:
+    name: '{name}/{platform}/upgrade-from-4-2-daily'
+    project-type: pipeline
+    number-to-keep: 30
+    days-to-keep: 30
+    parameters:
+        - string:
+            name: BRANCH
+            default: '{branch}'
+            description: The branch to checkout
+        - string:
+            name: PLATFORM
+            default: '{platform}'
+            description: The platform to perform the tests on
+        - string:
+            name: WORKER_LABEL
+            description: LABEL of the worker to execute the job in
+        - string:
+            name: WORKER_HOST
+            description: Host name or ip address of worker
+        - string:
+            name: INITIAL_VERSION
+            description: 'Initial version of skuba to deploy'
+            default: 'maintenance-caasp-v4'
+        - string:
+            name: TARGET_VERSION
+            description: 'version of skuba to migrate to'
+            default: 'master'
+        - bool:
+            name: RETAIN_CLUSTER
+            default: false
+            description: Retain cluster at the end of the job
+        - string:
+            name: RETENTION_PERIOD
+            default: 24
+            description: Retention period for cluster (in hours)  
+    pipeline-scm:
+        scm:
+            - git:
+                url: 'https://github.com/{repo-owner}/{repo-name}.git'
+                credentials-id: '{repo-credentials}'
+                refspec: '+refs/heads/*:refs/remotes/origin/* +refs/pull/*/head:refs/remotes/origin/pr/*'
+                branches:
+                    - '$BRANCH'
+                browser: auto
+                suppress-automatic-scm-triggering: true
+        script-path: ci/jenkins/pipelines/skuba-trigger-upgrade-from-4.2.Jenkinsfile
+


### PR DESCRIPTION
## Why is this PR needed?

Automate testing  the upgrade from 4.2 to 4.5 to prevent regressions when maintaining any of the branches.

Fixes: https://github.com/SUSE/avant-garde/issues/1836

## What does this PR do?

Implement a process with two jobs: one that creates a temporary worker and triggers the upgrade test on these cluster.

## Anything else a reviewer needs to know?

Test executions:
* Trigger job: https://ci.suse.de/job/caasp-jobs/job/ci-dev/job/pablo/job/trigger-upgrade-from-4-2-daily/
* Upgrade test job: https://ci.suse.de/job/caasp-jobs/job/ci-dev/job/pablo/job/upgrade-from-4-2/

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
