### PR TITLE
Bump coredns to include CVE-2019-19794 fix (bsc#1159274)

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -97,7 +97,7 @@ var (
 				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.13"},
 				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.13"},
 				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.13"},
-				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.5"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
 				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},


### PR DESCRIPTION
Upgrade coredns from 1.6.5 to 1.6.7

## Why is this PR needed?

Includes CVE-2019-19794

Fixes SUSE/avant-garde#2034

## What does this PR do?

States skuba to use 1.6.7 coredns container image

