### PR TITLE
Use latest kubernetes package in upgrade test

### DIFF
--- a/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
+++ b/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
@@ -12,6 +12,12 @@ def migrate_node(platform, checker, kubectl, role, node, regcode, option=1):
     platform.ssh_run(role, node, (f'sudo zypper migration --migration {option}'
                                   ' --no-recommends --non-interactive'
                                   ' --auto-agree-with-licenses --allow-vendor-change'))
+
+    # update to latest kubernetes package version, if any
+    k8s_major, k8s_minor, _ =  CURRENT_VERSION.split('.')
+    platform.ssh_run(role, node, 'sudo zypper ar http://download.suse.de/ibs/Devel:/CaaSP:/4.5/SLE_15_SP2/ CaasP_Devel')
+    platform.ssh_run(role, node, ('sudo zypper update --allow-vendor-change -y'
+                                  f' kubernetes-{k8s_major}.{k8s_minor}-kubeadm'))
     #:FIXME use kured for controlled reboot.
     platform.ssh_run(role, node, "sudo reboot &")
 


### PR DESCRIPTION
## Why is this PR needed?


Fixes https://github.com/SUSE/avant-garde/issues/2013

## What does this PR do?

Adds CaaSP development repository and updates kubernetes package to latest development version before upgrading the node.

## Anything else a reviewer needs to know?

These changes were tested on the cluster created by [this failed execution of the upgrade test](https://ci.suse.de/view/CaaSP/view/v4.5%20Dashboard/job/caasp-jobs/job/e2e/job/v4.5/job/vmware/job/upgrade-from-4-2-daily/68/), and the cluster was correctly upgraded:
```
NAME                                                          STATUS   ROLE     OS-IMAGE                              KERNEL-VERSION         KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES   CAASP-RELEASE-VERSION
caasp-master-68-caasp-jobs-e2e-v4.5-vmware-upgrade-from-4-0   Ready    master   SUSE Linux Enterprise Server 15 SP2   5.3.18-24.29-default   v1.18.10          cri-o://1.18.2      no            no                       4.2.3
caasp-master-68-caasp-jobs-e2e-v4.5-vmware-upgrade-from-4-1   Ready    master   SUSE Linux Enterprise Server 15 SP2   5.3.18-24.29-default   v1.18.10          cri-o://1.18.2      no            no                       4.5.1
caasp-master-68-caasp-jobs-e2e-v4.5-vmware-upgrade-from-4-2   Ready    master   SUSE Linux Enterprise Server 15 SP2   5.3.18-24.29-default   v1.18.10          cri-o://1.18.2      no            no                       4.5.1
caasp-worker-68-caasp-jobs-e2e-v4.5-vmware-upgrade-from-4-0   Ready    <none>   SUSE Linux Enterprise Server 15 SP2   5.3.18-24.29-default   v1.18.10          cri-o://1.18.2      no            no                       4.5.1
caasp-worker-68-caasp-jobs-e2e-v4.5-vmware-upgrade-from-4-1   Ready    <none>   SUSE Linux Enterprise Server 15 SP2   5.3.18-24.29-default   v1.18.10          cri-o://1.18.2      no            no                       4.5.1
caasp-worker-68-caasp-jobs-e2e-v4.5-vmware-upgrade-from-4-2   Ready    <none>   SUSE Linux Enterprise Server 15 SP2   5.3.18-24.29-default   v1.18.10          cri-o://1.18.2      no            no 
```

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
