### PR TITLE
Add label to cilium client secret

### DIFF
--- a/internal/pkg/skuba/cni/cilium.go
+++ b/internal/pkg/skuba/cni/cilium.go
@@ -126,6 +126,7 @@ func CreateCiliumSecret(client clientset.Interface, ciliumVersion string) error 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ciliumSecretName,
 			Namespace: metav1.NamespaceSystem,
+			Labels:    map[string]string{"caasp.suse.com/skuba-addon": "true"},
 		},
 		Data: secretData,
 	}


### PR DESCRIPTION
# Why is this PR needed?

Add label to cilium-cert for cert-exporter to monitoring.

Fixes: bsc#1176904
xrefs https://github.com/SUSE/avant-garde/issues/1969

## What does this PR do?

Add the label `caasp.suse.com/skuba-addon=true` to the cilium-secret.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

The cilium-cert secret without a label.

### Status **AFTER** applying the patch

The cilium-cert secret with a label.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
