### PR TITLE
[CI]Fix worker set offline

### DIFF
--- a/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
  
                 timeout(180){
                     waitUntil { script {
-                        sh(script: "ssh -i ${JENKINS_ID} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T jenkins@${WORKER_HOST} true", returnStatus: true) == 0
+                        sh(script: "ssh -i ${JENKINS_ID} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T jenkins@${WORKER_HOST} sudo systemctl is-active --quiet swarm-client", returnStatus: true) == 0
                     }}
                 }
             }

--- a/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
                 echo 'rebooting ${WORKER_HOST} ...'
                 sh "ssh -i ${JENKINS_ID} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -T jenkins@${WORKER_HOST} sudo reboot &"
                
-                sleep 60
+                sleep 120
  
                 timeout(180){
                     waitUntil { script {


### PR DESCRIPTION
## Why is this PR needed?

During the upgrade test, the worker is rebooted to update the operating system. In some cases, this causes the worker to be set ofline and the job to fail.

Fixes https://github.com/SUSE/avant-garde/issues/2004

## What does this PR do

Waits for the jenkins client service to become ready after the reboot.

## Anything else a reviewer needs to know?

Tested in this job https://ci.suse.de/view/CaaSP/view/v4.5%20Dashboard/job/caasp-jobs/job/e2e/job/v4.5/job/vmware/job/upgrade-from-4-2-daily/64/

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
