### PR TITLE
Remove kucero addon for k8s 1.17.4

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -132,7 +132,6 @@ var (
 				Dex:           &AddonVersion{"2.16.0-rev6", 7},
 				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
 				MetricsServer: &AddonVersion{"0.3.6", 1},
-				Kucero:        &AddonVersion{"1.3.0", 0},
 				PSP:           &AddonVersion{"", 4},
 			},
 		},


### PR DESCRIPTION
Kucero backport was done before including 1.17.13 k8s in versions.go as
a consequence it was backported for 1.17.4 release which is not the
intended result. Kucero should only appear in versions.go starting from
1.17.13 k8s version.