### PR TITLE
Remove hyperkube migration

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -99,14 +99,6 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 			return errors.Wrap(err, "error adding target information to init configuration")
 		}
 
-		// Upgrade 1.17 to 1.18.
-		// This updated UseHyperKube field in-memory (unsets it).
-		// Note: The cluster cm is uploaded at the end of the kubeadm process, as usual.
-		// The whole paragraph can be removed when upgrading from 1.17 is removed.
-		if currentClusterVersion.Minor() == 17 {
-			initCfg.UseHyperKubeImage = false
-		}
-
 		kubeadm.UpdateClusterConfigurationWithClusterVersion(initCfg, nodeVersionInfoUpdate.Update.APIServerVersion)
 		initCfgContents, err = kubeadmconfigutil.MarshalInitConfigurationToBytes(initCfg, schema.GroupVersion{
 			Group:   "kubeadm.k8s.io",


### PR DESCRIPTION
Without this patch, hyperkube will be migrated from 1.17.4 to
1.17.x, which is not something we want.

This is a re-implementation for backport reasons of the
patch https://github.com/SUSE/skuba/pull/1293.Remove hyperkube migration

Signed-off-by: Jean-Philippe Evrard <jean-philippe.evrard@suse.com>
Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>