### PR TITLE
Rename caasp-maintenance-v4 to caasp-maintenance-v4.2

### DIFF
--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -19,7 +19,7 @@
           - openstack
           - vmware
       version:
-          - v4:
+          - v4.2:
               sonobuoy_version: 'v0.17'
               schedule: '1-3'
               branch: maintenance-caasp-v4.2
@@ -28,14 +28,14 @@
           - '{name}/{version}/{platform}'
 
 - project:
-    name: caasp-jobs/e2e/v4
+    name: caasp-jobs/e2e/v4.2
     repo-name: skuba
     repo-owner: SUSE
     repo-credentials: github-token
     platform:
         - vmware
     version:
-        - v4
+        - v4.2
         - v5:
             branch: experimental-v5
     test:

--- a/ci/jenkins/jobs.yaml
+++ b/ci/jenkins/jobs.yaml
@@ -22,7 +22,7 @@
           - v4:
               sonobuoy_version: 'v0.17'
               schedule: '1-3'
-              branch: maintenance-caasp-v4 
+              branch: maintenance-caasp-v4.2
           - v5
       jobs:
           - '{name}/{version}/{platform}'


### PR DESCRIPTION
Because CaaSP 4.5 is master, so to avoid confusions.

fixes https://github.com/SUSE/avant-garde/issues/1866

