### PR TITLE
Rename kubernetes client package

### DIFF
--- a/internal/pkg/skuba/deployments/ssh/kubernetes.go
+++ b/internal/pkg/skuba/deployments/ssh/kubernetes.go
@@ -176,12 +176,12 @@ func kubernetesUpgradeStageTwo(t *Target, data interface{}) error {
 		pkgs = append(pkgs, fmt.Sprintf("-\"cri-o<%s\"", skubaconstants.FirstCaaSP5KubernetesVersion))
 		pkgs = append(pkgs, fmt.Sprintf("-\"cri-tools<%s\"", skubaconstants.FirstCaaSP5KubernetesVersion))
 	} else {
-		pkgs = append(pkgs, fmt.Sprintf("-kubernetes-%s-*", currentV))
+		pkgs = append(pkgs, fmt.Sprintf("-kubernetes%s-*", currentV))
 		pkgs = append(pkgs, fmt.Sprintf("-cri-o-%s*", currentV))
 		pkgs = append(pkgs, fmt.Sprintf("-cri-tools-%s*", currentV))
 	}
 
-	pkgs = append(pkgs, fmt.Sprintf("+kubernetes-%s-client", nextV))
+	pkgs = append(pkgs, fmt.Sprintf("+kubernetes%s-client", nextV))
 	pkgs = append(pkgs, fmt.Sprintf("+kubernetes-%s-kubelet", nextV))
 	pkgs = append(pkgs, fmt.Sprintf("+cri-o-%s*", nextV))
 	pkgs = append(pkgs, fmt.Sprintf("+cri-tools-%s*", nextV))


### PR DESCRIPTION
## Why is this PR needed?

In order to decouple CaaSP releases from Containers module (part of SLE code stream) it has been decided to include a new kubernetes-client in Containers module aligned with Factory which obsoletes the one released in CaaSP and keep using the kubernetes-client form Containers module in CaaSP.

The consequences of this is that kubernetes package in CaaSP will not build the kubernetes client subpackages any longer and just use what is in Containers modules instead.

This PR is inline with https://github.com/SUSE/avant-garde/issues/1813#issuecomment-717139840

## What does this PR do?

This commit renames the kubernetes client name to the binaries that will be part of the Containers module for SP2. We aim to release the kubernetes client aligned from Factory for the Containers Module (on SLE we should/must follow the Factory first policy), this implies small rename of the package, from `kubernetes-1.18-client` to `kubernetes1.18-client` package. Since `kubernetes1.18-client` obsoletes `kubernetes-1.18-client` the new one will replace the old one during the upgrade and thanks the the change provided here any new deployment will directly pull `kubernetes1.18-client`.

New kubernetes clients can be found on [Devel:CaaSP:4.5:Brances:k8sclt_split](https://build.suse.de/project/show/Devel:CaaSP:4.5:Branches:k8sclt_split) project and they have been already used for the tests on this PR. 

## Info for QA

Special attention to v4.5.1 -> v4.5.2 upgrade and v4.2.4 -> v4.5.2 migration.

Note that this the tests should be coordinated with a release on Containers Module including the changes.

### Related info

Related to SUSE/avant-garde#1813 SUSE/avant-garde#1514

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
