### PR TITLE
Bump kucero container image and manifest (bsc#1176578)

### DIFF
--- a/internal/pkg/skuba/addons/kucero.go
+++ b/internal/pkg/skuba/addons/kucero.go
@@ -231,8 +231,6 @@ spec:
       tolerations:
         - key: node-role.kubernetes.io/master
           effect: NoSchedule
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       hostPID: true
       restartPolicy: Always
       containers:
@@ -253,29 +251,21 @@ spec:
             - --ca-cert-path=/var/lib/kubelet/pki/kubelet-ca.crt
             - --ca-key-path=/var/lib/kubelet/pki/kubelet-ca.key
           volumeMounts:
+            - mountPath: /etc/kubernetes/kubelet.conf
+              name: kubelet-conf
             - mountPath: /var/lib/kubelet/pki/kubelet-ca.crt
               name: ca-crt
               readOnly: true
             - mountPath: /var/lib/kubelet/pki/kubelet-ca.key
               name: ca-key
               readOnly: true
-          livenessProbe:
-            httpGet:
-              path: /metrics
-              port: 8080
-            # The initial delay for the liveness probe is intentionally large to
-            # avoid an endless kill & restart cycle if in the event that the initial
-            # bootstrapping takes longer than expected.
-            initialDelaySeconds: 120
-            failureThreshold: 10
-            periodSeconds: 60
-          readinessProbe:
-            httpGet:
-              path: /metrics
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 60
+            - mountPath: /var/lib/kubelet/config.yaml
+              name: kubelet-config-yaml
       volumes:
+        - name: kubelet-conf
+          hostPath:
+            path: /etc/kubernetes/kubelet.conf
+            type: File
         - name: ca-crt
           hostPath:
             path: /var/lib/kubelet/pki/kubelet-ca.crt
@@ -283,6 +273,10 @@ spec:
         - name: ca-key
           hostPath:
             path: /var/lib/kubelet/pki/kubelet-ca.key
+            type: FileOrCreate
+        - name: kubelet-config-yaml
+          hostPath:
+            path: /var/lib/kubelet/config.yaml
             type: File
 `
 )

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -107,7 +107,7 @@ var (
 				Dex:           &AddonVersion{"2.23.0", 4500},
 				Gangway:       &AddonVersion{"3.1.0-rev5", 4500},
 				MetricsServer: &AddonVersion{"0.3.6", 4500},
-				Kucero:        &AddonVersion{"1.1.1", 4500},
+				Kucero:        &AddonVersion{"1.3.0", 4500},
 				PSP:           &AddonVersion{"", 4500},
 			},
 		},


### PR DESCRIPTION
## Why is this PR needed?

1. Fixes bsc#1176578 to auto-update legacy `/etc/kubernetes/kubelet.conf` if it is bootstrapped before Kubernetes 1.17.
2. Supports auto-enable kubelet server certificate `serverTLSBootstrap: true` in  `/var/lib/kubelet/config.yaml`.

xrefs https://github.com/SUSE/avant-garde/issues/1958

## What does this PR do?

Bump kucero container image and manifest to support:
* updates `/etc/kubernetes/kubelet.conf` to use symlink `/var/lib/kubelet/pki/kubelet-client-current.pem` if the kubelet.conf is bootstrapped before Kubernetes 1.17.
* supports automatically enable the kubelet server certificate in `/var/lib/kubelet/config.yaml`.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

A new package kucero `1.3.0`.

### Status **BEFORE** applying the patch

Bootstrap a cluster with Kubernetes cluster before 1.17, the `/etc/kubernetes/kubelet.conf` uses embedded base64 encoded client cert/key, not point to the `/var/lib/kubelet/kubelet-client-current.pem` and the `serverTLSBootstrap` is not configured in `/var/lib/kubelet/config.yaml`.

### Status **AFTER** applying the patch

1. Bootstrap a cluster with Kubernetes cluster before 1.17, the `/etc/kubernetes/kubelet.conf` uses embedded base64 encoded client cert/key, not point to the `/var/lib/kubelet/kubelet-client-current.pem` and the `serverTLSBootstrap` is not configured in `/var/lib/kubelet/config.yaml`.
2. Install kucero addon with container image version `1.3.0`.
3. Then kucero will:
   - auto-updates the `/etc/kubernetes/kubelet.conf` from base64 encoded client cert/key to symlink `/var/lib/kubelet/kubelet-client-current.pem`.
   - auth-enabled the `serverTLSBootstrap: true` in `/var/lib/kubelet/config.yaml` in order to auto rotates the kubelet server certificate.

## Docs

https://github.com/SUSE/doc-caasp/pull/1002

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
