### PR TITLE
fix: check the addon belongs to current cluster version

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -322,6 +322,10 @@ func (addon Addon) kustomizePath(rootDir string) string {
 }
 
 func (addon Addon) compareLocalBaseManifest(addonConfiguration AddonConfiguration) (bool, error) {
+	if f, err := os.Stat(addon.legacyManifestPath(addon.addonDir())); !os.IsNotExist(err) && !f.IsDir() {
+		return false, nil
+	}
+
 	localManifest, err := ioutil.ReadFile(addon.manifestPath(addon.addonDir()))
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to read %s addon rendered template", addon.Addon)

--- a/pkg/skuba/actions/addon/refresh/localconfig.go
+++ b/pkg/skuba/actions/addon/refresh/localconfig.go
@@ -46,6 +46,9 @@ func AddonsBaseManifest(client clientset.Interface) error {
 		ClusterName:    clusterConfiguration.ClusterName,
 	}
 	for addonName, addon := range addons.Addons {
+		if !addon.IsPresentForClusterVersion(currentClusterVersion) {
+			continue
+		}
 		if err := addon.Write(addonConfiguration); err != nil {
 			return errors.Wrapf(err, "failed to refresh addon %s manifest", string(addonName))
 		}


### PR DESCRIPTION
## Why is this PR needed?

If the existing local addon manifest is the legacy format, run `skuba addon refresh localconfig` or `skuba addon upgrade [plan|apply]` would panic.

## What does this PR do?

1. check is the local addon manifest matches the legacy format
2. fetch the add-ons list from the current Kubernetes cluster version.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

1. `skuba cluster init` with skuba before 4.2.0
2. build skuba on the master branch
3. run `skuba addon refresh localconfig` or `skuba addon upgrade [plan|apply]`, skuba panic

### Status **AFTER** applying the patch

1. `skuba cluster init` with skuba before 4.2.0
2. build skuba with this PR
3. run `skuba addon refresh localconfig` or `skuba addon upgrade [plan|apply]`, skuba would not panic anymore

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
