### PR TITLE
feat: refresh local addon base manifests (backport to v4.2)

### DIFF
--- a/ci/infra/testrunner/skuba/skuba.py
+++ b/ci/infra/testrunner/skuba/skuba.py
@@ -208,6 +208,13 @@ class Skuba:
         return self._run_skuba("cluster status")
 
     @step
+    def addon_refresh(self, action):
+        self._verify_bootstrap_dependency()
+        if action not in ['localconfig']:
+            raise ValueError("Invalid action '{}'".format(action))
+        return self._run_skuba("addon refresh {0}".format(action))
+
+    @step
     def addon_upgrade(self, action):
         self._verify_bootstrap_dependency()
         if action not in ['plan', 'apply']:

--- a/ci/infra/testrunner/tests/test_addon_upgrade.py
+++ b/ci/infra/testrunner/tests/test_addon_upgrade.py
@@ -56,6 +56,9 @@ def test_addon_upgrade_apply(deployment, kubectl, skuba):
     )
     assert not addons_up_to_date(skuba)
 
+    out = skuba.addon_refresh('localconfig')
+    assert out.find("Successfully refreshed addons base manifests") != -1
+
     out = skuba.addon_upgrade('apply')
     assert out.find("Successfully upgraded addons") != -1
     assert addons_up_to_date(skuba)

--- a/cmd/skuba/addon.go
+++ b/cmd/skuba/addon.go
@@ -31,6 +31,7 @@ func NewAddonCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		addons.NewRefreshCmd(),
 		addons.NewUpgradeCmd(),
 	)
 

--- a/cmd/skuba/addon/refresh.go
+++ b/cmd/skuba/addon/refresh.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	addons "github.com/SUSE/skuba/pkg/skuba/actions/addon/refresh"
+)
+
+// NewRefreshCmd creates a new `skuba addon refresh` cobra command
+func NewRefreshCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "refresh",
+		Short: "Manages addon refresh operations",
+	}
+
+	cmd.AddCommand(
+		newRefreshLocalConfigCmd(),
+	)
+
+	return cmd
+}
+
+func newRefreshLocalConfigCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "localconfig",
+		Short: "Update local cluster definition folder configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			clientSet, err := kubernetes.GetAdminClientSet()
+			if err != nil {
+				klog.Errorf("unable to get admin client set: %s", err)
+				os.Exit(1)
+			}
+			if err := addons.AddonsBaseManifest(clientSet); err != nil {
+				fmt.Printf("Unable to update addons base manifests: %s\n", err)
+				os.Exit(1)
+			}
+		},
+		Args: cobra.NoArgs,
+	}
+}

--- a/docs/man/skuba-addon-refresh-localconfig.1.md
+++ b/docs/man/skuba-addon-refresh-localconfig.1.md
@@ -1,0 +1,18 @@
+% skuba-addon-refresh-localconfig(1) # skuba addon refresh localconfig - Update local addon definition folder configuration
+
+# NAME
+
+localconfig - Update local addon definition folder configuration
+
+# SYNOPSIS
+**localconfig**
+[**--help**|**-h**]
+*localconfig* [-h]
+
+# DESCRIPTION
+**localconfig** Update local addon definition folder configuration
+
+# OPTIONS
+
+**--help, -h**
+  Print usage statement.

--- a/docs/man/skuba.1.md
+++ b/docs/man/skuba.1.md
@@ -44,5 +44,6 @@ reconfiguration in an easy way.
 **skuba-node-remove**(1),
 **skuba-node-upgrade-plan**(1),
 **skuba-node-upgrade-apply**(1),
+**skuba-addon-refresh-localconfig**(1),
 **skuba-addon-upgrade-plan**(1),
 **skuba-addon-upgrade-apply**(1)

--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -256,6 +256,10 @@ func (addon Addon) preflightManifestFilename() string {
 	return fmt.Sprintf("%s-preflight.yaml", addon.addon)
 }
 
+func (addon Addon) legacyManifestPath(rootDir string) string {
+	return filepath.Join(rootDir, addon.manifestFilename())
+}
+
 func (addon Addon) manifestPath(rootDir string) string {
 	return filepath.Join(addon.baseResourcesDir(rootDir), addon.manifestFilename())
 }
