### PR TITLE
[TF] Handle resource name errors

### DIFF
--- a/ci/infra/openstack/output.tf
+++ b/ci/infra/openstack/output.tf
@@ -1,9 +1,19 @@
 output "ip_masters" {
-  value = "${zipmap(openstack_compute_instance_v2.master.*.name, openstack_networking_floatingip_v2.master_ext.*.address)}"
+  value = zipmap(
+    concat(
+      openstack_compute_instance_v2.master.*.name, [ for i in range(length(openstack_compute_instance_v2.master), var.masters) : format("master-%d (not provisioned)", i ) ]),
+    concat(
+      openstack_networking_floatingip_v2.master_ext.*.address,  [ for _ in range(length(openstack_networking_floatingip_v2.master_ext.*.address), var.masters) : "" ])
+    )
 }
 
 output "ip_workers" {
-  value = "${zipmap(openstack_compute_instance_v2.worker.*.name, openstack_networking_floatingip_v2.worker_ext.*.address)}"
+  value = zipmap(
+    concat(
+      openstack_compute_instance_v2.worker.*.name, [ for i in range(length(openstack_compute_instance_v2.master), var.workers) : format("worker-%d (not provisioned)", i ) ]),
+    concat(
+      openstack_networking_floatingip_v2.worker_ext.*.address,  [ for _ in range(length(openstack_networking_floatingip_v2.worker_ext.*.address), var.workers) : "" ])
+  )
 }
 
 output "ip_internal_load_balancer" {
@@ -11,5 +21,9 @@ output "ip_internal_load_balancer" {
 }
 
 output "ip_load_balancer" {
-  value = "${zipmap(list(openstack_lb_loadbalancer_v2.lb.name), list(openstack_networking_floatingip_v2.lb_ext.address))}"
+  value = zipmap(
+    length(openstack_lb_loadbalancer_v2.lb.*) == 1 ? list(openstack_lb_loadbalancer_v2.lb.name) : list("${var.stack_name}-lb"),
+    length(openstack_networking_floatingip_v2.lb_ext.*) == 1 ? list(openstack_networking_floatingip_v2.lb_ext.address) :
+      list("Could not obtain ip address, please retry terraform refresh to update the output")
+  )
 }


### PR DESCRIPTION
There seems to be an issue when handling the output in openstack
in which the resource name is not available which results into
the output file failing to write due to zipmap operating into an
empty tuple

This patch fixes that by recovering from an empty resource name and
generating the same names based on the length of the addresses list

This should be safe to use but the real problem is somewhere else if
terraform is not able to provide the name, it could also not provide
the addresses for the resources, but the bug report seems to indicate
that only the names are not available while the addresses are there
so it should cover that failure and have a safe fallback

Fixes #1171653
Fixes https://github.com/SUSE/avant-garde/issues/1469

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
