### PR TITLE
Add systemd as cgroup-driver to kubelet, bsc#1191654

### DIFF
--- a/internal/pkg/skuba/node/config_test.go
+++ b/internal/pkg/skuba/node/config_test.go
@@ -43,6 +43,7 @@ nodeRegistration:
     cni-bin-dir: /usr/lib/cni
     hostname-override: worker-0
     pod-infra-container-image: registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4/pause:3.1
+    cgroup-driver: systemd
   name: worker-0
 `
 
@@ -162,6 +163,7 @@ func Test_documentMapToJoinConfiguration(t *testing.T) {
 						"cni-bin-dir":               "/usr/lib/cni",
 						"hostname-override":         "worker-0",
 						"pod-infra-container-image": "registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4/pause:3.1",
+						"cgroup-driver":             "systemd",
 					},
 				},
 				CACertPath: "/etc/kubernetes/pki/ca.crt",

--- a/internal/pkg/skuba/node/node.go
+++ b/internal/pkg/skuba/node/node.go
@@ -34,6 +34,7 @@ func AddTargetInformationToInitConfigurationWithClusterVersion(target *deploymen
 	initConfiguration.NodeRegistration.CRISocket = skuba.CRISocket
 	initConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename
 	initConfiguration.NodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = kubernetes.ComponentContainerImageForClusterVersion(kubernetes.Pause, clusterVersion)
+	initConfiguration.NodeRegistration.KubeletExtraArgs["cgroup-driver"] = skuba.CGroupDriver
 	isSUSE, err := target.IsSUSEOS()
 	if err != nil {
 		return err

--- a/internal/pkg/skuba/node/testdata/join.conf
+++ b/internal/pkg/skuba/node/testdata/join.conf
@@ -14,4 +14,5 @@ nodeRegistration:
     cni-bin-dir: /usr/lib/cni
     hostname-override: worker-0
     pod-infra-container-image: registry.suse.de/devel/caasp/4.0/containers/containers/caasp/v4/pause:3.1
+    cgroup-driver: systemd
   name: worker-0

--- a/pkg/skuba/actions/node/join/join.go
+++ b/pkg/skuba/actions/node/join/join.go
@@ -177,6 +177,7 @@ func addTargetInformationToJoinConfiguration(target *deployments.Target, role de
 	joinConfiguration.NodeRegistration.CRISocket = skuba.CRISocket
 	joinConfiguration.NodeRegistration.KubeletExtraArgs["hostname-override"] = target.Nodename
 	joinConfiguration.NodeRegistration.KubeletExtraArgs["pod-infra-container-image"] = kubernetes.ComponentContainerImageForClusterVersion(kubernetes.Pause, clusterVersion)
+	joinConfiguration.NodeRegistration.KubeletExtraArgs["cgroup-driver"] = skuba.CGroupDriver
 	isSUSE, err := target.IsSUSEOS()
 	if err != nil {
 		return errors.Wrap(err, "unable to get os info")

--- a/pkg/skuba/constants.go
+++ b/pkg/skuba/constants.go
@@ -32,6 +32,7 @@ const (
 	SUSECNIDir = "/usr/lib/cni"
 	// MaxNodeNameLength is the maximum node name length accepted by kubelet.
 	MaxNodeNameLength = 63
+	CGroupDriver      = "systemd"
 )
 
 func KubeadmInitConfFile() string {


### PR DESCRIPTION
## Why is this PR needed?

We want to migrate cgroup-driver from cgroupfs to systemd. Which resolve problem with error log in kubelet
```
Failed to create existing container
```

Fixes #

fixes bsc#1191654