@@ -301,6 +305,15 @@ func (addon Addon) Write(addonConfiguration AddonConfiguration) error {
 	if err := os.MkdirAll(patchResourcesDir, 0700); err != nil {
 		return errors.Wrapf(err, "unable to create directory: %s", patchResourcesDir)
 	}
+
+	// migrates legacy addon manifest if existed
+	legacyManifestPath := addon.legacyManifestPath(addon.addonDir())
+	if f, err := os.Stat(legacyManifestPath); !os.IsNotExist(err) && !f.IsDir() {
+		if err := os.Remove(legacyManifestPath); err != nil {
+			return errors.Wrapf(err, "unable to remove %s addon legacy rendered template", addon.Addon)
+		}
+	}
+
 	if err := ioutil.WriteFile(addon.manifestPath(addon.addonDir()), []byte(addonTemplateWarning+addonManifest), 0600); err != nil {
 		return errors.Wrapf(err, "unable to write %s addon rendered template", addon.addon)
 	}

--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -305,6 +305,10 @@ func (addon Addon) kustomizePath(rootDir string) string {
 }
 
 func (addon Addon) compareLocalBaseManifest(addonConfiguration AddonConfiguration) (bool, error) {
+	if f, err := os.Stat(addon.legacyManifestPath(addon.addonDir())); !os.IsNotExist(err) && !f.IsDir() {
+		return false, nil
+	}
+
 	localManifest, err := ioutil.ReadFile(addon.manifestPath(addon.addonDir()))
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to read %s addon rendered template", addon.Addon)

--- a/internal/pkg/skuba/addons/addons_test.go
+++ b/internal/pkg/skuba/addons/addons_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package addons
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubernetes"
+	skubaconstants "github.com/SUSE/skuba/pkg/skuba"
+)
+
+func TestAddonLegacyManifestMigration(t *testing.T) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Errorf("unable to get current directory: %v", err)
+		return
+	}
+
+	defer func() {
+		// removes rendered addon folder
+		dir := filepath.Join(pwd, "addons")
+		if f, err := os.Stat(dir); !os.IsNotExist(err) && f.IsDir() {
+			if err := os.RemoveAll(dir); err != nil {
+				t.Errorf("unable to remove rendered addon folder: %v", err)
+				return
+			}
+		}
+	}()
+
+	// create legacy addons manifest folder
+	if err := os.Mkdir(filepath.Join(pwd, skubaconstants.AddonsDir()), 0700); err != nil {
+		t.Errorf("unable to create directory %s: %v", skubaconstants.AddonsDir(), err)
+		return
+	}
+	for _, addon := range Addons {
+		addonDir := filepath.Join(pwd, addon.addonDir())
+		if err := os.Mkdir(addonDir, 0700); err != nil {
+			t.Errorf("unable to create directory %s: %v", addonDir, err)
+			return
+		}
+		lagacyManifestPath := addon.legacyManifestPath(addonDir)
+		if err := ioutil.WriteFile(lagacyManifestPath, []byte(""), 0600); err != nil {
+			t.Errorf("unable to write legacy addon manifest: %v", err)
+			return
+		}
+	}
+
+	addonConfiguration := AddonConfiguration{
+		ClusterVersion: kubernetes.LatestVersion(),
+		ControlPlane:   "unit.test",
+		ClusterName:    "unit-test",
+	}
+	// render new addons manifest folder
+	for _, addon := range Addons {
+		if err := addon.Write(addonConfiguration); err != nil {
+			t.Errorf("expected no error, but got error: %v", err)
+			return
+		}
+	}
+
+	// check the legacy addons manifest gone
+	for _, addon := range Addons {
+		lagacyManifestPath := addon.legacyManifestPath(filepath.Join(pwd, addon.addonDir()))
+		if _, err := os.Stat(lagacyManifestPath); !os.IsNotExist(err) {
+			t.Error("expected legacy manifest not exists")
+			return
+		}
+	}
+}

--- a/pkg/skuba/actions/addon/refresh/localconfig.go
+++ b/pkg/skuba/actions/addon/refresh/localconfig.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package refresh
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"github.com/SUSE/skuba/internal/pkg/skuba/addons"
+	"github.com/SUSE/skuba/internal/pkg/skuba/kubeadm"
+)
+
+// AddonsBaseManifest implements the `skuba addon refresh localconfig` command.
+func AddonsBaseManifest(client clientset.Interface) error {
+	currentClusterVersion, err := kubeadm.GetCurrentClusterVersion(client)
+	if err != nil {
+		return err
+	}
+
+	clusterConfiguration, err := kubeadm.GetClusterConfiguration(client)
+	if err != nil {
+		return errors.Wrap(err, "Could not fetch cluster configuration")
+	}
+
+	// re-render all addons manifest
+	addonConfiguration := addons.AddonConfiguration{
+		ClusterVersion: currentClusterVersion,
+		ControlPlane:   clusterConfiguration.ControlPlaneEndpoint,
+		ClusterName:    clusterConfiguration.ClusterName,
+	}
+	for addonName, addon := range addons.Addons {
+		if err := addon.Write(addonConfiguration); err != nil {
+			return errors.Wrapf(err, "failed to refresh addon %s manifest", string(addonName))
+		}
+	}
+
+	fmt.Println("Successfully refreshed addons base manifests")
+	return nil
+}

