### PR TITLE
Test Cilium with MTU size 1450

### DIFF
--- a/ci/infra/testrunner/tests/test_cilium.py
+++ b/ci/infra/testrunner/tests/test_cilium.py
@@ -52,3 +52,27 @@ def test_cillium(deployment, kubectl):
         time.sleep(30)
 
     assert all_reachable
+
+    logger.info("Change Cilium ConfigMap and set MTU 1450 bytes")
+    # Change Cilium ConfigMap and set MTU 1450 bytes
+    kubectl.run_kubectl("get configmap -n kube-system cilium-config -o json | jq '.data.mtu = \"1450\"'")
+    # Apply changes and restart cilium pods
+    kubectl.run_kubectl("delete pod -n kube-system -l name=cilium-operator")
+    kubectl.run_kubectl("delete pods -n kube-system -l k8s-app=cilium")
+
+    logger.info("Check status (N/N) with cilium MTU 1450")
+    cilium_podlist = kubectl.run_kubectl("get pods -n kube-system -l k8s-app=cilium -o jsonpath='{ .items[0].metadata.name }'").split(" ")
+    cilium_podid = cilium_podlist[0]
+    cilium_status_cmd = "-n kube-system exec {} -- cilium status".format(cilium_podid)
+    cilium_status = kubectl.run_kubectl(cilium_status_cmd)
+    assert re.search(r'Controller Status:\s+([0-9]+)/\1 healthy', cilium_status) is not None
+
+    for i in range(1, 10):
+        cilium_status = kubectl.run_kubectl(cilium_status_cmd)
+        all_reachable = re.search(r"Cluster health:\s+({})/\1 reachable".format(node_count), cilium_status)
+        if all_reachable:
+            break
+        time.sleep(30)
+
+    assert all_reachable
+


### PR DESCRIPTION
## Why is this PR needed?

We would like to test Cilium with different MTU size 1450 which is using our customer

## What does this PR do?

It is setting `mtu: "1450"` for cilium-config ConfigMap

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
