### PR TITLE
Inhibit kured on CI cluster upgrade

### DIFF
--- a/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
+++ b/ci/jenkins/pipelines/skuba-upgrade-from-4.2.Jenkinsfile
@@ -65,7 +65,11 @@ pipeline {
                 }
             }
         }
-        
+
+        stage('Inhibit kured reboots') { steps {
+            sh(script: 'make -f ci/Makefile inhibit_kured')
+            }
+        }
         stage('upgrade skuba') { 
             steps {
                 sh(script: "sudo zypper in -y --no-recommends go1.13")


### PR DESCRIPTION
Looks like kured is triggering node reboots in the middle of our
testing which results in a very unstable job.

This patch reuses the same inhibit_kured step that we used on
other jobs to prevent kured from restarting nodes while we manipulate
them

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes https://github.com/SUSE/avant-garde/issues/2002

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
