### PR TITLE
Add --auto-agree-with-licenses flag to install

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/zypper.go
+++ b/internal/pkg/skuba/deployments/ssh/zypper.go
@@ -21,7 +21,7 @@ package ssh
 // wrapped with the right userdata and parameters
 func (t *Target) ZypperInstall(packages ...string) (stdout string, stderr string, error error) {
 	var cliArgs []string
-	cliArgs = append(cliArgs, "--userdata", "skuba", "-i", "--non-interactive", "install", "--")
+	cliArgs = append(cliArgs, "--userdata", "skuba", "-i", "--non-interactive", "install", "--auto-agree-with-licenses", "--")
 	cliArgs = append(cliArgs, packages...)
 	return t.ssh("zypper", cliArgs...)
 }


### PR DESCRIPTION
## Why is this PR needed?

This is required for non-intercative installation as the default
is to not accept licence, which leads to a failed install
as we cannot override interactively.

#1385 

Fixes #1385 

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Add --auto-agree-with-licenses to install commands

## Anything else a reviewer needs to know?


## Info for QA

### Related info

### Status **BEFORE** applying the patch

See Issue

### Status **AFTER** applying the patch

Caasp 4.5 installs properly with licence acceptet

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
