### PR TITLE
Add file permission for upload file method to fix CVE-2020-8029 (bsc#1177362) (backport to v4.2)

### DIFF
--- a/internal/pkg/skuba/deployments/deployments.go
+++ b/internal/pkg/skuba/deployments/deployments.go
@@ -20,13 +20,14 @@ package deployments
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 
 	"k8s.io/klog"
 )
 
 type Actionable interface {
 	Apply(data interface{}, states ...string) error
-	UploadFileContents(targetPath, contents string) error
+	UploadFileContents(targetPath, contents string, perm os.FileMode) error
 	DownloadFileContents(sourcePath string) (string, error)
 	IsServiceEnabled(serviceName string) (bool, error)
 }
@@ -55,16 +56,16 @@ func (t *Target) Apply(data interface{}, states ...string) error {
 	return t.Actionable.Apply(data, filteredStates...)
 }
 
-func (t *Target) UploadFile(sourcePath, targetPath string) error {
+func (t *Target) UploadFile(sourcePath, targetPath string, perm os.FileMode) error {
 	klog.V(1).Infof("uploading local file %q to remote file %q", sourcePath, targetPath)
 	if contents, err := ioutil.ReadFile(sourcePath); err == nil {
-		return t.UploadFileContents(targetPath, string(contents))
+		return t.UploadFileContents(targetPath, string(contents), perm)
 	}
 	return fmt.Errorf("could not find file %s", sourcePath)
 }
 
-func (t *Target) UploadFileContents(targetPath, contents string) error {
-	return t.Actionable.UploadFileContents(targetPath, contents)
+func (t *Target) UploadFileContents(targetPath, contents string, perm os.FileMode) error {
+	return t.Actionable.UploadFileContents(targetPath, contents, perm)
 }
 
 func (t *Target) DownloadFileContents(sourcePath string) (string, error) {

--- a/internal/pkg/skuba/deployments/ssh/cri.go
+++ b/internal/pkg/skuba/deployments/ssh/cri.go
@@ -47,7 +47,7 @@ func criConfigure(t *Target, data interface{}) error {
 	}()
 
 	for _, f := range criFiles {
-		if err := t.target.UploadFile(filepath.Join(skuba.CriConfDir(), f.Name()), filepath.Join("/tmp/crio.conf.d", f.Name())); err != nil {
+		if err := t.target.UploadFile(filepath.Join(skuba.CriConfDir(), f.Name()), filepath.Join("/tmp/crio.conf.d", f.Name()), f.Mode()); err != nil {
 			return err
 		}
 	}
@@ -71,7 +71,7 @@ func criSysconfig(t *Target, data interface{}) error {
 	}()
 
 	for _, f := range criFiles {
-		if err := t.target.UploadFile(filepath.Join(skuba.CriDir(), f.Name()), filepath.Join("/tmp/cri.d", f.Name())); err != nil {
+		if err := t.target.UploadFile(filepath.Join(skuba.CriDir(), f.Name()), filepath.Join("/tmp/cri.d", f.Name()), f.Mode()); err != nil {
 			return err
 		}
 	}

--- a/internal/pkg/skuba/deployments/ssh/kernel.go
+++ b/internal/pkg/skuba/deployments/ssh/kernel.go
@@ -97,12 +97,12 @@ func loadModule(t *Target, module string) error {
 	if _, _, err := t.ssh(fmt.Sprintf("modprobe %s", module)); err != nil {
 		return err
 	}
-	return t.UploadFileContents(fmt.Sprintf("/etc/modules-load.d/skuba-%s.conf", module), module)
+	return t.UploadFileContents(fmt.Sprintf("/etc/modules-load.d/skuba-%s.conf", module), module, 0644)
 }
 
 func configureParameter(t *Target, name, attribute, value string) error {
 	if _, _, err := t.ssh(fmt.Sprintf("sysctl -w %s=%s", attribute, value)); err != nil {
 		return err
 	}
-	return t.UploadFileContents(fmt.Sprintf("/etc/sysctl.d/90-skuba-%s.conf", name), fmt.Sprintf("%s=%s", attribute, value))
+	return t.UploadFileContents(fmt.Sprintf("/etc/sysctl.d/90-skuba-%s.conf", name), fmt.Sprintf("%s=%s", attribute, value), 0644)
 }

--- a/internal/pkg/skuba/deployments/ssh/kubeadm.go
+++ b/internal/pkg/skuba/deployments/ssh/kubeadm.go
@@ -19,6 +19,7 @@ package ssh
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -47,8 +48,12 @@ func kubeadmInit(t *Target, data interface{}) error {
 	if err != nil {
 		return err
 	}
+	f, err := os.Stat(skubaconstants.KubeadmInitConfFile())
+	if err != nil {
+		return err
+	}
 	remoteKubeadmInitConfFile := filepath.Join(tempDir, skubaconstants.KubeadmInitConfFile())
-	err = t.target.UploadFile(skubaconstants.KubeadmInitConfFile(), remoteKubeadmInitConfFile)
+	err = t.target.UploadFile(skubaconstants.KubeadmInitConfFile(), remoteKubeadmInitConfFile, f.Mode())
 	if err != nil {
 		return err
 	}
@@ -89,8 +94,12 @@ func kubeadmJoin(t *Target, data interface{}) error {
 	if err != nil {
 		return err
 	}
+	f, err := os.Stat(configPath)
+	if err != nil {
+		return err
+	}
 	remoteKubeadmInitConfFile := filepath.Join(tempDir, skubaconstants.KubeadmInitConfFile())
-	err = t.target.UploadFile(configPath, remoteKubeadmInitConfFile)
+	err = t.target.UploadFile(configPath, remoteKubeadmInitConfFile, f.Mode())
 	if err != nil {
 		return err
 	}
@@ -124,7 +133,7 @@ func kubeadmUpgradeApply(t *Target, data interface{}) error {
 	}
 
 	remoteKubeadmUpgradeConfFile := filepath.Join("/tmp/", skubaconstants.KubeadmUpgradeConfFile())
-	if err := t.target.UploadFileContents(remoteKubeadmUpgradeConfFile, upgradeConfiguration.KubeadmConfigContents); err != nil {
+	if err := t.target.UploadFileContents(remoteKubeadmUpgradeConfFile, upgradeConfiguration.KubeadmConfigContents, 0644); err != nil {
 		return err
 	}
 	defer func() {

--- a/internal/pkg/skuba/deployments/ssh/kubelet.go
+++ b/internal/pkg/skuba/deployments/ssh/kubelet.go
@@ -46,15 +46,23 @@ func init() {
 
 func kubeletUploadRootCert(t *Target, data interface{}) error {
 	// Upload root ca cert
-	if err := t.target.UploadFile(filepath.Join(skuba.PkiDir(), kubernetes.KubeletCACertName), filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletCACertName)); err != nil {
+	caCertPath := filepath.Join(skuba.PkiDir(), kubernetes.KubeletCACertName)
+	f, err := os.Stat(caCertPath)
+	if err != nil {
 		return err
 	}
+	if err := t.target.UploadFile(caCertPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletCACertName), f.Mode()); err != nil {
+		return err
+	}
+
 	// Upload root ca key on control plane node only
 	if *t.target.Role == deployments.MasterRole {
-		if err := t.target.UploadFile(filepath.Join(skuba.PkiDir(), kubernetes.KubeletCAKeyName), filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletCAKeyName)); err != nil {
+		caKeyPath := filepath.Join(skuba.PkiDir(), kubernetes.KubeletCAKeyName)
+		f, err = os.Stat(caKeyPath)
+		if err != nil {
 			return err
 		}
-		if _, _, err := t.silentSsh("chmod", "0400", filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletCAKeyName)); err != nil {
+		if err := t.target.UploadFile(caKeyPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletCAKeyName), f.Mode()); err != nil {
 			return err
 		}
 	}
@@ -116,13 +124,18 @@ func kubeletCreateAndUploadServerCert(t *Target, data interface{}) error {
 
 	// Upload server certificate and key
 	certPath, keyPath := pkiutil.PathsForCertAndKey(skuba.PkiDir(), host)
-	if err := t.target.UploadFile(certPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerCertName)); err != nil {
+	f, err := os.Stat(certPath)
+	if err != nil {
 		return err
 	}
-	if err := t.target.UploadFile(keyPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerKeyName)); err != nil {
+	if err := t.target.UploadFile(certPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerCertName), f.Mode()); err != nil {
 		return err
 	}
-	if _, _, err := t.silentSsh("chmod", "0400", filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerKeyName)); err != nil {
+	f, err = os.Stat(keyPath)
+	if err != nil {
+		return err
+	}
+	if err := t.target.UploadFile(keyPath, filepath.Join(kubernetes.KubeletCertAndKeyDir, kubernetes.KubeletServerKeyName), f.Mode()); err != nil {
 		return err
 	}
 
@@ -143,17 +156,17 @@ func kubeletConfigure(t *Target, data interface{}) error {
 		return err
 	}
 	if isSUSE {
-		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
+		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service", assets.KubeletService, 0644); err != nil {
 			return err
 		}
-		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
+		if err := t.UploadFileContents("/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService, 0644); err != nil {
 			return err
 		}
 	} else {
-		if err := t.UploadFileContents("/lib/systemd/system/kubelet.service", assets.KubeletService); err != nil {
+		if err := t.UploadFileContents("/lib/systemd/system/kubelet.service", assets.KubeletService, 0644); err != nil {
 			return err
 		}
-		if err := t.UploadFileContents("/etc/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService); err != nil {
+		if err := t.UploadFileContents("/etc/systemd/system/kubelet.service.d/10-kubeadm.conf", assets.KubeadmService, 0644); err != nil {
 			return err
 		}
 	}
@@ -200,14 +213,12 @@ func getCloudProvider() (string, error) {
 func uploadCloudProvider(t *Target, cloudProvider string) error {
 	cloudConfigFile := cloudProvider + ".conf"
 	cloudConfigFilePath := filepath.Join(skuba.CloudDir(), cloudProvider, cloudConfigFile)
-	if _, err := os.Stat(cloudConfigFilePath); os.IsNotExist(err) {
+	f, err := os.Stat(cloudConfigFilePath)
+	if os.IsNotExist(err) {
 		return err
 	}
 	cloudConfigRuntimeFilePath := filepath.Join(constants.KubernetesDir, cloudConfigFile)
-	if err := t.target.UploadFile(cloudConfigFilePath, cloudConfigRuntimeFilePath); err != nil {
-		return err
-	}
-	if _, _, err := t.ssh("chmod", "0400", cloudConfigRuntimeFilePath); err != nil {
+	if err := t.target.UploadFile(cloudConfigFilePath, cloudConfigRuntimeFilePath, f.Mode()); err != nil {
 		return err
 	}
 	return nil

--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -19,6 +19,7 @@ package ssh
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -46,7 +47,16 @@ func init() {
 func kubernetesUploadSecrets(errorHandling KubernetesUploadSecretsErrorBehavior) Runner {
 	return func(t *Target, data interface{}) error {
 		for _, file := range deployments.Secrets {
-			if err := t.target.UploadFile(file, filepath.Join(constants.KubernetesDir, file)); err != nil {
+			f, err := os.Stat(file)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				if errorHandling == KubernetesUploadSecretsFailOnError {
+					return err
+				}
+			}
+			if err := t.target.UploadFile(file, filepath.Join(constants.KubernetesDir, file), f.Mode()); err != nil {
 				if errorHandling == KubernetesUploadSecretsFailOnError {
 					return err
 				}


### PR DESCRIPTION
## Why is this PR needed?

fix CVE-2020-8029 (aka bsc#1177362), add file permission for the upload file method.
It prevents when uploading the key, the attacker could steal the key by watching the file
because the file creates with permission `0644` first, and then `chmod` to `0400`.

Fixes bsc#1177362
Fixes CVE-2020-8029

## What does this PR do?

Add set the file permission parameter to `UploadFile`/`UploadFileContents` method
- caller `UploadFile`: it re-uses the local file's permission
- caller `UploadFileContents`: it uses file permission `0644` 

## Anything else a reviewer needs to know?

N/A

## Info for QA

N/A

### Related info

N/A

### Status **BEFORE** applying the patch

When node bootstrap/join, we could use another user account and watch `/var/lib/kubelet/pki/kubelet.key`, this user has the ability to get the content of `/var/lib/kubelet/pki/kubelet.key` since the file permission is `0644` when creating, and then set to `0400`.

### Status **AFTER** applying the patch

When node bootstrap/join, we could not use another user account to get the content of `/var/lib/kubelet/pki/kubelet.key` since the file permission re-uses the local file permission `0600`.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
