### PR TITLE
Fix detects new add-on manifest not exist (backport to v4.5)

### DIFF
--- a/internal/pkg/skuba/addons/addons.go
+++ b/internal/pkg/skuba/addons/addons.go
@@ -328,7 +328,7 @@ func (addon Addon) compareLocalBaseManifest(addonConfiguration AddonConfiguratio
 
 	localManifest, err := ioutil.ReadFile(addon.manifestPath(addon.addonDir()))
 	if err != nil {
-		return false, errors.Wrapf(err, "unable to read %s addon rendered template", addon.Addon)
+		return false, nil
 	}
 
 	addonManifest, err := addon.Render(addonConfiguration)

--- a/internal/pkg/skuba/addons/addons_test.go
+++ b/internal/pkg/skuba/addons/addons_test.go
@@ -112,8 +112,8 @@ func TestCheckLocalAddonsBaseManifests(t *testing.T) {
 
 	// pre-check
 	_, err = CheckLocalAddonsBaseManifests(addonConfiguration)
-	if err == nil {
-		t.Error("expected got error but no error reported")
+	if err != nil {
+		t.Errorf("expected no error but an error reported: %v", err)
 		return
 	}
 


### PR DESCRIPTION
## Why is this PR needed?

If there is a new add-on like `kucero` in the new Kubernetes version, the skuba CLI outputs `unable to read kucero addon rendered template`.

## What does this PR do?

Advise the user to perform the `skuba addon refresh localconfig` if the local base manifest cannot find.

## Anything else a reviewer needs to know?

Special test cases, manual steps, links to resources or anything else that could be helpful to the reviewer.

## Info for QA

This is info for QA so that they can validate this. This is **mandatory** if this PR fixes a bug.
If this is a new feature, a good description in "What does this PR do" may be enough.

### Related info

N/A

### Status **BEFORE** applying the patch

1. Deploy skuba `4.2.3`.
2. Build a new skuba CLI from this PR.
3. Perform the skuba node upgrade.
4. Run the `skuba addon upgrade plan`, the error message output on the console.

### Status **AFTER** applying the patch

1. Deploy skuba `4.2.3`.
2. Build a new skuba CLI from this PR.
3. Perform the skuba node upgrade.
4. Run the `skuba addon upgrade plan`, it'll advise the user to run `skuba addon refresh localconfig`.

## Docs

N/A

# Merge restrictions

(Please do not edit this)

We are in *v4-maintenance phase*, so we will restrict what can be merged to prevent unexpected surprises:

    What can be merged (merge criteria):
        2 approvals:
            1 developer: code is fine
            1 QA: QA is fine
        there is a PR for updating documentation (or a statement that this is not needed)

<!-- Remember, if this is a work in progress please pre-append [WIP] to the title until you are ready! 
    If you can, please apply all applicable labels to help reviews out! -->
