### PR TITLE
[CI] Check role is present in tfout

### DIFF
--- a/ci/infra/testrunner/platforms/terraform.py
+++ b/ci/infra/testrunner/platforms/terraform.py
@@ -112,8 +112,14 @@ class Terraform(Platform):
 
         role_key = "ip_" + role + "s"
         if self.state["version"] == 3:
+            # check if output actually contains the role's values
+            if not self.state["modules"][0]["outputs"][role_key]:
+                return []
             return list(self.state["modules"][0]["outputs"][role_key]["value"].values())
         elif self.state["version"] == 4:
+            # check if output actually contains the role's values
+            if not self.state["outputs"][role_key]:
+                return []
             return list(self.state["outputs"][role_key]["value"].values())
 
     @step


### PR DESCRIPTION
## Why is this PR needed?

In some cases, the output for a role is not present in the tfout. For example, the ip addresses could not be provisioned.

Fixes https://github.com/SUSE/avant-garde/issues/1959

## What does this PR do?

Checks the ouput contains the role before trying to access it and returns an empty list if not.

## Anything else a reviewer needs to know?

Testing properly this change requires forcing the output not to contain the ip addresses for a role, which is not simple to emulate. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
