### PR TITLE
Update kubelet.conf during node upgrade (bsc#1176578)

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -194,6 +194,7 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 	err = target.Apply(nil,
 		"kubelet.rootcert.upload",
 		"kubelet.servercert.create-and-upload",
+		"kubelet.update.config",
 		"kubernetes.restart-services",
 		"kubernetes.enable-services",
 	)


### PR DESCRIPTION
# Why is this PR needed?

If the cluster is deployed priori to Kubernetes version 1.17,
the kubelent client cert and key is embedded in /etc/kubernetes/kubelet.conf with base64 encoded.
however, it should points to the /var/lib/kubelet/pki/kubelet-client-current.pem for kubelet client cert rotation automatically.
and, the kubeadm did not takes care update the kubelet.conf during kubeadm upgrade.

Therefore, we let skuba to help on this to update the /etc/kubernetes/kubelet.conf from base64-encoded data to
point to the file /var/lib/kubelet/pki/kubelet-client-current.pem

Fixes bsc#1176578
xrefs to https://github.com/SUSE/avant-garde/issues/1961

## What does this PR do?

Calls during upgrade:
- `sed -i "s|client-certificate-data: .*|client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem|" /etc/kubernetes/kubelet.conf`
- `sed -i "s|client-key-data: .*|client-key: /var/lib/kubelet/pki/kubelet-client-current.pem|" /etc/kubernetes/kubelet.conf`

## Anything else a reviewer needs to know?

https://github.com/kubernetes/kubeadm/issues/1753#issuecomment-695886896
https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/#check-certificate-expiration

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

1. Prepare a cluster bootstrap priority to Kubernetes 1.17
2. Watch /etc/kubernetes/kubelet.conf, you could see that the client cert/key is embbed in configuration file with base64 encoded
3. Upgrade cluster by skuba, the /etc/kubernetes/kubelet.conf client cert/key _won't_ points to `/var/lib/kubelet/pki/kubelet-client-current.pem`

### Status **AFTER** applying the patch

1. Prepare a cluster bootstrap priority to Kubernetes 1.17
2. Watch /etc/kubernetes/kubelet.conf, you could see that the client cert/key is embbed in configuration file with base64 encoded
3. Upgrade cluster by skuba, the /etc/kubernetes/kubelet.conf client cert/key _would_ points to `/var/lib/kubelet/pki/kubelet-client-current.pem`

## Docs

https://github.com/SUSE/doc-caasp/pull/998

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
