### PR TITLE
[CI] Fix worker type in upgrade test

### DIFF
--- a/ci/jenkins/pipelines/skuba-trigger-upgrade-from-4.2.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-trigger-upgrade-from-4.2.Jenkinsfile
@@ -3,7 +3,7 @@ def worker_host
 def keep_worker = false
 
 pipeline {
-    agent { node {label 'caasp-team-private-experimental && openstack' }}
+    agent { node {label 'caasp-team-private-integration && e2e' }}
 
     environment {
         OPENRC = credentials('ecp-openrc')


### PR DESCRIPTION
Make upgrade test run in regular e2e integration workers.

# Note to reviewers

This PR requires https://github.com/SUSE/caasp-automation/pull/782 to be merged before merging. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
