### PR TITLE
Add crio mirror command to testrunner

### DIFF
--- a/ci/Makefile
+++ b/ci/Makefile
@@ -90,7 +90,11 @@ test:
 test_pr:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} test --verbose --junit pr --filter "pr" --skip-setup deployed
 
-.PHONE: inhibit_kured
+.PHONY: inhibit_kured
 inhibit_kured:
 	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} inhibit_kured
+
+.PHONY: crio_mirror
+crio_mirror:
+	${TEST_RUNNER} -v vars.yaml -p ${PLATFORM} crio_mirror
 

--- a/ci/infra/testrunner/testrunner.py
+++ b/ci/infra/testrunner/testrunner.py
@@ -127,6 +127,10 @@ def inhibit_kured(options):
     Kubectl(options.conf).inhibit_kured()
 
 
+def crio_mirror(options):
+    platforms.get_platform(options.conf, options.platform).configure_crio_mirror_dockerhub()
+
+
 def main():
     help_str = """
     This script is meant to be run manually on test servers, developer desktops, or Jenkins.
@@ -263,6 +267,9 @@ def main():
     ssh_args.add_argument("-c", "--cmd", dest="cmd", nargs=REMAINDER, help="remote command and its arguments. e.g ls -al. Must be last argument for ssh command")
     cmd_ssh = commands.add_parser("ssh", parents=[node_args, ssh_args], help="Execute command in node via ssh.")
     cmd_ssh.set_defaults(func=ssh)
+
+    crio_mirror_command = commands.add_parser("crio_mirror", help="Set mirror registry for CI testing in the workers")
+    crio_mirror_command.set_defaults(func=crio_mirror)
 
     test_args = ArgumentParser(add_help=False)
     test_args.add_argument("-f", "--filter", dest="mark", help="Filter the tests based on markers")

--- a/ci/infra/testrunner/utils/utils.py
+++ b/ci/infra/testrunner/utils/utils.py
@@ -154,6 +154,18 @@ class Utils:
                f" {self.ssh_user()}@{ip_address}:{remote_file_path} {local_file_path}")
         self.runshellcommand(cmd)
 
+    def scp_file_to_remote(self, ip_address, remote_file_path, local_file_path):
+        """
+        Copies a local file from the given path to the give ip
+        :param ip_address: (str) IP address of the node to copy to
+        :param local_file_path: (str) Path of the file to be copied
+        :param remote_file_path: (str) Path where to store the file in remote
+        :return:
+        """
+        cmd = (f"scp {Constant.SSH_OPTS} -i {self.conf.utils.ssh_key}"
+               f" {local_file_path} {self.ssh_user()}@{ip_address}:{remote_file_path}")
+        self.runshellcommand(cmd)
+
     def rsync(self, ip_address, remote_dir_path, local_dir_path):
         """
         Copies a remote dir from the given ip to the give path


### PR DESCRIPTION
Adds a command to copy a modified registries.conf to k8s
workers in order to point to our local docker image mirror.
Triggered by DOCKERHUB_MIRROR env var, if empty it will skip
doing anything.

This is done to avoid hitting the newly enacted DockerHub rate limits
of pulling images which we are hitting daily on CI jobs


Prerequisite to https://github.com/SUSE/caasp-automation/pull/807

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
