### PR TITLE
Bump etcd version to 3.4.13

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -96,7 +96,7 @@ var (
 				ControllerManager: &ContainerImageTag{Name: "kube-controller-manager", Tag: "v1.18.10"},
 				Scheduler:         &ContainerImageTag{Name: "kube-scheduler", Tag: "v1.18.10"},
 				Proxy:             &ContainerImageTag{Name: "kube-proxy", Tag: "v1.18.10"},
-				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.3"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.13"},
 				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
 				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.2"},
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},


### PR DESCRIPTION
## Why is this PR needed?

This is needed to include upstream fixes as related in SUSE/avant-garde#1876 and it also fixes known issues as related in SUSE/avant-garde#1924

## What does this PR do?

Bumps etcd version from v3.4.3 up to v3.4.13.

Fixes SUSE/avant-garde#1924

## Info for QA

This PR is the fix for SUSE/avant-garde#1924 The migration process from 4.2.x series up to 4.5.z series should also upgrade the etcd container image.