### PR TITLE
addons: Remove cilium-init image (bsc#1172270)

### DIFF
--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -34,11 +34,7 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.Cilium, CniAddOn, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumInitImage, GetCiliumOperatorImage, GetCiliumImage})
-}
-
-func GetCiliumInitImage(clusterVersion *version.Version, imageTag string) string {
-	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "cilium-init", imageTag)
+	registerAddon(kubernetes.Cilium, CniAddOn, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumOperatorImage, GetCiliumImage})
 }
 
 func GetCiliumOperatorImage(clusterVersion *version.Version, imageTag string) string {
@@ -47,10 +43,6 @@ func GetCiliumOperatorImage(clusterVersion *version.Version, imageTag string) st
 
 func GetCiliumImage(clusterVersion *version.Version, imageTag string) string {
 	return images.GetGenericImage(skubaconstants.ImageRepository(clusterVersion), "cilium", imageTag)
-}
-
-func (renderContext renderContext) CiliumInitImage() string {
-	return GetCiliumInitImage(renderContext.config.ClusterVersion, kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
 }
 
 func (renderContext renderContext) CiliumOperatorImage() string {

--- a/internal/pkg/skuba/addons/cilium_test.go
+++ b/internal/pkg/skuba/addons/cilium_test.go
@@ -29,38 +29,6 @@ import (
 	img "github.com/SUSE/skuba/pkg/skuba"
 )
 
-func TestGetCiliumInitImage(t *testing.T) {
-	tests := []struct {
-		name     string
-		imageTag string
-		want     string
-	}{
-		{
-			name:     "get cilium init image without revision",
-			imageTag: "1.7.6",
-			want:     "cilium-init:1.7.6",
-		},
-		{
-			name:     "get cilium init image with revision",
-			imageTag: "1.7.6-rev2",
-			want:     "cilium-init:1.7.6-rev2",
-		},
-	}
-
-	for _, ver := range kubernetes.AvailableVersions() {
-		for _, tt := range tests {
-			tt := tt // Parallel testing
-			t.Run(tt.name, func(t *testing.T) {
-				imageUri := fmt.Sprintf("%s/%s", img.ImageRepository(ver), tt.want)
-
-				if got := GetCiliumInitImage(ver, tt.imageTag); got != imageUri {
-					t.Errorf("GetCiliumInitImage() = %v, want %v", got, tt.want)
-				}
-			})
-		}
-	}
-}
-
 func TestGetCiliumOperatorImage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -122,39 +90,6 @@ func TestGetCiliumImage(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-func Test_renderContext_CiliumInitImage(t *testing.T) {
-	type test struct {
-		name          string
-		renderContext renderContext
-		want          string
-	}
-	for _, ver := range kubernetes.AvailableVersions() {
-		tt := test{
-			name: "render Cilium Init Image URL when cluster version is " + ver.String(),
-			renderContext: renderContext{
-				config: AddonConfiguration{
-					ClusterVersion: ver,
-					ControlPlane:   "",
-					ClusterName:    "",
-				},
-			},
-			want: img.ImageRepository(ver) + "/cilium-init:([[:digit:]]{1,}.){2}[[:digit:]]{1,}(-rev[:digit:]{1,})?",
-		}
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.renderContext.CiliumInitImage()
-			matched, err := regexp.Match(tt.want, []byte(got))
-			if err != nil {
-				t.Error(err)
-				return
-			}
-			if !matched {
-				t.Errorf("renderContext.CiliumInitImage() = %v, want %v", got, tt.want)
-				return
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
We don't ship a separate cilium-init image anymore. The cilium-init
script is included in the main cilium container image.

Fixes: SUSE/avant-garde#1923

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>