### PR TITLE
Fix kubectl --server-dry-run argument for kubectl v1.17

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -375,7 +375,7 @@ func (addon Addon) applyPreflight(addonConfiguration AddonConfiguration, rootDir
 		"-f", preflightManifestPath,
 	}
 	if dryRun {
-		kubectlArgs = append(kubectlArgs, "--dry-run=server")
+		kubectlArgs = append(kubectlArgs, "--server-dry-run")
 	}
 	cmd := exec.Command("kubectl", kubectlArgs...)
 	var stderr bytes.Buffer
@@ -441,7 +441,7 @@ func (addon Addon) Apply(client clientset.Interface, addonConfiguration AddonCon
 		"-k", addon.addonDir(),
 	}
 	if dryRun {
-		kubectlArgs = append(kubectlArgs, "--dry-run=server")
+		kubectlArgs = append(kubectlArgs, "--server-dry-run")
 	}
 	cmd := exec.Command("kubectl", kubectlArgs...)
 	var stderr bytes.Buffer


### PR DESCRIPTION
## Why is this PR needed?

```skuba addon upgrade plan
Current Kubernetes cluster version: 1.17.4
Latest Kubernetes version: 1.17.13

Addon upgrades for 1.17.4:
  - cilium: 1.6.6 -> 1.6.6-rev5
  - dex: 2.16.0 -> 2.16.0-rev6
  - gangway: 3.1.0-rev4 (manifest version from 5 to 6)
Error: invalid argument "server" for "--dry-run" flag: strconv.ParseBool: parsing "server": invalid syntax
See 'kubectl apply --help' for usage.
```

There is no argument "--dry-run=server" for kubectl in version 1.17, instead of this we can use "--server-dry-run"

## What does this PR do?

It is replacing "--dry-run=server" on "--server-dry-run"

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

Info that can be relevant for QA:
* link to other PRs that should be merged together
* link to packages that should be released together
* upstream issues

### Status **BEFORE** applying the patch

How can we reproduce the issue? How can we see this issue? Please provide the steps and the prove
this issue is not fixed.

### Status **AFTER** applying the patch

How can we validate this issue is fixed? Please provide the steps and the prove this issue is fixed.

## Docs

If docs need to be updated, please add a link to a PR to https://github.com/SUSE/doc-caasp.
At the time of creating the issue, this PR can be work in progress (set its title to [WIP]),
but the documentation needs to be finalized before the PR can be merged. 

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
