### PR TITLE
Fix kubectl server-side dry-run flag

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -375,7 +375,11 @@ func (addon Addon) applyPreflight(addonConfiguration AddonConfiguration, rootDir
 		"-f", preflightManifestPath,
 	}
 	if dryRun {
-		kubectlArgs = append(kubectlArgs, "--dry-run=server")
+		flag, err := kubectlServerSideDryRunFlag()
+		if err != nil {
+			return true, err
+		}
+		kubectlArgs = append(kubectlArgs, flag)
 	}
 	cmd := exec.Command("kubectl", kubectlArgs...)
 	var stderr bytes.Buffer
@@ -441,7 +445,11 @@ func (addon Addon) Apply(client clientset.Interface, addonConfiguration AddonCon
 		"-k", addon.addonDir(),
 	}
 	if dryRun {
-		kubectlArgs = append(kubectlArgs, "--dry-run=server")
+		flag, err := kubectlServerSideDryRunFlag()
+		if err != nil {
+			return err
+		}
+		kubectlArgs = append(kubectlArgs, flag)
 	}
 	cmd := exec.Command("kubectl", kubectlArgs...)
 	var stderr bytes.Buffer
@@ -508,4 +516,25 @@ func updateSkubaConfigMapWithAddonVersion(client clientset.Interface, addon kube
 	}
 	skubaConfiguration.AddonsVersion[addon] = addonVersion
 	return skuba.UpdateSkubaConfiguration(client, skubaConfiguration)
+}
+
+func kubectlServerSideDryRunFlag() (string, error) {
+	// If k8s client version < v1.18.0, the server-side dry-run flag is `--server-dry-run`
+	// If k8s client version >= v1.18.0, the server-side dry-run flag is `--dry-run=server`
+	cmd := exec.Command("kubectl", "version", "--client", "--short")
+	combinedOutput, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	var clientVersion string
+	_, err = fmt.Sscanf(string(combinedOutput), "Client Version: %s", &clientVersion)
+	if err != nil {
+		return "", err
+	}
+
+	if version.MustParseSemantic(clientVersion).LessThan(version.MustParseSemantic("v1.18.0")) {
+		return "--server-dry-run", nil
+	}
+	return "--dry-run=server", nil
 }


### PR DESCRIPTION
## Why is this PR needed?

The flag of server-side dry-run is different at k8s client < 1.18.0 and k8s client >= 1.18.0.

## What does this PR do?

Check the kubectl client version and return the corresponding server-side dry-run flag.
If k8s client version < v1.18.0, the server-side dry-run flag is `--server-dry-run`.
If k8s client version >= v1.18.0, the server-side dry-run flag is `--dry-run=server`.

## Anything else a reviewer needs to know?

N/A

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

1. The local kubectl CLI version < 1.18.0
2. Deploy a cluster by previous skuba CLI.
3. Use the new skuba CLI to perform cluster upgrade and add-on upgrade.
4. The error message display on the console.

### Status **AFTER** applying the patch

1. The local kubectl CLI version < 1.18.0
2. Deploy a cluster by previous skuba CLI.
3. Use the new skuba CLI to perform cluster upgrade and add-on upgrade.
4. The add-on upgrade success.

AND

1. The local kubectl CLI version >= 1.18.0
2. Deploy a cluster by previous skuba CLI.
3. Use the new skuba CLI to perform cluster upgrade and add-on upgrade.
4. The add-on upgrade success.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
