### PR TITLE
Disable multibranch jobs

### DIFF
--- a/ci/jenkins/templates/jjb-validation.yaml
+++ b/ci/jenkins/templates/jjb-validation.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: '{name}/jjb-validation'
     project-type: multibranch
+    disabled: true
     periodic-folder-trigger: 5m
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/test-template.yaml
+++ b/ci/jenkins/templates/test-template.yaml
@@ -1,6 +1,7 @@
 - job-template:
     name: '{name}/test'
     project-type: multibranch
+    disabled: true
     periodic-folder-trigger: 5m
     number-to-keep: 30
     days-to-keep: 30

--- a/ci/jenkins/templates/update-acceptance-template.yaml
+++ b/ci/jenkins/templates/update-acceptance-template.yaml
@@ -2,6 +2,7 @@
     name: '{name}/update-acceptance'
     project-type: multibranch
     periodic-folder-trigger: 5m
+    disabled: true
     number-to-keep: 30
     days-to-keep: 30
     script-path: ci/jenkins/pipelines/prs/skuba-update-acceptance.Jenkinsfile

--- a/ci/jenkins/templates/update-unit-template.yaml
+++ b/ci/jenkins/templates/update-unit-template.yaml
@@ -2,6 +2,7 @@
     name: '{name}/update-unit'
     project-type: multibranch
     periodic-folder-trigger: 5m
+    disabled: true
     number-to-keep: 30
     days-to-keep: 30
     script-path: ci/jenkins/pipelines/prs/skuba-update-unit.Jenkinsfile


### PR DESCRIPTION
This commit disable multibranch jobs for skuba repository.
They eat resources on CI and there is almost no activity in this
repository. The CI investment is not worth.

Signed-off-by: David Cassany <dcassany@suse.com>