### PR TITLE
Port k8s version bump from CaaSP 4.2.4 release

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -136,6 +136,31 @@ var (
 				PSP:           &AddonVersion{"", 4500},
 			},
 		},
+		"1.17.13": KubernetesVersion{
+			ComponentHostVersion: ComponentHostVersion{
+				KubeletVersion:          "1.17.13",
+				ContainerRuntimeVersion: "1.16.1",
+			},
+			ComponentContainerVersion: ComponentContainerVersion{
+				APIServer:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.13"},
+				ControllerManager: &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.13"},
+				Scheduler:         &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.13"},
+				Proxy:             &ContainerImageTag{Name: "hyperkube", Tag: "v1.17.13"},
+				Etcd:              &ContainerImageTag{Name: "etcd", Tag: "3.4.13"},
+				CoreDNS:           &ContainerImageTag{Name: "coredns", Tag: "1.6.7"},
+				Pause:             &ContainerImageTag{Name: "pause", Tag: "3.1"},
+				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
+			},
+			AddonsVersion: AddonsVersion{
+				Cilium:        &AddonVersion{"1.6.6-rev5", 4},
+				Kured:         &AddonVersion{"1.3.0", 4},
+				Dex:           &AddonVersion{"2.16.0-rev6", 7},
+				Gangway:       &AddonVersion{"3.1.0-rev4", 6},
+				MetricsServer: &AddonVersion{"0.3.6", 1},
+				Kucero:        &AddonVersion{"1.3.0", 0},
+				PSP:           &AddonVersion{"", 4},
+			},
+		},
 		"1.17.4": KubernetesVersion{
 			ComponentHostVersion: ComponentHostVersion{
 				KubeletVersion:          "1.17.4",


### PR DESCRIPTION
## Why is this PR needed?

Having the `versions.go` file aligned between v4.2.x and v4.5.x series is required for the migration process from v4.2 to v4.5.

## What does this PR do?

This commit includes the latest release of CaaSP v4.2.x series in
versions.go file. This is required to let skuba compute a full and
precise migration path from v4.2.x to v4.5.x.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
