### PR TITLE
Check if node alive before running migration

### DIFF
--- a/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
+++ b/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
@@ -1,10 +1,21 @@
 import os
-import pytest
 
 from tests.utils import (check_node_is_ready, check_node_version, CURRENT_VERSION, wait)
 
+
 # Migrates a node to the upgrate option speficied in the option
 def migrate_node(platform, checker, kubectl, role, node, regcode, option=1):
+    # first check if node is up
+    wait(platform.ssh_run,
+         role,
+         node,
+         "true",
+         wait_delay=60,
+         wait_timeout=10,
+         wait_backoff=30,
+         wait_elapsed=180,
+         wait_allow=(RuntimeError)
+    )
     platform.ssh_run(role, node, f'sudo SUSEConnect -r {regcode}')
     platform.ssh_run(role, node, "sudo SUSEConnect -p sle-module-containers/15.1/x86_64")
     platform.ssh_run(role, node, f'sudo SUSEConnect -p caasp/4.0/x86_64 -r {regcode}')


### PR DESCRIPTION
Seems like sometime when migrating the nodes they can be
not accessible, be it for a temporary network issue or
rebooting or even overloaded with other tasks.

For sanity, check before running the migration to see if the
node is up and accepting ssh connections

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
