### PR TITLE
fix: renew admin.conf when node upgrade (bsc#1176903) (backport to v4.2)

### DIFF
--- a/pkg/skuba/actions/node/upgrade/apply.go
+++ b/pkg/skuba/actions/node/upgrade/apply.go
@@ -19,6 +19,7 @@ package upgrade
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -161,6 +162,10 @@ func Apply(client clientset.Interface, target *deployments.Target) error {
 		if err != nil {
 			return err
 		}
+		err = downloadAdminConf(target)
+		if err != nil {
+			return err
+		}
 	} else if err := target.Apply(nil, "kubeadm.upgrade.node"); err != nil {
 		return err
 	}
@@ -223,5 +228,17 @@ func fillTargetWithNodeNameAndRole(client clientset.Interface, target *deploymen
 	}
 	target.Role = &role
 
+	return nil
+}
+
+func downloadAdminConf(target *deployments.Target) error {
+	fmt.Printf("Downloading admin.conf from upgrade node %q\n", target.Target)
+	secretData, err := target.DownloadFileContents("/etc/kubernetes/admin.conf")
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile("admin.conf", []byte(secretData), 0600); err != nil {
+		return err
+	}
 	return nil
 }


### PR DESCRIPTION
## Why is this PR needed?

To download the remotely upgraded admin.conf to local to refresh the client certificate.

Fixes bsc#1176903
reference to https://github.com/SUSE/avant-garde/issues/2031

## What does this PR do?

After the first control plane upgraded, download the remotely upgraded admin.conf to local to refresh the client certificate.

## Anything else a reviewer needs to know?

When `kubeadm upgrade apply`, kubeadm will renews the client certificate admin.conf on control plane nodes.

## Info for QA

### Related info

N/A
### Status **BEFORE** applying the patch

skuba upgrade the Kubernetes cluster, it won't download the updated client certificate admin.conf from remote control plane node to locally.

### Status **AFTER** applying the patch

skuba performs the first control plane node upgrade, it will download the updated client certificate admin.conf from the remote control plane node to locally.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
