### PR TITLE
[CI] Wait for node readiness after node upgrade

### DIFF
--- a/ci/infra/testrunner/checks/checks.py
+++ b/ci/infra/testrunner/checks/checks.py
@@ -150,7 +150,7 @@ def check_apiserver_healthz(conf, platform, role, node):
     return output.find("ok") > -1
 
 
-@check(description="etcd health check", scope="node", roles=['master'])
+@check(description="etcd health check", scope="node", roles=['master'], stages=["joined"])
 def check_etcd_health(conf, platform, role, node):
     platform = platforms.get_platform(conf, platform)
     cmd = ('sudo curl -Ls --cacert /etc/kubernetes/pki/etcd/ca.crt '

--- a/ci/infra/testrunner/checks/checks.py
+++ b/ci/infra/testrunner/checks/checks.py
@@ -84,12 +84,15 @@ class Checker:
         self.utils.setup_ssh()
         self.platform = platform
 
-    def _filter_checks(self, checks, scope=None, stage=None):
+    def _filter_checks(self, checks, scope=None, stage=None, role=None):
         _filtered = checks
         if scope:
             _filtered = [c for c in _filtered if scope == c.scope]
         if stage:
             _filtered = [c for c in _filtered if stage in c.stages]
+        if role:
+            _filtered = [c for c in _filtered if role in c.roles]
+
         return _filtered
 
     def _filter_by_name(self, names):
@@ -118,7 +121,7 @@ class Checker:
         else:
             if not stage:
                 raise ValueError("stage must be specified")
-            checks = self._filter_checks(_checks, stage=stage, scope="node")
+            checks = self._filter_checks(_checks, stage=stage, scope="node", role=role)
 
         start = int(time.time())
         for check in checks:

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -96,7 +96,8 @@ def remove_node(options):
 
 def node_upgrade(options):
     Skuba(options.conf, options.platform).node_upgrade(
-        action=options.upgrade_action, role=options.role, nr=options.node)
+        action=options.upgrade_action, role=options.role,
+        nr=options.node, timeout=options.timeout)
 
 
 def node_check(options):
@@ -234,6 +235,8 @@ def main():
                                            help="upgrade kubernetes version in node")
     cmd_node_upgrade.add_argument("-a", "--action", dest="upgrade_action",
                                   help="action: plan or apply upgrade", choices=["plan", "apply"])
+    cmd_node_upgrade.add_argument("-t", "--timeout", type=int, default=180,
+                                help="timeout for waiting the nodes to become ready after upgrade (seconds)")
     cmd_node_upgrade.set_defaults(func=node_upgrade)
 
     cmd_check_node = commands.add_parser(

--- a/ci/infra/testrunner/tests/conftest.py
+++ b/ci/infra/testrunner/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 import platforms
+from checks import Checker
 from kubectl import Kubectl
 from skuba import Skuba
 from utils import BaseConfig
@@ -91,6 +92,10 @@ def platform(conf, target):
     platform = platforms.get_platform(conf, target)
     return platform
 
+@pytest.fixture
+def checker(conf, target):
+    checker = Checker(conf, target)
+    return checker
 
 @pytest.fixture
 def setup(request, platform, skuba):

--- a/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
+++ b/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
@@ -38,7 +38,7 @@ def test_upgrade_from_4_2(deployment, platform, skuba, kubectl):
         num_nodes = platform.get_num_nodes(role)
         for node in range(0, num_nodes):
             migrate_node(platform, kubectl, role, node, reg_code)
-            result = skuba.node_upgrade("apply", role, node)
+            result = skuba.node_upgrade("apply", role, node, timeout=300)
             assert result.find("successfully upgraded") != -1
 
             # check node version is update


### PR DESCRIPTION
## Why is this PR needed?

Upgrade tests fail due to etcd related errors, likely produced as a consequence of master nodes reboot.

Fixes https://github.com/SUSE/avant-garde/issues/1968


## What does this PR do?

Add delay to allow master nodes to get back operational before attempting any other action.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
