### PR TITLE
Backport kucero to CaaSP v4.2 (bsc#1176578)

### DIFF
--- a/internal/pkg/skuba/addons/kucero.go
+++ b/internal/pkg/skuba/addons/kucero.go
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
+)
+
+func init() {
+	registerAddon(kubernetes.Kucero, renderKuceroTemplate, nil, nil, normalPriority, []getImageCallback{GetKuceroImage})
+}
+
+func GetKuceroImage(imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository, "kucero", imageTag)
+}
+
+func (renderContext renderContext) KuceroImage() string {
+	return GetKuceroImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Kucero, renderContext.config.ClusterVersion).Version)
+}
+
+func renderKuceroTemplate(addonConfiguration AddonConfiguration) string {
+	return kuceroManifest
+}
+
+const (
+	kuceroManifest = `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kucero
+  namespace: kube-system
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - kucero
+  resources:
+  - daemonsets
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kucero
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/kubelet-serving
+  resources:
+  - signers
+  verbs:
+  - approve
+  - sign
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/approval
+  verbs:
+  - create
+  - update
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/status
+  verbs:
+  - patch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kucero
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kucero
+subjects:
+- kind: ServiceAccount
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kucero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kucero
+subjects:
+- kind: ServiceAccount
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: suse:caasp:psp:kucero
+roleRef:
+  kind: ClusterRole
+  name: suse:caasp:psp:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: kucero
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kucero
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: kucero
+  revisionHistoryLimit: 3
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: kucero
+      annotations:
+        {{.AnnotatedVersion}}
+    spec:
+      serviceAccountName: kucero
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      hostPID: true
+      restartPolicy: Always
+      containers:
+        - name: kucero
+          image: {{.KuceroImage}}
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true # Give permission to nsenter /proc/1/ns/mnt
+          env:
+            # Pass in the name of the node on which this pod is scheduled
+            # for use with drain/uncordon operations and lock acquisition
+            - name: KUCERO_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command:
+            - /usr/bin/kucero
+            - --ca-cert-path=/var/lib/kubelet/pki/kubelet-ca.crt
+            - --ca-key-path=/var/lib/kubelet/pki/kubelet-ca.key
+          volumeMounts:
+            - mountPath: /etc/kubernetes/kubelet.conf
+              name: kubelet-conf
+            - mountPath: /var/lib/kubelet/pki/kubelet-ca.crt
+              name: ca-crt
+              readOnly: true
+            - mountPath: /var/lib/kubelet/pki/kubelet-ca.key
+              name: ca-key
+              readOnly: true
+            - mountPath: /var/lib/kubelet/config.yaml
+              name: kubelet-config-yaml
+      volumes:
+        - name: kubelet-conf
+          hostPath:
+            path: /etc/kubernetes/kubelet.conf
+            type: File
+        - name: ca-crt
+          hostPath:
+            path: /var/lib/kubelet/pki/kubelet-ca.crt
+            type: File
+        - name: ca-key
+          hostPath:
+            path: /var/lib/kubelet/pki/kubelet-ca.key
+            type: FileOrCreate
+        - name: kubelet-config-yaml
+          hostPath:
+            path: /var/lib/kubelet/config.yaml
+            type: File
+`
+)

--- a/internal/pkg/skuba/addons/kucero_test.go
+++ b/internal/pkg/skuba/addons/kucero_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"fmt"
+	"testing"
+
+	img "github.com/SUSE/skuba/pkg/skuba"
+)
+
+func TestGetKuceroImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageTag string
+		want     string
+	}{
+		{
+			name:     "get kucero image without revision",
+			imageTag: "1.1.1",
+			want:     "kucero:1.1.1",
+		},
+		{
+			name:     "get kucero image with revision",
+			imageTag: "1.1.1-rev1",
+			want:     "kucero:1.1.1-rev1",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Parallel testing
+		t.Run(tt.name, func(t *testing.T) {
+			imageUri := fmt.Sprintf("%s/%s", img.ImageRepository, tt.want)
+
+			if got := GetKuceroImage(tt.imageTag); got != imageUri {
+				t.Errorf("GetKuceroImage() = %v, want %v", got, imageUri)
+			}
+		})
+	}
+}

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -37,6 +37,7 @@ const (
 	Dex           Addon = "dex"
 	Gangway       Addon = "gangway"
 	MetricsServer Addon = "metrics-server"
+	Kucero        Addon = "kucero"
 	PSP           Addon = "psp"
 
 	Kubelet          Component = "kubelet"
@@ -106,6 +107,7 @@ var (
 				Dex:           &AddonVersion{"2.16.0-rev6", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
 				MetricsServer: &AddonVersion{"0.3.6", 1},
+				Kucero:        &AddonVersion{"1.3.0", 0},
 				PSP:           &AddonVersion{"", 4},
 			},
 		},


### PR DESCRIPTION
## Why is this PR needed?

Release kucero to CaaSP 4.2 to fix the customers who might run into the "certificate expires after one year" problem.

fixes bsc#1176578
xrefs https://github.com/SUSE/avant-garde/issues/1961

## What does this PR do?

Add kucero addon to CaaSP 4.2.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

The kucero container image `1.3.0` will be released in CaaSP v4 channel together.

### Status **BEFORE** applying the patch

N/A

### Status **AFTER** applying the patch

The kucero DaemonSet will be deployed when the cluster bootstrap or upgrade.

## Docs

WIP

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
