### PR TITLE
Add label to set specific kubernetes version in PR

### DIFF
--- a/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
+++ b/ci/jenkins/pipelines/prs/skuba-test.Jenkinsfile
@@ -17,6 +17,10 @@ def branch_registry = ""
 // original (non-branched) registry, only needed when branch_registry is in use
 def original_registry = ""
 
+
+// kubernetes version to deploy. A blank value uses the default version for the skuba
+def kubernetes_version = ""
+
 // CaaSP Version for repo and registry branch
 def repo_version = "4.5"
 
@@ -94,6 +98,14 @@ node('caasp-team-private-integration') {
                original_registry = "registry.suse.de/devel/caasp/4.5/containers/containers"
            }
 
+           //check if the PR requires an specific kubernetes version 
+           def pr_kubernetes_label = pr.labels.find {
+               it.name.startsWith("ci-kubernetes:")
+           }
+           if (pr_kubernetes_label != null) {
+               kubernetes_version = pr_kubernetes_label.name.split(":")[1]
+           }
+
         } catch (Exception e) {
             echo "Error retrieving labels for PR ${e.getMessage()}"
             currentBuild.result = 'ABORTED'
@@ -119,6 +131,7 @@ pipeline {
         BRANCH_REPO = "${branch_repo}"
         BRANCH_REGISTRY = "${branch_registry}"
         ORIGINAL_REGISTRY = "${original_registry}"
+        KUBERNETES_VERSION = "${kubernetes_version}"
    }
 
     stages {


### PR DESCRIPTION
## Why is this PR needed?

Some PRs are intended to address issues with a specific Kubernetes version. Therefore is necessary to be able to set the version of Kubernetes to be deployed.

Fixes https://github.com/SUSE/avant-garde/issues/1984

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

Add label to select the Kubernetes version to deploy in the test cluster for the PR:

## Note to reviewers

When testing this PR, the deployment of kubernetes 1.17.4 failed to reasons not related to this PR. https://github.com/SUSE/avant-garde/issues/1986

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
