### PR TITLE
Fix nodeVersion for all upgrade plan

### DIFF
--- a/pkg/skuba/actions/cluster/upgrade/plan.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan.go
@@ -86,9 +86,17 @@ func plan(client clientset.Interface, availableVersions []*version.Version, clus
 			if nodeVersionInfo.EqualsClusterVersion(currentClusterVersion) {
 				fmt.Printf("  - %s: up to date", nodeName)
 			} else if !nodeVersionInfo.ToleratesClusterVersion(currentClusterVersion) {
-				fmt.Printf("  - %s; current version: %s (upgrade required)", nodeName, nodeVersionInfo.String())
+				if nodeVersionInfo.IsControlPlane() {
+					fmt.Printf("  - %s; current kubelet package version: %s, kube-apiserver container version: %s (upgrade required)", nodeName, nodeVersionInfo.KubeletVersion.String(), nodeVersionInfo.APIServerVersion.String())
+				} else {
+					fmt.Printf("  - %s; current kubelet package version: %s (upgrade required)", nodeName, nodeVersionInfo.KubeletVersion.String())
+				}
 			} else {
-				fmt.Printf("  - %s; current version: %s (upgrade suggested)", nodeName, nodeVersionInfo.String())
+				if nodeVersionInfo.IsControlPlane() {
+					fmt.Printf("  - %s; current kubelet package version: %s, kube-apiserver container version: %s (upgrade suggested)", nodeName, nodeVersionInfo.KubeletVersion.String(), nodeVersionInfo.APIServerVersion.String())
+				} else {
+					fmt.Printf("  - %s; current kubelet package version: %s (upgrade suggested)", nodeName, nodeVersionInfo.KubeletVersion.String())
+				}
 			}
 			if nodeVersionInfo.Unschedulable() {
 				fmt.Println("; unschedulable, ignored")

--- a/pkg/skuba/actions/cluster/upgrade/plan_test.go
+++ b/pkg/skuba/actions/cluster/upgrade/plan_test.go
@@ -86,7 +86,7 @@ Latest Kubernetes version: 1.16.0
 
 Some nodes do not match the current cluster version (1.16.0):
   - control-plane-0: up to date
-  - worker-0; current version: 1.14.0 (upgrade required)
+  - worker-0; current kubelet package version: 1.14.0 (upgrade required)
 
 Addons at the current cluster version 1.16.0 are up to date.
 `,
@@ -106,7 +106,7 @@ Latest Kubernetes version: 1.16.0
 
 Some nodes do not match the current cluster version (1.16.0):
   - control-plane-0: up to date
-  - worker-unschedulable-0; current version: 1.14.0 (upgrade required); unschedulable, ignored
+  - worker-unschedulable-0; current kubelet package version: 1.14.0 (upgrade required); unschedulable, ignored
 
 Addons at the current cluster version 1.16.0 are up to date.
 `,
@@ -127,7 +127,7 @@ Latest Kubernetes version: 1.16.1
 
 Some nodes do not match the current cluster version (1.16.1):
   - control-plane-0: up to date
-  - worker-0; current version: 1.16.0 (upgrade suggested)
+  - worker-0; current kubelet package version: 1.16.0 (upgrade suggested)
 
 Addons at the current cluster version 1.16.1 are up to date.
 `,
@@ -148,7 +148,7 @@ Latest Kubernetes version: 1.16.0
 
 Some nodes do not match the current cluster version (1.16.0):
   - control-plane-0: up to date
-  - worker-0; current version: 1.15.0 (upgrade suggested)
+  - worker-0; current kubelet package version: 1.15.0 (upgrade suggested)
 
 Addons at the current cluster version 1.16.0 are up to date.
 `,
@@ -261,7 +261,7 @@ Latest Kubernetes version: 1.17.0
 
 Some nodes do not match the current cluster version (1.17.0):
   - control-plane-0: up to date
-  - worker-0; current version: 1.16.0 (upgrade suggested)
+  - worker-0; current kubelet package version: 1.16.0 (upgrade suggested)
 
 Addon upgrades for 1.17.0:
   - cilium: 1.0.1 -> 1.0.2


### PR DESCRIPTION
(cherry picked from commit 11f2c49d4adc3889a9891b73fffa04a2eeb42db7)
Signed-off-by: Danny Sauer <dsauer@suse.com>

## Why is this PR needed?

Backport version detection code to 4.2.x

This backport (and the tag) was added to branch after the previous PR was merged.  This branch can be deleted after merging if so desired, but it would be ideal to merge this one instead of backporting again so the 1.4.5 tag will continue to work properly. :)