### PR TITLE
Set up automatic release generation on v* tag

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -1,0 +1,136 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Release Skuba
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    env:
+      ARTIFACT_PATH: artifacts/
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          # fetch-depth: 0 is necessary to get all history, which we need
+          fetch-depth: 0
+
+      - name: Set Scriptdir After Checkout
+        run: |
+          SCRIPTDIR=$GITHUB_WORKSPACE/ci/packaging/suse
+          echo "SCRIPTDIR=$SCRIPTDIR" >> $GITHUB_ENV
+
+      - name: env debug
+        run: |
+          env | sort
+
+      - name: Prep Artifacts Dir
+        run: |
+          mkdir -vp $ARTIFACT_PATH
+
+      - name: Identify Previous Release Tag
+        id: release_tag
+        run: |
+          PREV_TAG=$(git describe --abbrev=0 --tags "${{ github.ref }}^")
+          echo "PREV_TAG=$PREV_TAG" >> $GITHUB_ENV
+          echo "::set-output name=tag::$PREV_TAG"
+
+      - name: Set Pretty Tag
+        id: pretty_tag
+        run: |
+          PRETTY_TAG='${{ github.ref }}' # fix broken YAML hilighting with '
+          PRETTY_TAG=${PRETTY_TAG##*/}   # make "refs/tags/x" just "x"
+          echo "PRETTY_TAG=$PRETTY_TAG" >> $GITHUB_ENV
+          echo "::set-output name=tag::$PRETTY_TAG"
+
+      - name: Generate changelog
+        id: gen_changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # token provided by Actions
+          CHANGELOG_PATH: "${{ env.ARTIFACT_PATH }}/skuba.changes.append"
+          RELEASE_BODY: "changes.md"
+          CURRENT_TAG: ${{ github.ref }}
+        run: |
+          "$SCRIPTDIR"/changelog_maker.sh "$CHANGELOG_PATH"
+
+          echo "full changes are:'$( <$CHANGELOG_PATH )'"
+          echo "release body is:'$(  <$RELEASE_BODY   )'"
+          echo "::set-output name=changelog_path::$CHANGELOG_PATH"
+          echo "::set-output name=obs_path::$RELEASE_BODY"
+
+      - name: Generate Release Tarball and Spec
+        id: gen_release_files
+        env:
+          TARBALL_PATH: ${{ env.ARTIFACT_PATH }}/skuba.tar.gz
+          PUB_NAME: skuba-${{ env.PRETTY_TAG }}.tar.gz # cosmetic for release
+          SPECFILE_PATH: ${{ env.ARTIFACT_PATH }}/skuba.spec
+          TEMPLATE_PATH: ${{ env.SCRIPTDIR }}/skuba_spec_template
+        run: |
+          "$SCRIPTDIR"/rpmfiles_maker.sh \
+            "${PRETTY_TAG#v}"   \
+            "$PRETTY_TAG" \
+            "$PRETTY_TAG"
+
+          echo "::set-output name=tar_path::$TARBALL_PATH"
+          echo "::set-output name=tar_name::$( basename $TARBALL_PATH )"
+          echo "::set-output name=tar_pubname::$PUB_NAME"
+          echo "::set-output name=spec_path::$SPECFILE_PATH"
+
+      - name: Generate OBS Files
+        id: gen_obs_files
+        run: |
+          TARBALL_PATH=obs.tar.gz
+          ( cd "$ARTIFACT_PATH" && tar cvzf - * ) > "$TARBALL_PATH"
+
+          echo "::set-output name=path::$TARBALL_PATH"
+          echo "::set-output name=name::$( basename $TARBALL_PATH )"
+
+      ##########################################
+      - name: Save generated artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: generated_files
+          path: |
+            ${{ steps.gen_changelog.outputs.obs_path }}
+            ${{ steps.gen_changelog.outputs.changelog_path }}
+            ${{ steps.gen_release_files.outputs.tar_path }}
+            ${{ steps.gen_release_files.outputs.spec_path }}
+            ${{ steps.gen_obs_files.outputs.path }}
+
+      ##########################################
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # token provided by Actions
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body_path: changes.md
+          draft: false
+          prerelease: false
+
+      - name: Add skuba tar file to release
+        id: release_skuba_tarball
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.gen_release_files.outputs.tar_path }}
+          asset_name: ${{ steps.gen_release_files.outputs.tar_pubname }}
+          asset_content_type: application/gzip
+
+      - name: Add OBS tar file to release
+        id: release_obs_tar
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.gen_obs_files.outputs.path }}
+          asset_name: ${{ steps.gen_obs_files.outputs.name }}
+          asset_content_type: application/gzip