--- a/pkg/skuba/actions/addon/refresh/localconfig.go
+++ b/pkg/skuba/actions/addon/refresh/localconfig.go
@@ -46,6 +46,9 @@ func AddonsBaseManifest(client clientset.Interface) error {
 		ClusterName:    clusterConfiguration.ClusterName,
 	}
 	for addonName, addon := range addons.Addons {
+		if !addon.IsPresentForClusterVersion(currentClusterVersion) {
+			continue
+		}
 		if err := addon.Write(addonConfiguration); err != nil {
 			return errors.Wrapf(err, "failed to refresh addon %s manifest", string(addonName))
 		}

--- a/pkg/skuba/actions/node/bootstrap/bootstrap.go
+++ b/pkg/skuba/actions/node/bootstrap/bootstrap.go
@@ -80,7 +80,8 @@ func Bootstrap(bootstrapConfiguration deployments.BootstrapConfiguration, target
 		ControlPlane:   initConfiguration.ControlPlaneEndpoint,
 		ClusterName:    initConfiguration.ClusterName,
 	}
-	if err := addons.DeployAddons(clientSet, addonConfiguration); err != nil {
+	dryRun := false
+	if err := addons.DeployAddons(clientSet, addonConfiguration, dryRun); err != nil {
 		return err
 	}
 

--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -19,6 +19,7 @@ package upgrade
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -161,6 +162,10 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		if err != nil {
 			return err
 		}
+		err = downloadAdminConf(target)
+		if err != nil {
+			return err
+		}
 	} else if err := target.Apply(nil, "kubeadm.upgrade.node"); err != nil {
 		return err
 	}
@@ -223,5 +228,17 @@ func fillTargetWithNodeNameAndRole(client clientset.Interface, target *deploymen
 	}
 	target.Role = &role
 
+	return nil
+}
+
+func downloadAdminConf(target *deployments.Target) error {
+	fmt.Printf("Downloading admin.conf from upgrade node %q\n", target.Target)
+	secretData, err := target.DownloadFileContents("/etc/kubernetes/admin.conf")
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile("admin.conf", []byte(secretData), 0600); err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
## Why is this PR needed?

The addons base manifest will be outdated because skuba did not provide a way to update the base addons manifest.
As time goes by, the addon manifest data structure/key might change, it causes the user's kustomize patch is not valid anymore.

We need to provide a command `skuba addon refresh localconfig` to upgrade existed base addons manifest, also we'll help to migrate legacy addon manifest folder definition. Note that, we'll not keep the content of the legacy add-on manifest if the admin had changed the default value in it.

More, we perform a dry-run check before applied to the current Kubernetes cluster, the user provides kustomize patch manifests might have some problem like manifest indentation error.

Therefore, for `skuba addon upgrade plan`, we not only display is there any new addon or existed addon need to be upgraded, moreover, we also perform the Kubernetes server-side validation by running `kubectl apply -k addons/<addon> --dry-run=server` and outputs the stderr to the user if present.

Besides, we'll generate `kustomization.yaml` inside `addons/<addon>` to make the user have the ability to run `kubectl apply -k addons/<addon>` after addons upgraded because the user might want to add more patches into the cluster and make sure the patches manifests will keep overtime for each add-on upgrade.

Last not the least, before actually perform the `skuba addon upgrade [plan|apply]`, we will check the local addons base manifests match to the current Kubernetes cluster version, to make sure it's up-to-date.

## What does this PR do?

backport #1226 #1247
reference to https://github.com/SUSE/avant-garde/issues/2032

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

We did not have a command to update the local cluster definition folder before, the only way is to create a temporary cluster definition folder and replace the existed local cluster definition folder. For example:

1. we have existed local cluster definition folder called `my-cluster`
2. create a temporary cluster definition folder: `skuba cluster init --control-plane <IP/FQDN> temp-cluster`
3. copy `temp-cluster/addons/<addon>/base/<addon>.yaml` to `my-cluster/addons/<addon>/base/<addon>.yaml`
4. the `kustomization.yaml` does not existed inside `addons/<addon>`
5. the `skuba addon upgrade plan` won't do Kubernetes server-side dry-run

### Status **AFTER** applying the patch

We have a new command to update the local cluster definition folder to the current Kubernetes version. For example:

1. we have an existed local cluster definition folder called `my-cluster`
2. run `skuba addon upgrade [plan|apply]`, it checks the local addons base manifests is up-to-date
3. run `skuba addon refresh localconfig` inside folder `my-cluster` to updates base add-on manifest
4. run `skuba addon upgrade [plan|apply]`, it generates the `kustomization.yaml` inside each `addon/<addon>`
5. run `skuba addon upgrade plan`, it performs Kubernetes server-side dry-run

## Docs

WIP

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
