### PR TITLE
CI tests can't distinguish patch level versions of k8s

### DIFF
--- a/ci/infra/testrunner/tests/utils.py
+++ b/ci/infra/testrunner/tests/utils.py
@@ -2,7 +2,7 @@ import signal
 import time
 import yaml
 
-PREVIOUS_VERSION = "1.17.4"
+PREVIOUS_VERSION = "1.16.2"
 CURRENT_VERSION = "1.17.13"
 
 


### PR DESCRIPTION
On the CI we are always installing the latest k8s version for a given
minor version. So that the previous and current k8s version for the
upgrade test can't be under the same minor version, a patch level
divergence is not enough to distinguish them. The distinction is done
at pattern level and the patterns only divide minor version changes, not
patch level changes.

Fixes SUSE/avant-garde#2027