### PR TITLE
Add file permission for upload file method to fix CVE-2020-8029 (bsc#1177362)

### DIFF
--- a/internal/pkg/skuba/deployments/deployments.go
+++ b/internal/pkg/skuba/deployments/deployments.go
@@ -20,13 +20,14 @@ package deployments
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"k8s.io/klog"
 )
 
 type Actionable interface {
 	Apply(data interface{}, states ...string) error
-	UploadFileContents(targetPath, contents string) error
+	UploadFileContents(targetPath, contents string, perm os.FileMode) error
 	DownloadFileContents(sourcePath string) (string, error)
 	IsServiceEnabled(serviceName string) (bool, error)
 }
@@ -55,16 +56,16 @@ func (t *Target) Apply(data interface{}, states ...string) error {
 	return t.Actionable.Apply(data, filteredStates...)
 }
 
-func (t *Target) UploadFile(sourcePath, targetPath string) error {
+func (t *Target) UploadFile(sourcePath, targetPath string, perm os.FileMode) error {
 	klog.V(1).Infof("uploading local file %q to remote file %q", sourcePath, targetPath)
 	if contents, err := ioutil.ReadFile(sourcePath); err == nil {
-		return t.UploadFileContents(targetPath, string(contents))
+		return t.UploadFileContents(targetPath, string(contents), perm)
 	}
 	return fmt.Errorf("could not find file %s", sourcePath)
 }
 
-func (t *Target) UploadFileContents(targetPath, contents string) error {
-	return t.Actionable.UploadFileContents(targetPath, contents)
+func (t *Target) UploadFileContents(targetPath, contents string, perm os.FileMode) error {
+	return t.Actionable.UploadFileContents(targetPath, contents, perm)
 }
 
 func (t *Target) DownloadFileContents(sourcePath string) (string, error) {

--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -48,7 +48,7 @@ func criConfigure(t *Target, data interface{}) error {
 	}()
 
 	for _, f := range criFiles {
-		if err := t.target.UploadFile(filepath.Join(skuba.CriConfDir(), f.Name()), filepath.Join("/tmp/crio.conf.d", f.Name())); err != nil {
+		if err := t.target.UploadFile(filepath.Join(skuba.CriConfDir(), f.Name()), filepath.Join("/tmp/crio.conf.d", f.Name()), f.Mode()); err != nil {
 			return err
 		}
 	}
@@ -60,7 +60,9 @@ func criConfigure(t *Target, data interface{}) error {
 		return err
 	}
 
-	if _, err := os.Stat(filepath.Join(skuba.ContainersDir(), "registries.conf")); err != nil {
+	registriesConfPath := filepath.Join(skuba.ContainersDir(), "registries.conf")
+	f, err := os.Stat(registriesConfPath)
+	if err != nil {
 		return nil
 	}
 	defer func() {
@@ -72,7 +74,7 @@ func criConfigure(t *Target, data interface{}) error {
 		}
 	}()
 
-	if err := t.target.UploadFile(filepath.Join(skuba.ContainersDir(), "registries.conf"), filepath.Join("/tmp/containers", "registries.conf")); err != nil {
+	if err := t.target.UploadFile(registriesConfPath, filepath.Join("/tmp/containers", "registries.conf"), f.Mode()); err != nil {
 		return err
 	}
 

--- a/internal/pkg/skuba/deployments/ssh/files.go
+++ b/internal/pkg/skuba/deployments/ssh/files.go
@@ -20,6 +20,7 @@ package ssh
 import (
 	"encoding/base64"
 	"fmt"
+	"os"
 	"path"
 
 	"k8s.io/klog"
@@ -27,7 +28,7 @@ import (
 
 // UploadFileContents creates a file with the content sent
 // into a target system's specific path.
-func (t *Target) UploadFileContents(targetPath, contents string) error {
+func (t *Target) UploadFileContents(targetPath, contents string, perm os.FileMode) error {
 	klog.V(1).Infof("uploading to remote file %q with contents", targetPath)
 	dir, _ := path.Split(targetPath)
 	encodedContents := base64.StdEncoding.EncodeToString([]byte(contents))

--- a/internal/pkg/skuba/deployments/ssh/files.go
+++ b/internal/pkg/skuba/deployments/ssh/files.go
@@ -35,31 +35,11 @@ func (t *Target) UploadFileContents(targetPath, contents string, perm os.FileMod
 	if _, _, err := t.silentSsh("mkdir", "-p", dir); err != nil {
 		return err
 	}
-	_, _, err := t.silentSshWithStdin(encodedContents, "umask", osFileModeToUmaskSymbolMode(perm), "&&", "base64", "-d", "-w0", fmt.Sprintf("> %s", targetPath))
-	return err
-}
-
-func osFileModeToUmaskSymbolMode(perm os.FileMode) string {
-	permS := perm.String()
-	mask := ""
-	umask := ""
-
-	for i := 1; i < len(permS); i++ {
-		if permS[i] != '-' {
-			mask = mask + string(permS[i])
-		}
-		switch i {
-		case 3:
-			umask = fmt.Sprintf("u=%s,", mask)
-			mask = ""
-		case 6:
-			umask = umask + fmt.Sprintf("g=%s,", mask)
-			mask = ""
-		case 9:
-			umask = umask + fmt.Sprintf("o=%s", mask)
-		}
+	if _, _, err := t.silentSsh("install", "-m", fmt.Sprintf("%04o", perm), "/dev/null", targetPath); err != nil {
+		return err
 	}
-	return umask
+	_, _, err := t.silentSshWithStdin(encodedContents, "base64", "-d", "-w0", fmt.Sprintf("> %s", targetPath))
+	return err
 }
 
 // DownloadFileContents gets the content of a file in a target system

--- a/internal/pkg/skuba/deployments/ssh/kernel.go
+++ b/internal/pkg/skuba/deployments/ssh/kernel.go
@@ -97,12 +97,12 @@ func loadModule(t *Target, module string) error {
 	if _, _, err := t.ssh(fmt.Sprintf("modprobe %s", module)); err != nil {
 		return err
 	}
-	return t.UploadFileContents(fmt.Sprintf("/etc/modules-load.d/skuba-%s.conf", module), module)
+	return t.UploadFileContents(fmt.Sprintf("/etc/modules-load.d/skuba-%s.conf", module), module, 0644)
 }
 
 func configureParameter(t *Target, name, attribute, value string) error {
 	if _, _, err := t.ssh(fmt.Sprintf("sysctl -w %s=%s", attribute, value)); err != nil {
 		return err
 	}
-	return t.UploadFileContents(fmt.Sprintf("/etc/sysctl.d/90-skuba-%s.conf", name), fmt.Sprintf("%s=%s", attribute, value))
+	return t.UploadFileContents(fmt.Sprintf("/etc/sysctl.d/90-skuba-%s.conf", name), fmt.Sprintf("%s=%s", attribute, value), 0644)
 }

--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -19,6 +19,7 @@ package ssh
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -47,8 +48,12 @@ func kubeadmInit(t *Target, data interface{}) error {
 	if err != nil {
 		return err
 	}
+	f, err := os.Stat(skubaconstants.KubeadmInitConfFile())
+	if err != nil {
+		return err
+	}
 	remoteKubeadmInitConfFile := filepath.Join(tempDir, skubaconstants.KubeadmInitConfFile())
-	err = t.target.UploadFile(skubaconstants.KubeadmInitConfFile(), remoteKubeadmInitConfFile)
+	err = t.target.UploadFile(skubaconstants.KubeadmInitConfFile(), remoteKubeadmInitConfFile, f.Mode())
 	if err != nil {
 		return err
 	}
@@ -89,8 +94,12 @@ func kubeadmJoin(t *Target, data interface{}) error {
 	if err != nil {
 		return err
 	}
+	f, err := os.Stat(configPath)
+	if err != nil {
+		return err
+	}
 	remoteKubeadmInitConfFile := filepath.Join(tempDir, skubaconstants.KubeadmInitConfFile())
-	err = t.target.UploadFile(configPath, remoteKubeadmInitConfFile)
+	err = t.target.UploadFile(configPath, remoteKubeadmInitConfFile, f.Mode())
 	if err != nil {
 		return err
 	}
@@ -124,7 +133,7 @@ func kubeadmUpgradeApply(t *Target, data interface{}) error {
 	}
 
 	remoteKubeadmUpgradeConfFile := filepath.Join("/tmp/", skubaconstants.KubeadmUpgradeConfFile())
-	if err := t.target.UploadFileContents(remoteKubeadmUpgradeConfFile, upgradeConfiguration.KubeadmConfigContents); err != nil {
+	if err := t.target.UploadFileContents(remoteKubeadmUpgradeConfFile, upgradeConfiguration.KubeadmConfigContents, 0644); err != nil {
 		return err
 	}
 	defer func() {

--- a/internal/pkg/skuba/deployments/ssh/oidc.go
+++ b/internal/pkg/skuba/deployments/ssh/oidc.go
@@ -18,6 +18,7 @@
 package ssh
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/SUSE/skuba/internal/pkg/skuba/deployments"
@@ -47,7 +48,12 @@ func oidcCAUpload(t *Target, data interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := t.target.UploadFile(filepath.Join(skuba.PkiDir(), oidc.CACertFileName), remoteOIDCCAFilePath); err != nil {
+	caCertPath := filepath.Join(skuba.PkiDir(), oidc.CACertFileName)
+	f, err := os.Stat(caCertPath)
+	if err != nil {
+		return err
+	}
+	if err := t.target.UploadFile(filepath.Join(skuba.PkiDir(), oidc.CACertFileName), remoteOIDCCAFilePath, f.Mode()); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Why is this PR needed?

fix CVE-2020-8029 (aka bsc#1177362), add file permission for the upload file method.
It prevents when uploading the key, the attacker could steal the key by watching the file
because the file creates with permission `0644` first, and then `chmod` to `0400`.

Fixes bsc#1177362
Fixes CVE-2020-8029

## What does this PR do?

Add set the file permission parameter to `UploadFile`/`UploadFileContents` method
- caller `UploadFile`: it re-uses the local file's permission
- caller `UploadFileContents`: it uses file permission `0644` 

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

### Related info

N/A

### Status **BEFORE** applying the patch

When node bootstrap/join, we could use another user account and watch `/var/lib/kubelet/pki/kubelet.key`, this user has the ability to get the content of `/var/lib/kubelet/pki/kubelet.key` since the file permission is `0644` when creating, and then set to `0400`.

### Status **AFTER** applying the patch

When node bootstrap/join, we could not use another user account to get the content of `/var/lib/kubelet/pki/kubelet.key` since the file permission re-uses the local file permission `0600`.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
