### PR TITLE
Improve reboot command on tests

### DIFF
--- a/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
+++ b/ci/infra/testrunner/tests/test_upgrade_from_4_2.py
@@ -19,7 +19,7 @@ def migrate_node(platform, checker, kubectl, role, node, regcode, option=1):
     platform.ssh_run(role, node, ('sudo zypper update --allow-vendor-change -y'
                                   f' kubernetes-{k8s_major}.{k8s_minor}-kubeadm'))
     #:FIXME use kured for controlled reboot.
-    platform.ssh_run(role, node, "sudo reboot &")
+    platform.ssh_run(role, node, "nohup sudo reboot &>/dev/null & exit")
 
     # wait the node become live
     wait(platform.ssh_run,


### PR DESCRIPTION
We need to cleanly execyute the reboot command over ssh by using
nohup to redirect stdin and redirect stdout/stderro to /dev/null while
also cleanly exiting. Otherwise the ssh cannection can be broken and
that would result in the test failure for no real reason

## Why is this PR needed?

Does it fix an issue? addresses a business case?

add a description and link to the issue if one exists.

Fixes #

**Reminder**: Add the "fixes bsc#XXXX" to the title of the commit so that it will
appear in the changelog.

## What does this PR do?

please include a brief "management" technical overview (details are in the code)

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
