### PR TITLE
Align versions.go with latest container images

### DIFF
--- a/internal/pkg/skuba/kubernetes/versions.go
+++ b/internal/pkg/skuba/kubernetes/versions.go
@@ -102,10 +102,10 @@ var (
 				Tooling:           &ContainerImageTag{Name: "skuba-tooling", Tag: "0.1.0"},
 			},
 			AddonsVersion: AddonsVersion{
-				Cilium:        &AddonVersion{"1.7.6-rev3", 4520},
+				Cilium:        &AddonVersion{"1.7.6-rev5", 4530},
 				Kured:         &AddonVersion{"1.4.3", 4520},
 				Dex:           &AddonVersion{"2.23.0", 4520},
-				Gangway:       &AddonVersion{"3.1.0-rev5", 4520},
+				Gangway:       &AddonVersion{"3.1.0-rev6", 4530},
 				MetricsServer: &AddonVersion{"0.3.6", 4520},
 				Kucero:        &AddonVersion{"1.3.0", 4520},
 				PSP:           &AddonVersion{"", 4520},


### PR DESCRIPTION
## Why is this PR needed?

Make sure to include bpftool fix in cilium image and properly align ganway image with the latest released image.


## What does this PR do?

Updates the version.go file to ensure the updated images for release 4.5.3 are being pulled during the upgrade.