--- a/ci/packaging/suse/changelog_maker.sh
+++ b/ci/packaging/suse/changelog_maker.sh
@@ -1,21 +1,51 @@
 #!/bin/bash
 
-dashes="-------------------------------------------------------------------"
+# if we're in a Github Action ($GITHUB_ACTIONS=true)
+# and GIT_WORK_TREE isn't set, ensure git commands work...
+if [[ -n "${GITHUB_ACTIONS:-}" && -z "${GIT_WORK_TREE=:-}" ]]
+then
+  export GIT_WORK_TREE=$GITHUB_WORKSPACE
+fi
+
+dashes=$( printf -- "-%.0s" {1..67} ) # why 67 hyphens? Who knows.
 header="${dashes}%n%cd - %an <%ae>"
 datef="%a %b %e %H:%M:%S %Z %Y"
-changes=${1:-skuba.changes.append}
 
-[ -f "${changes}" ] && rm "${changes}"
+changes=${1:-skuba.changes.append}
+# default to putting release body in same location as $changes file
+touch "$changes"
+release_body=${RELEASE_BODY:-$(find "$changes" -printf '%h/release_body.txt\n')}
 
 branch=$(git branch --show-current)
 
 mapfile -t tags < <( git tag --merged "${branch}" | sort -rV | head -n2 )
