### PR TITLE
Fixes issues in validation script

### DIFF
--- a/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
+++ b/ci/jenkins/pipelines/prs/helpers/pr_manager/pr_checks.py
@@ -43,7 +43,7 @@ class PrChecks:
 
         added_changes = []
         removed_changes = []
-        p = re.compile('(-|\+)([A-Za-z]+):&AddonVersion{"(.+)",([0-9]+)},')
+        p = re.compile('(-|\+)([A-Za-z]+):&AddonVersion{"(.*)",([0-9]+)},')
 
         cmd = f'git diff --no-ext-diff --unified=0 origin/master -- {WORKSPACE}/internal/pkg/skuba/kubernetes/versions.go | grep "AddonVersion"'
 
@@ -65,7 +65,7 @@ class PrChecks:
         error = False
         for r in removed_changes:
             for a in added_changes:
-                if r["name"] == a["name"] and (r["version"] == a["version"] or  r["manifest"] == a["manifest"]):
+                if r["name"] == a["name"] and ((r["version"] == a["version"] and r["version"] != "") or  r["manifest"] == a["manifest"]):
                     error = True
                     print(f'Error in Addon {r["name"]} please double check the manifest number')
 


### PR DESCRIPTION
Signed-off-by: Vicente Zepeda Mas <vzepedamas@suse.com>

## Why is this PR needed?

Fixes issues in validation script

This happens when the version of an addon is empty, the regex failed to
parse it.
Subsequently the validation gave a false positive since previous and
current version were the same.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
