### PR TITLE
[4.2] addons: List cilium-init image only for Cilium < 1.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/SUSE/skuba
 
 require (
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/coreos/go-oidc v2.1.0+incompatible
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0
@@ -43,3 +44,5 @@ replace (
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.17.5
 	vbom.ml/util => github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bifurcation/mint v0.0.0-20180715133206-93c51c6ce115/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
+github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
@@ -124,6 +125,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc h1:nwStfwjRx+GgKD5lxZnky7Cyy8o45Cj5JznhJKgZij0=
+github.com/fvbommel/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:AlRx4sdoz6EdWGYPMeunQWYf46cKnq7J4iVvLgyb5cY=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -470,7 +470,10 @@ func (addon Addon) Apply(client clientset.Interface, addonConfiguration AddonCon
 func (addon Addon) Images(imageTag string) []string {
 	images := []string{}
 	for _, cb := range addon.getImageCallbacks {
-		images = append(images, cb(imageTag))
+		image := cb(imageTag)
+		if image != "" {
+			images = append(images, image)
+		}
 	}
 	return images
 }

--- a/internal/pkg/skuba/addons/cilium.go
+++ b/internal/pkg/skuba/addons/cilium.go
@@ -24,6 +24,7 @@ import (
 	"github.com/SUSE/skuba/internal/pkg/skuba/cni"
 	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
 	"github.com/SUSE/skuba/internal/pkg/skuba/skuba"
+	"github.com/SUSE/skuba/internal/pkg/skuba/util"
 	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
 	"github.com/pkg/errors"
 	clientset "k8s.io/client-go/kubernetes"
@@ -35,6 +36,10 @@ func init() {
 }
 
 func GetCiliumInitImage(imageTag string) string {
+	// A separate cilium-init image exists only for Cilium < 1.6.
+	if util.VersionCompare(imageTag, ">=1.6.0") {
+		return ""
+	}
 	return images.GetGenericImage(skubaconstants.ImageRepository, "cilium-init", imageTag)
 }
 

--- a/internal/pkg/skuba/addons/cilium_test.go
+++ b/internal/pkg/skuba/addons/cilium_test.go
@@ -36,13 +36,18 @@ func TestGetCiliumInitImage(t *testing.T) {
 	}{
 		{
 			name:     "get cilium init image without revision",
-			imageTag: "1.6.6",
-			want:     img.ImageRepository + "/cilium-init:1.6.6",
+			imageTag: "1.5.3",
+			want:     img.ImageRepository + "/cilium-init:1.5.3",
 		},
 		{
 			name:     "get cilium init image with revision",
-			imageTag: "1.6.6-rev2",
-			want:     img.ImageRepository + "/cilium-init:1.6.6-rev2",
+			imageTag: "1.5.3-rev1",
+			want:     img.ImageRepository + "/cilium-init:1.5.3-rev1",
+		},
+		{
+			name:     "get newer cilium version which does not ship cilium-init image",
+			imageTag: "1.6.6",
+			want:     "",
 		},
 	}
 	for _, tt := range tests {
@@ -129,6 +134,11 @@ func Test_renderContext_CiliumInitImage(t *testing.T) {
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.renderContext.CiliumInitImage()
+			// Skip empty results, which mean that Cilium >= 1.6 is checked and thus
+			// the cilium-init image is not shipped.
+			if got == "" {
+				return
+			}
 			matched, err := regexp.Match(tt.want, []byte(got))
 			if err != nil {
 				t.Error(err)

--- a/internal/pkg/skuba/util/versioncheck.go
+++ b/internal/pkg/skuba/util/versioncheck.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package util
+
+import (
+	"github.com/blang/semver"
+)
+
+func VersionCompare(versionS, constraintS string) bool {
+	version, err := semver.ParseTolerant(versionS)
+	if err != nil {
+		panic(err)
+	}
+	constraint, err := semver.ParseRange(constraintS)
+	if err != nil {
+		panic(err)
+	}
+	return constraint(version)
+}

--- a/internal/pkg/skuba/util/versioncheck_test.go
+++ b/internal/pkg/skuba/util/versioncheck_test.go
@@ -94,6 +94,12 @@ func TestVersionCompare(t *testing.T) {
 			constraint: "<=1.5.0",
 			exp:        false,
 		},
+		{
+			name:       "greater, with rev",
+			version:    "1.6.6-rev5",
+			constraint: ">1.6.0",
+			exp:        true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/pkg/skuba/util/versioncheck_test.go
+++ b/internal/pkg/skuba/util/versioncheck_test.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package util
+
+import (
+	"testing"
+)
+
+func TestVersionCompare(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		constraint string
+		exp        bool
+	}{
+		{
+			name:       "equal, should match",
+			version:    "1.7.5",
+			constraint: "1.7.5",
+			exp:        true,
+		},
+		{
+			name:       "greater or equal, should match",
+			version:    "1.7.5",
+			constraint: ">=1.7.5",
+			exp:        true,
+		},
+		{
+			name:       "lower or equal, should match",
+			version:    "1.7.5",
+			constraint: "<=1.7.5",
+			exp:        true,
+		},
+		{
+			name:       "greater, should match",
+			version:    "1.7.5",
+			constraint: ">1.7.0",
+			exp:        true,
+		},
+		{
+			name:       "lower, should match",
+			version:    "1.7.5",
+			constraint: "<1.8.0",
+			exp:        true,
+		},
+		{
+			name:       "equal, should not match, is lower",
+			version:    "1.7.5",
+			constraint: "1.5.3",
+			exp:        false,
+		},
+		{
+			name:       "equal, should not match, is greater",
+			version:    "1.7.5",
+			constraint: "1.8.0",
+			exp:        false,
+		},
+		{
+			name:       "greater, should not match",
+			version:    "1.7.5",
+			constraint: ">1.7.5",
+			exp:        false,
+		},
+		{
+			name:       "lower, should not match",
+			version:    "1.7.5",
+			constraint: "<1.7.5",
+			exp:        false,
+		},
+		{
+			name:       "greater or equal, should not match",
+			version:    "1.7.5",
+			constraint: ">=1.8.0",
+			exp:        false,
+		},
+		{
+			name:       "lower or equal, should not match",
+			version:    "1.7.5",
+			constraint: "<=1.5.0",
+			exp:        false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			cmp := VersionCompare(tt.version, tt.constraint)
+			if cmp != tt.exp {
+				t.Errorf("version comparison does not match, expected %v, got %v", tt.exp, cmp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We don't ship a separate cilium-init image anymore. The cilium-init
script is included in the main cilium container image.

Fixes: SUSE/avant-garde#1923

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>