### PR TITLE
Backport: Fix vbom url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,4 +41,5 @@ replace (
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.5
 	k8s.io/metrics => k8s.io/metrics v0.17.5
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.5
+	vbom.ml/util => github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc
 )


### PR DESCRIPTION
Looks like the vanity url for the vbom.ml package has been dropped
and the new one its just pointing to github according to [0][1]

The vbom dependency comes from kubernetes, they already fixed it
upstream on version 1.19.1[2] so until we update our dependency
to match that, we need this as a workaround.

This workaround replaces the old url with the new one

[0] fvbommel/util#5
[1] fvbommel/util#6
[2] kubernetes/kubernetes@ad3891d

This is a Backport of https://github.com/SUSE/skuba/pull/1351/commits/c0bc123b8ea2f4c5079d8dc60782d19f09c83884

Signed-off-by: Pablo Chacin <pchacin@suse.com>

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
