### PR TITLE
Check if kubelet was upgraded before APIserver

### DIFF
--- a/internal/pkg/skuba/kubernetes/node_version.go
+++ b/internal/pkg/skuba/kubernetes/node_version.go
@@ -118,14 +118,25 @@ func (nvi NodeVersionInfo) DriftsFromClusterVersion(clusterVersion *version.Vers
 
 func (nvi NodeVersionInfo) ToleratesClusterVersion(clusterVersion *version.Version) bool {
 	if nvi.IsControlPlane() {
+		// When worker checks for tolerates cluster version, the API servers should ALL have been
+		// upgraded at the same version. No drift should be allowed.
 		if nvi.APIServerVersion.Major() != clusterVersion.Major() ||
-			nvi.APIServerVersion.Minor() != clusterVersion.Minor() {
+			(nvi.APIServerVersion.Major() == clusterVersion.Major() &&
+				nvi.APIServerVersion.Minor() != clusterVersion.Minor()) ||
+			(nvi.APIServerVersion.Major() == clusterVersion.Major() &&
+				nvi.APIServerVersion.Minor() == clusterVersion.Minor() &&
+				nvi.APIServerVersion.Patch() != clusterVersion.Patch()) {
 			return false
 		}
 	}
 
-	return nvi.KubeletVersion.Minor() == clusterVersion.Minor() ||
-		nvi.KubeletVersion.Minor()+1 == clusterVersion.Minor()
+	// When checking this function, we should prevent kubelets from being ahead.
+	// We should only tolerate the workers to be lagging behind before upgrading them
+	return (nvi.KubeletVersion.Major() == clusterVersion.Major() &&
+		nvi.KubeletVersion.Minor()+1 == clusterVersion.Minor()) ||
+		(nvi.KubeletVersion.Major() == clusterVersion.Major() &&
+			nvi.KubeletVersion.Minor() == clusterVersion.Minor() &&
+			nvi.KubeletVersion.Patch() <= clusterVersion.Patch())
 }
 
 // AllNodesVersioningInfo returns the version info for all nodes in the cluster

--- a/internal/pkg/skuba/kubernetes/node_version_test.go
+++ b/internal/pkg/skuba/kubernetes/node_version_test.go
@@ -462,18 +462,18 @@ func TestToleratesFromClusterVersion(t *testing.T) {
 			expectReturn:     false,
 		},
 		{
-			name:             "master node patch version is one less than as cluster version",
+			name:             "master node (kubelet) patch version is one less than as cluster version",
 			isMaster:         true,
-			apiServerVersion: patchLess,
+			apiServerVersion: clusterVersion,
 			kubeletVersion:   patchLess,
 			expectReturn:     true,
 		},
 		{
-			name:             "master node patch version is one greater than as cluster version",
+			name:             "master node (kubelet) patch version is one greater than as cluster version",
 			isMaster:         true,
-			apiServerVersion: patchMore,
+			apiServerVersion: clusterVersion,
 			kubeletVersion:   patchMore,
-			expectReturn:     true,
+			expectReturn:     false,
 		},
 		{
 			name:           "worker node version is same as cluster version",
@@ -498,7 +498,7 @@ func TestToleratesFromClusterVersion(t *testing.T) {
 		{
 			name:           "worker node patch version is one greater than cluster version",
 			kubeletVersion: patchMore,
-			expectReturn:   true,
+			expectReturn:   false,
 		},
 	}
 

--- a/internal/pkg/skuba/upgrade/node/versions.go
+++ b/internal/pkg/skuba/upgrade/node/versions.go
@@ -98,6 +98,19 @@ func (nviu NodeVersionInfoUpdate) NodeUpgradeableCheck(client clientset.Interfac
 	if err != nil {
 		return err
 	}
+
+	// Explain user to downgrade kubelet package when it was installed ahead kube-apiserver.
+	if nviu.Current.IsControlPlane() {
+		if nviu.Current.KubeletVersion.Major() > nviu.Current.APIServerVersion.Major() ||
+			(nviu.Current.KubeletVersion.Major() == nviu.Current.APIServerVersion.Major() &&
+				nviu.Current.KubeletVersion.Minor() > nviu.Current.APIServerVersion.Minor()) ||
+			(nviu.Current.KubeletVersion.Major() == nviu.Current.APIServerVersion.Major() &&
+				nviu.Current.KubeletVersion.Minor() == nviu.Current.APIServerVersion.Minor() &&
+				nviu.Current.KubeletVersion.Patch() > nviu.Current.APIServerVersion.Patch()) {
+			errorMessages = append(errorMessages, fmt.Sprintf("Kubelet is in higher version than kube-apiserver, please downgrade kubelet package to version %s", currentClusterVersion))
+		}
+	}
+
 	if isFirstControlPlaneNodeToBeUpgraded {
 		// First check if all schedulable workers will tolerate the version we are upgrading to. If they don't, they need to be upgraded first.
 		upgradeable, err := kubernetes.AllWorkerNodesTolerateVersion(client, nviu.Update.APIServerVersion)


### PR DESCRIPTION
## Why is this PR needed?

We have to check if kubelet package was upgraded before kube-apiserver, which is incorrect.

## What does this PR do?

Checking if kubelet package is in right version.

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
