### PR TITLE
fix: Prevent incorrect node joins

### DIFF
--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -58,6 +59,15 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 	}
 	if clusterTooOld < 0 {
 		err := fmt.Errorf("[join] failed to join the node as the cluster is not yet ready for SP2 nodes")
+		return err
+	}
+
+	// IsSUSEOS builds target Cache
+	if _, err := target.IsSUSEOS(); err != nil {
+		return err
+	}
+	if strings.Contains(target.Cache.OsRelease["VERSION_ID"], "15.1") {
+		err := fmt.Errorf("[join] SP1 nodes cannot join a SP2 cluster")
 		return err
 	}
 

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -52,6 +52,15 @@ func Join(client clientset.Interface, joinConfiguration deployments.JoinConfigur
 		return err
 	}
 
+	clusterTooOld, err := currentClusterVersion.Compare("1.18.0")
+	if err != nil {
+		return err
+	}
+	if clusterTooOld < 0 {
+		err := fmt.Errorf("[join] failed to join the node as the cluster is not yet ready for SP2 nodes")
+		return err
+	}
+
 	if err := target.Apply(deployments.KubernetesBaseOSConfiguration{
 		CurrentVersion: currentClusterVersion.String(),
 	}, "kubernetes.install-fresh-pkgs"); err != nil {


### PR DESCRIPTION
## Why is this PR needed?

People can try to join with SP1 nodes, while it's not a good idea.
Please see also the commit messages.

## What does this PR do?

Prevent incorrect joins

## Anything else a reviewer needs to know?

## Info for QA


### Related info


### Status **BEFORE** applying the patch

People can join clusters with SP1 nodes.

### Status **AFTER** applying the patch

You cannot join SP2 to SP1 cluster, and you cannot join SP1 to SP2
cluster.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->