### PR TITLE
addons: cilium: Add missing ClusterRoles rules (bsc#1178931)

### DIFF
--- a/internal/pkg/skuba/addons/cilium_manifests/v17.go
+++ b/internal/pkg/skuba/addons/cilium_manifests/v17.go
@@ -118,6 +118,7 @@ rules:
   - ciliumnodes
   - ciliumnodes/status
   - ciliumidentities
+  - ciliumidentities/status
   verbs:
   - '*'
 ---
@@ -177,6 +178,23 @@ rules:
   - ciliumidentities/status
   verbs:
   - '*'
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between mulitple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
+# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
+# that we only authorize access to leases resources in supported K8s versions.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
 ---
 # Source: cilium/charts/agent/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
ClusterRoles cilium and cilium-operator were missing rules for the
ciliumidentities/status resource and cilium-operator running in HA mode.

The first missing rule was most likely the cause of bsc#1178931.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>