### PR TITLE
Informs the user about wrong OS on node

### DIFF
--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -34,7 +34,7 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
 	upgradecluster "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/cluster"
-	"github.com/SUSE/skuba/pkg/skuba"
+	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
 )
 
 type NodeVersionInfoUpdate struct {
@@ -103,7 +103,7 @@ func (nviu NodeVersionInfoUpdate) NodeUpgradeableCheck(client clientset.Interfac
 	}
 	//Check if node OS SP compatible with kubernetes.latestVersion
 	if strings.Contains(nviu.Current.Node.Status.NodeInfo.OSImage, "SUSE Linux Enterprise Server 15 SP1") {
-		errorMessages = append(errorMessages, fmt.Sprintf("You are still running 15 SP1 on your node. Please upgrade to kubernetes version %s on SP1 first, and migrate to SP2 before triggering this upgrade.", skuba.LastCaaSP4KubernetesVersion))
+		errorMessages = append(errorMessages, fmt.Sprintf("You are still running 15 SP1 on your node. Please upgrade to kubernetes version %s on SP1 first, and migrate to SP2 before triggering this upgrade.", skubaconstants.LastCaaSP4KubernetesVersion))
 	}
 	if isFirstControlPlaneNodeToBeUpgraded {
 		// First check if all schedulable workers will tolerate the version we are upgrading to. If they don't, they need to be upgraded first.

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -33,6 +34,7 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/upgrade/addon"
 	upgradecluster "github.com/SUSE/skuba/internal/pkg/skuba/upgrade/cluster"
+	"github.com/SUSE/skuba/pkg/skuba"
 )
 
 type NodeVersionInfoUpdate struct {
@@ -98,6 +100,10 @@ func (nviu NodeVersionInfoUpdate) NodeUpgradeableCheck(client clientset.Interfac
 	isFirstControlPlaneNodeToBeUpgraded, err := nviu.IsFirstControlPlaneNodeToBeUpgraded(client)
 	if err != nil {
 		return err
+	}
+	//Check if node OS SP compatible with kubernetes.latestVersion
+	if strings.Contains(nviu.Current.Node.Status.NodeInfo.OSImage, "SUSE Linux Enterprise Server 15 SP1") {
+		errorMessages = append(errorMessages, fmt.Sprintf("You are still running 15 SP1 on your node. Please upgrade to kubernetes version %s on SP1 first, and migrate to SP2 before triggering this upgrade.", skuba.LastCaaSP4KubernetesVersion))
 	}
 	if isFirstControlPlaneNodeToBeUpgraded {
 		// First check if all schedulable workers will tolerate the version we are upgrading to. If they don't, they need to be upgraded first.

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -63,6 +63,8 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		return nil
 	}
 
+	// Refreshing cache info about target OS
+	target.IsSUSEOS()
 	// Check if the node is upgradeable (matches preconditions)
 	if err := nodeVersionInfoUpdate.NodeUpgradeableCheck(client, currentClusterVersion); err != nil {
 		fmt.Println()

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -64,7 +64,14 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 	}
 
 	// Refreshing cache info about target OS
-	target.IsSUSEOS()
+	isSUSE, err := target.IsSUSEOS()
+	if err != nil {
+		return err
+	}
+	// Check if target node OS is valid
+	if !isSUSE {
+		return fmt.Errorf("Invalid target node OS: %s", nodeVersionInfoUpdate.Current.Node.Status.NodeInfo.OSImage)
+	}
 	// Check if the node is upgradeable (matches preconditions)
 	if err := nodeVersionInfoUpdate.NodeUpgradeableCheck(client, currentClusterVersion); err != nil {
 		fmt.Println()


### PR DESCRIPTION
#### Related issue: https://github.com/SUSE/avant-garde/issues/1667
## Why is this PR needed?

Without this fix, a user can try to upgrade a cluster node with an OS SLES15-SP1  while using skuba-2 (CaaSP-4.5).
The upgrade fails, but the information is not necessarily clear to the user ( packages not found).


With this fix, user will be properly informed what steps are needed to be done prior to upgrading the node.
Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Prior to further k8s-related versioning checks, we check if the OS corresponds to skuba-2 (CaaSP-4.5).

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
