### PR TITLE
Upgrade of k8s (CVE-2020-8564, CVE-2020-8565, bsc#1177660, bsc#1177661)

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -3,7 +3,7 @@ import time
 import yaml
 
 PREVIOUS_VERSION = "1.17.4"
-CURRENT_VERSION = "1.18.6"
+CURRENT_VERSION = "1.18.10"
 
 
 def check_node_is_ready(platform, kubectl, role, nr):

--- a/internal/pkg/skuba/kubeadm/configmap_test.go
+++ b/internal/pkg/skuba/kubeadm/configmap_test.go
@@ -354,8 +354,8 @@ func TestUpdateClusterConfigurationWithClusterVersion(t *testing.T) {
 			expectedAdmissionPlugins: []string{"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition", "Priority", "DefaultTolerationSeconds", "DefaultStorageClass", "PersistentVolumeClaimResize", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook", "ResourceQuota", "StorageObjectInUseProtection", "RuntimeClass", "NodeRestriction", "PodSecurityPolicy", "ExtendedResourceToleration"},
 		},
 		{
-			name:                    "1.18.6 without duplicates",
-			clusterVersion:          version.MustParseSemantic("1.18.6"),
+			name:                    "1.18.10 without duplicates",
+			clusterVersion:          version.MustParseSemantic("1.18.10"),
 			currentAdmissionPlugins: []string{},
 			expectedAdmissionPlugins: []string{
 				"NamespaceLifecycle", "LimitRanger", "ServiceAccount", "TaintNodesByCondition",

--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -86,6 +86,31 @@ type ClusterAddonsKnownVersions = func(clusterVersion *version.Version) AddonsVe
 
 var (
 	supportedVersions = KubernetesVersions{
+		"1.18.10": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.18.10",
+				ContainerRuntimeVersion: "1.18.2",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				APIServer:         &ContainerImageTag{Name: "kube-apiserver", Tag: "v1.18.10"},
+				ControllerManager: &ContainerImageTag{Name: "kube-controller-manager", Tag: "v1.18.10"},
+				Scheduler:         &ContainerImageTag{Name: "kube-scheduler", Tag: "v1.18.10"},
+				Proxy:             &ContainerImageTag{Name: "kube-proxy", Tag: "v1.18.10"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.2"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.7.6-rev3", 4501},
+				Kured:         &AddonVersion{"1.4.3", 4520},
+				Dex:           &AddonVersion{"2.23.0", 4500},
+				Gangway:       &AddonVersion{"3.1.0-rev5", 4500},
+				MetricsServer: &AddonVersion{"0.3.6", 4500},
+				Kucero:        &AddonVersion{"1.3.0", 4520},
+				PSP:           &AddonVersion{"", 4500},
+			},
+		},
 		"1.18.6": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.18.6",

--- a/internal/pkg/skuba/kubernetes/versions_test.go
+++ b/internal/pkg/skuba/kubernetes/versions_test.go
@@ -374,7 +374,7 @@ func TestMajorMinorVersion(t *testing.T) {
 func TestEnsureHyperKubeIsRemovedForSupportedVersions(t *testing.T) {
 	for kubernetesVersionStr := range supportedVersions {
 		kubernetesVersion := version.MustParseSemantic(kubernetesVersionStr)
-		versionComparedTo118, err := kubernetesVersion.Compare("1.18.6")
+		versionComparedTo118, err := kubernetesVersion.Compare("1.18.10")
 		if err != nil {
 			t.Fatalf("our versions should always be valid semver and something bad happened: %+v", err)
 		}


### PR DESCRIPTION
## Why is this PR needed?

This PR is required to fix SUSE/avant-garde#1993 and fix SUSE/avant-garde#1995.

## What does this PR do?

Multiple security issues have been discovered in Kubernetes that allow for the exposure of secret data in logs, when verbose logging options are enabled. Ungrading k8s to include upstream fixes.

### Related info

* SUSE/avant-garde#1993
* SUSE/avant-garde#1995
* bsc#1177660
* bsc#1177661
* CVE-2020-8564
* CVE-2020-8565