### PR TITLE
Fix maintenance caasp v4 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ lint: deps
 .PHONY: deps
 deps:
 	test -f $(BINPATH)/golangci-lint || curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(BINPATH) v1.21.0
-	test -f $(BINPATH)/shellcheck || curl -sfL "https://storage.googleapis.com/shellcheck/shellcheck-v0.4.7.linux.x86_64.tar.xz" | tar -xJv --strip-components=1 -C $(BINPATH)
+	test -f $(BINPATH)/shellcheck || curl -sfL "https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz" | tar -xJv --strip-components=1 -C $(BINPATH)
 
 .PHONY: pre-commit-install
 pre-commit-install:

--- a/go.mod
+++ b/go.mod
@@ -41,4 +41,5 @@ replace (
 	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.17.5
 	k8s.io/metrics => k8s.io/metrics v0.17.5
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.5
+	vbom.ml/util => github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc
 )


### PR DESCRIPTION
## Why is this PR needed?

The build process in maintenance-caasp-v4 branch is broken due to outdated dependencies. 


## What does this PR do?

- Updates shellchecker version
- Fixes broken url to go module (vbom)

## Anything else a reviewer needs to know?

These changes are backports from changes applied to master branch

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
