### PR TITLE
Revert "Merge pull request #1384 from mrostecki/4.2-remove-cilium-init"

### DIFF
--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -31,7 +31,11 @@ import (
 )
 
 func init() {
-	registerAddon(kubernetes.Cilium, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumOperatorImage, GetCiliumImage})
+	registerAddon(kubernetes.Cilium, renderCiliumTemplate, renderCiliumPreflightTemplate, ciliumCallbacks{}, normalPriority, []getImageCallback{GetCiliumInitImage, GetCiliumOperatorImage, GetCiliumImage})
+}
+
+func GetCiliumInitImage(imageTag string) string {
+	return images.GetGenericImage(skubaconstants.ImageRepository, "cilium-init", imageTag)
 }
 
 func GetCiliumOperatorImage(imageTag string) string {
@@ -40,6 +44,10 @@ func GetCiliumOperatorImage(imageTag string) string {
 
 func GetCiliumImage(imageTag string) string {
 	return images.GetGenericImage(skubaconstants.ImageRepository, "cilium", imageTag)
+}
+
+func (renderContext renderContext) CiliumInitImage() string {
+	return GetCiliumInitImage(kubernetes.AddonVersionForClusterVersion(kubernetes.Cilium, renderContext.config.ClusterVersion).Version)
 }
 
 func (renderContext renderContext) CiliumOperatorImage() string {


### PR DESCRIPTION
This reverts commit 79a5c1f5a084a10e1e3d65cc2d5597b1eb4fd895, reversing
changes made to 748de90f14a49d1921f0f852faae562e6429d251.

## Why is this PR needed?

This change is reverting a commit that seems to have broken e2e tests in CI.

fixes:: https://github.com/SUSE/avant-garde/issues/1981

See https://github.com/SUSE/skuba/commit/c7c1a31881a9ee8ad43c53e92a19f95d27e1cef7

## What does this PR do?

This change is reverting a commit that seems to have broken e2e tests in CI.
