### PR TITLE
Allow to upgrade addons

### DIFF
--- a/pkg/skuba/actions/addon/upgrade/apply.go
+++ b/pkg/skuba/actions/addon/upgrade/apply.go
@@ -48,7 +48,7 @@ func Apply(client clientset.Interface) error {
 	fmt.Println()
 
 	if !allNodesMatchClusterVersion {
-		return errors.Errorf("[apply] Not all nodes match clusterVersion %s", currentVersion)
+		fmt.Printf("[apply] Not all nodes match clusterVersion %s\n", currentVersion)
 	}
 
 	clusterConfiguration, err := kubeadm.GetClusterConfiguration(client)


### PR DESCRIPTION
## Why is this PR needed?

There might be situation for multi-master setup when
```
> skuba node upgrade apply --target <MASTER2> -s -u sles -v 5

Unable to apply node upgrade: node master02 cannot be upgraded yet. The following errors were detected:
 - There are addon upgrades available for the current cluster version (1.17.13) that need to be applied first

> skuba addon upgrade apply                                   

Unable to Apply addons upgrade: [apply] Not all nodes match clusterVersion 1.17.13

> skuba node upgrade apply --target <MASTER2> -s -u sles -v 5

Unable to apply node upgrade: node master02 cannot be upgraded yet. The following errors were detected:
 - There are addon upgrades available for the current cluster version (1.17.13) that need to be applied first
```

## What does this PR do?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