-scope="${tags[1]}...${tags[0]}"
+cur_tag=${CURRENT_TAG:-${tags[0]}}
+prv_tag=${PREV_TAG:-${tags[1]}}
+pretty_tag=${PRETTY_TAG:-${cur_tag##*/}} # make sure no "refs/tags/v..." format
 
+function bulleted_changelog {
+    scope=$1
+    git log \
+      --no-patch \
+      --no-merges \
+      --cherry-pick \
+      --format="%w(77,2,12)* %h %s" \
+      "$scope"
+}
+
+##########################################
+# Generate GitHub release body
 {
-    git show --format="${header}%n%n- Update to ${tags[0]}:" \
-        --date="format-local:${datef}" -s "${tags[0]}^{commit}"
-    git log -s --cherry-pick --format="%w(77,2,12)* %h %s" --no-merges "${scope}"
+    echo "Update to $pretty_tag"
+    bulleted_changelog "${prv_tag}...${cur_tag}"
+} > "${release_body}"
+
+##########################################
+# Generate OBS changelog file
+{
+    git show --format="${header}%n%n- Update to ${cur_tag}:" \
+        --date="format-local:${datef}" -s "${cur_tag}^{commit}"
+    bulleted_changelog "${prv_tag}...${cur_tag}"
     # Add empty line
-    echo
-} >> "${changes}"
+    echo ""
+} > "${changes}"

--- a/ci/packaging/suse/rpmfiles_maker.sh
+++ b/ci/packaging/suse/rpmfiles_maker.sh
@@ -1,40 +1,81 @@
 #!/bin/bash
+##########################################
+# generate skuba tar.gz and specfile
+##########################################
 
+##########################################
+# Housekeeping
 set -e
-
-susepkg_dir=$(cd "$( dirname "$0" )" && pwd)
 tmp_dir=$(mktemp -d -t skuba_XXXX)
-rpm_files="${susepkg_dir}/obs_files"
-devel_prj="Devel:CaaSP:4.0"
-version="$1"
-tag="$2"
-closest_tag="$3"
-
 log()   { (>&2 echo ">>> $*") ; }
 clean() { log "Cleaning temporary directory ${tmp_dir}"; rm -rf "${tmp_dir}"; }
+trap clean ERR
+susepkg_dir=$(cd "$( dirname "$0" )" && pwd)
+rpm_files="${susepkg_dir}/obs_files"
+devel_prj="Devel:CaaSP:4.0"
 
-if [ $# -ne 3 ]; then
+##########################################
+# CLI args
+if (( $# != 3 )); then
     log "usage: <version> <tag> <closest-tag>"
     exit 1
 fi
+version="$1"     # pretty version string for display 
+tag="$2"         # can be ugly refs/tags/xxx or specific commit hash
+closest_tag="$3" # usually $tag, but might be commit
 
-trap clean ERR
+##########################################
+# env vars which come from GitHub Actions
+TARBALL_PATH=${TARBALL_PATH:-${tmp_dir}/skuba.tar.gz}
+TEMPLATE_PATH=${TEMPLATE_PATH:-${susepkg_dir}/skuba_spec_template}
+SPECFILE_PATH=${SPECFILE_PATH:-${tmp_dir}/skuba.spec}
 
-rm -rf "${rpm_files}"
-mkdir -p "${rpm_files}"
-git archive --prefix=skuba/ -o "${tmp_dir}/skuba.tar.gz" HEAD
-sed -e "s|%%VERSION|${version}|;s|%%TAG|${tag}|;s|%%CLOSEST_TAG|${closest_tag}|" "${susepkg_dir}/skuba_spec_template" \
-    > "${tmp_dir}/skuba.spec"
-make CHANGES="${tmp_dir}/skuba.changes.append" suse-changelog
-cp "${tmp_dir}"/* "${rpm_files}"
-log "Find files for RPM package in ${rpm_files}"
+##########################################
+# other global stuff
 
-ibs_user=$(osc config https://api.suse.de user | awk '$0=$NF' || echo -n '')
-if [[ -n "$ibs_user" ]]
-then
+function main {
+    gen_tar
+    gen_spec
+    if [[ "${GITHUB_ACTIONS:-}" != "true" ]]
+    then
+        # GitHub Actions calls this script directly
+        make CHANGES="${tmp_dir}/skuba.changes.append" suse-changelog
+
+        # Assemble for OBS / manual use later 
+        rm -rf "${rpm_files}"
+        mkdir -p "${rpm_files}"
+        cp "${tmp_dir}"/* "${rpm_files}"
+        log "Find files for RPM package in ${rpm_files}"
+
+        ibs_user=$(osc config https://api.suse.de user | awk '$0=$NF' \
+                   || echo -n '')
+        if [[ -n "$ibs_user" ]]
+        then
+            do_ibs_update "$ibs_user"
+        fi
+    fi
+}
+
+# generate tarball
+function gen_tar {
+    log "Generating tarball at '$TARBALL_PATH'"
+    git archive --prefix=skuba/ -o "$TARBALL_PATH" "$tag"
+}
+
+# generate specfile
+function gen_spec {
+    log "Generating specfile at '$SPECFILE_PATH'"
+    sed -e "
+      s|%%VERSION|${version}|;
+      s|%%TAG|${tag}|;
+      s|%%CLOSEST_TAG|${closest_tag}|
+      " "$TEMPLATE_PATH" > "$SPECFILE_PATH"
+}
+
+function do_ibs_update {
     log "Found IBS config; updating IBS"
-    ibs_user=${ibs_user//\'}
-    branch_project="home:${ibs_user}:caasp_auto_release"
+    user=${1//\'}
+    branch_project="home:${user}:caasp_auto_release"
     branch_name="skuba_$tag"
     work_dir="$tmp_dir/ibs_skuba"
     log "Creating IBS branch"
@@ -56,6 +97,8 @@ then
     )
     osc -A 'https://api.suse.de' ci "$work_dir" \
       -m "$(<"$rpm_files/skuba.changes.append")"
-fi
+}
+
+main
 
 clean


### PR DESCRIPTION
Modify existing release scripts and create `create_release` GitHub workflow to
call them.

(cherry picked from commit 1fbc7a78deebcaf3b8796638bac211634cf98947)
Signed-off-by: Danny Sauer <dsauer@suse.com>

## Why is this PR needed?

Backport of PR #1371