### PR TITLE
Check if kubelet was upgraded before kube-apiserver

### DIFF
--- a/internal/pkg/skuba/kubernetes/node_version.go
+++ b/internal/pkg/skuba/kubernetes/node_version.go
@@ -259,7 +259,7 @@ func AllControlPlanesMatchVersionWithVersioningInfo(allNodesVersioningInfo NodeV
 		if !nodeInfo.IsControlPlane() {
 			continue
 		}
-		if !nodeInfo.ToleratesClusterVersion(clusterVersion) {
+		if !nodeInfo.EqualsClusterVersion(clusterVersion) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Why is this PR needed?

We have to check if kubelet package was upgraded before kube-apiserver, which is incorrect.

## What does this PR do?

Checking if kubelet package is in right version.

## Anything else a reviewer needs to know?

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
